### PR TITLE
commit-lock-timeout support for PostgreSQL 9.3+

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@
 Next Major Release
 ------------------
 
+- commit-lock-timeout support for PostgreSQL 9.3+.
+
 - MySQL 5.5: The test suite was freezing in checkBackwardTimeTravel. Fixed.
 
 - Added performance metrics using the perfmetrics package.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,9 @@
 
+1.6.0b3 (unreleased)
+--------------------
+
+- commit-lock-timeout support for PostgreSQL 9.3+.
+
 1.6.0b2 (2014-10-03)
 --------------------
 
@@ -15,8 +20,6 @@
 
 - Packing: Reduced RAM consumption while packing by using IIBTree.Set
   instead of built-in set objects.
-
-- commit-lock-timeout support for PostgreSQL 9.3+.
 
 - MySQL 5.5: The test suite was freezing in checkBackwardTimeTravel. Fixed.
 


### PR DESCRIPTION
This commit-lock-timeout support for PostgreSQL 9.3+ should be backward-compatible with previous PostgreSQL versions.  The lock_timeout feature [1] in 9.3 is used, if version is 9.3 or greater.

[1] http://www.postgresql.org/docs/9.3/static/runtime-config-client.html