### PR TITLE
Raise a specific exception when acquiring the commit lock fails.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,10 @@
 Next Major Release
 ------------------
 
+- Raise a specific exception,
+  relstorage.adapters.interfaces.UnableToAcquireCommitLockError, when
+  acquiring the commit lock fails.
+
 - MySQL 5.5: The test suite was freezing in checkBackwardTimeTravel. Fixed.
 
 - Added performance metrics using the perfmetrics package.

--- a/relstorage/adapters/interfaces.py
+++ b/relstorage/adapters/interfaces.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Interfaces provided by RelStorage database adapters"""
 
+from ZODB.POSException import StorageError
 from zope.interface import Attribute
 from zope.interface import Interface
 
@@ -470,3 +471,6 @@ class ITransactionControl(Interface):
 
 class ReplicaClosedException(Exception):
     """The connection to the replica has been closed"""
+
+class UnableToAcquireCommitLockError(StorageError):
+    """The commit lock cannot be acquired."""

--- a/relstorage/adapters/locker.py
+++ b/relstorage/adapters/locker.py
@@ -17,6 +17,7 @@
 from ZODB.POSException import StorageError
 from perfmetrics import metricmethod
 from relstorage.adapters.interfaces import ILocker
+from relstorage.adapters.interfaces import UnableToAcquireCommitLockError
 from zope.interface import implements
 
 
@@ -63,7 +64,7 @@ class PostgreSQLLocker(Locker):
         except self.lock_exceptions:
             if nowait:
                 return False
-            raise StorageError('Acquiring a commit lock failed')
+            raise UnableToAcquireCommitLockError('Acquiring a commit lock failed')
         return True
 
     def release_commit_lock(self, cursor):
@@ -114,7 +115,7 @@ class MySQLLocker(Locker):
         if nowait and locked in (0, 1):
             return bool(locked)
         if not locked:
-            raise StorageError("Unable to acquire commit lock")
+            raise UnableToAcquireCommitLockError("Unable to acquire commit lock")
 
     def release_commit_lock(self, cursor):
         stmt = "SELECT RELEASE_LOCK(CONCAT(DATABASE(), '.commit'))"
@@ -166,7 +167,7 @@ class OracleLocker(Locker):
                     'lock already owned', 'illegal handle')[int(status)]
             else:
                 msg = str(status)
-            raise StorageError(
+            raise UnableToAcquireCommitLockError(
                 "Unable to acquire commit lock (%s)" % msg)
 
         # Alternative:


### PR DESCRIPTION
Like other issues and pull requests have noted, the global commit lock can sometimes become a bottleneck. Because this issue is most often due to transient issues like high write loads which in certain scenarios may be recoverable (e.g., by backing off and retrying), it can be useful to specifically catch the exception thrown in that case. A plain `StorageError` can have many meanings, and the different text messages used between databases means it's not necessarily portably reliable to try to distinguish this case based on the message alone.

This PR adds a specific exception that the `ILocker` instances throw when getting a commit lock fails. For backwards compatibility, it is a subclass of `StorageError`. It does not mixin `transaction.interfaces.TransientError` (even though it *is* probably transient) because that would probably result in behaviour changes as middleware transaction managers would start retrying on this case, which may actually increase database load and commit lock failures. Therefore, users would still need to account for this case explicitly.

Internally, we've been using a monkey-patched version of this technique and it has been useful for us to be able to distinguish this case. Although we haven't had a use case for them, I can add specific exception subclasses for the other errors thrown by locker.py in this or another PR. I'm very open to any comments or suggestions.