### PR TITLE
Travis CI for MySQL and Postgres

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+source = relstorage
+omit = relstorage/tests/*
+
+[report]
+# Coverage is run on Linux under cPython 2, so
+# exclude branches that are windows specific or pypy/python3
+# specific
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+    except ImportError:
+    if __name__ == .__main__.:
+    if PYPY:
+    if PY3:
+    if sys.platform == 'win32':
+    if mswindows:
+    if is_windows:
+    if sys.version_info.*>=.*3

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.egg-info
 *.pyc
 *.sublime-*
+.coverage
+htmlcov/
 bin/
 develop-eggs/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: python
+sudo: false
+services:
+  - mysql
+  - postgresql
+env:
+  matrix:
+    - ENV=mysql
+    - ENV=postgres
+matrix:
+  fast_finish: true
+script:
+  - coverage run -m relstorage.tests.alltests
+after_success:
+  - coveralls
+notifications:
+  email: false
+
+install:
+  - pip install -U pip
+  - pip install -U tox coveralls zope.testing mock coverage
+  - pip install -U -e .
+  - .travis/setup-$ENV.sh
+# cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.venv
+    - $HOME/.runtimes
+    - $HOME/.wheelhouse
+
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/.travis/setup-mysql.sh
+++ b/.travis/setup-mysql.sh
@@ -1,0 +1,11 @@
+pip install -U MySQL-python
+mysql -uroot -e "CREATE USER 'relstoragetest'@'localhost' IDENTIFIED BY 'relstoragetest';"
+mysql -uroot -e "CREATE DATABASE relstoragetest;"
+mysql -uroot -e "GRANT ALL ON relstoragetest.* TO 'relstoragetest'@'localhost';"
+mysql -uroot -e "CREATE DATABASE relstoragetest2;"
+mysql -uroot -e "GRANT ALL ON relstoragetest2.* TO 'relstoragetest'@'localhost';"
+mysql -uroot -e "CREATE DATABASE relstoragetest_hf;"
+mysql -uroot -e "GRANT ALL ON relstoragetest_hf.* TO 'relstoragetest'@'localhost';"
+mysql -uroot -e "CREATE DATABASE relstoragetest2_hf;"
+mysql -uroot -e "GRANT ALL ON relstoragetest2_hf.* TO 'relstoragetest'@'localhost';"
+mysql -uroot -e "FLUSH PRIVILEGES;"

--- a/.travis/setup-postgres.sh
+++ b/.travis/setup-postgres.sh
@@ -1,0 +1,6 @@
+pip install -U psycopg2
+psql -U postgres -c "CREATE USER relstoragetest WITH PASSWORD 'relstoragetest';"
+psql -U postgres -c "CREATE DATABASE relstoragetest OWNER relstoragetest;"
+psql -U postgres -c "CREATE DATABASE relstoragetest2 OWNER relstoragetest;"
+psql -U postgres -c "CREATE DATABASE relstoragetest_hf OWNER relstoragetest;"
+psql -U postgres -c "CREATE DATABASE relstoragetest2_hf OWNER relstoragetest;"

--- a/relstorage/tests/alltests.py
+++ b/relstorage/tests/alltests.py
@@ -12,12 +12,13 @@
 #
 ##############################################################################
 """Combines the tests of all adapters"""
-
+from __future__ import absolute_import
 import unittest
+import logging
 
-from testpostgresql import test_suite as postgresql_test_suite
-from testmysql import test_suite as mysql_test_suite
-from testoracle import test_suite as oracle_test_suite
+from .testpostgresql import test_suite as postgresql_test_suite
+from .testmysql import test_suite as mysql_test_suite
+from .testoracle import test_suite as oracle_test_suite
 
 def make_suite():
     suite = unittest.TestSuite()
@@ -25,3 +26,10 @@ def make_suite():
     suite.addTest(mysql_test_suite())
     suite.addTest(oracle_test_suite())
     return suite
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    # We get constant errors about failing to lock a blob file,
+    # which really bloats the CI logs, so turn those off.
+    logging.getLogger('zc.lockfile').setLevel(logging.CRITICAL)
+    unittest.main(defaultTest='make_suite')

--- a/relstorage/tests/blob/testblob.py
+++ b/relstorage/tests/blob/testblob.py
@@ -56,6 +56,13 @@ def new_time():
     time.sleep(1)
     return new_time
 
+with open(__file__) as _f:
+    # Just use the this module as the source of our data
+    # Capture it at import time because test cases may
+    # chdir(), and we may not have an absolute path in __file__,
+    # depending on how they are run.
+    _random_file_data = _f.read().replace('\n', '').split()
+del _f
 
 def random_file(size, fd):
     """Create a random data of at least the given size, writing to fd.
@@ -68,8 +75,7 @@ def random_file(size, fd):
     """
     def fdata():
         seed = "1092384956781341341234656953214543219"
-        # Just use the this module as the source of our data
-        words = open(__file__, "r").read().replace("\n", '').split()
+        words = _random_file_data
         a = collections.deque(words)
         b = collections.deque(seed)
         while True:
@@ -125,7 +131,7 @@ class BlobUndoTests(BlobTestBase):
         # the blob footprint object should exist no longer
         self.assertRaises(KeyError, root.__getitem__, 'blob')
         database.close()
-        
+
     def testUndo(self):
         database = DB(self._storage)
         connection = database.open()
@@ -158,7 +164,7 @@ class BlobUndoTests(BlobTestBase):
         blob.consumeFile('consume1')
         root['blob'] = blob
         transaction.commit()
-        
+
         transaction.begin()
         blob = root['blob']
         open('consume2', 'w').write('this is state 2')
@@ -261,7 +267,7 @@ class RecoveryBlobStorage(BlobTestBase,
         transaction.commit()
         self._dst.copyTransactionsFrom(self._storage)
         self.compare(self._storage, self._dst)
-    
+
 
 class LargeBlobTest(BlobTestBase):
     """Test large blob upload and download.
@@ -607,7 +613,7 @@ def storage_reusable_suite(prefix, factory,
             return factory(name, blob_dir, **kw)
 
         test.globs['create_storage'] = create_storage
-    
+
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocFileSuite(
         "blob_connection.txt", "blob_importexport.txt",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,10 @@ setup(
         'zope.interface',
         'zc.lockfile',
     ],
-    tests_require=['mock'],
+    tests_require=[
+        'mock',
+        'zope.testing',
+    ],
     extras_require={
         'mysql': ['MySQL-python>=1.2.2'],
         'postgresql': ['psycopg2>=2.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py27-mysql,py27-postgres
+
+[testenv]
+deps = coverage
+commands =
+    coverage run -m relstorage.tests.alltests
+
+[testenv:py27-mysql]
+deps =
+    MySQL-python
+    {[testenv]deps}
+commands =
+    {[testenv]commands}
+
+[testenv:py27-postgres]
+deps =
+    psycopg2
+    {[testenv]deps}
+commands =
+    {[testenv]commands}


### PR DESCRIPTION
This fixes #32 in that it enables CI.

This only enables CI for CPython; I'll add PyPy later and/or modify the existing PyPy PR.

There are currently test failures (mostly known) that will be addressed with subsequent PRs.

The tox.ini is not optimized for local usage, only for Travis usage. 

(Travis is being uncharacteristically slow to start builds this morning.)