### PR TITLE
Release commit lock after filling object_refs table

### DIFF
--- a/relstorage/adapters/packundo.py
+++ b/relstorage/adapters/packundo.py
@@ -1032,6 +1032,8 @@ class HistoryFreePackUndo(PackUndo):
             else:
                 # No changes since last pass.
                 break
+        if holding_commit:
+            self.locker.release_commit_lock(cursor)            
 
     def _add_refs_for_oids(self, cursor, oids, get_references):
         """Fill object_refs with the states for some objects.


### PR DESCRIPTION
Having an issue on a large system during zodbpack. The commit lock is being held during the filling of the pack_object table and traverse which combined take about 50 minutes. Is it safe to release the commit lock after filling the objects_ref table?
