### PR TITLE
Fix (most) tests under ZODB 4.3.1; update ZODB dep

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,10 @@
 
 - Update the ZODB dependency from ZODB3 3.7.0 to ZODB 4.3.0.
 
+- Fixed ``loadBefore`` of a deleted/undone object to correctly raise a
+  POSKeyError instead of returning an empty state. (Revealed by
+  updated tests for FileStorage in ZODB 4.3.1.)
+
 1.6.0b3 (2014-12-08)
 --------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.7.0a1 (Unreleased)
+--------------------
+
+- Update the ZODB dependency from ZODB3 3.7.0 to ZODB 4.3.0.
 
 1.6.0b3 (2014-12-08)
 --------------------

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -566,6 +566,13 @@ class RelStorage(
                 if end_int is not None:
                     end = p64(end_int)
                 else:
+                    if state is None:
+                        # This can happen if something attempts to load
+                        # an object whose creation has been undone, see load()
+                        # XXX: Is this the only place? What if just state is None?
+                        # This change fixes the test in TransactionalUndoStorage.checkUndoCreationBranch1
+                        self._log_keyerror(oid_int, "creation has been undone")
+                        raise POSKeyError(oid)
                     end = None
                 if state is not None:
                     state = str(state)

--- a/relstorage/tests/alltests.py
+++ b/relstorage/tests/alltests.py
@@ -19,9 +19,11 @@ import logging
 from .testpostgresql import test_suite as postgresql_test_suite
 from .testmysql import test_suite as mysql_test_suite
 from .testoracle import test_suite as oracle_test_suite
+from .test_zodbconvert import test_suite as zodbconvert_test_suite
 
 def make_suite():
     suite = unittest.TestSuite()
+    suite.addTest(zodbconvert_test_suite())
     suite.addTest(postgresql_test_suite())
     suite.addTest(mysql_test_suite())
     suite.addTest(oracle_test_suite())

--- a/relstorage/tests/blob/testblob.py
+++ b/relstorage/tests/blob/testblob.py
@@ -14,7 +14,7 @@
 
 from ZODB.blob import Blob
 from ZODB.DB import DB
-from zope.testing import doctest
+import doctest
 
 import atexit
 import collections

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -627,9 +627,20 @@ class GenericRelStorageTests(
     def checkPackBrokenPickle(self):
         # Verify the pack stops with the right exception if it encounters
         # a broken pickle.
-        from cPickle import UnpicklingError
+        # Under Python 2, with zodbpickle, there may be a difference depending
+        # on whether the accelerated implementation is in use.
+        from zodbpickle.pickle import UnpicklingError as pUnpickErr
+        unpick_errs = (pUnpickErr,)
+        try:
+            from zodbpickle.fastpickle import UnpicklingError as fUnpickErr
+        except ImportError:
+            pass
+        else:
+            unpick_errs += (fUnpickErr,)
+
+
         self._dostoreNP(self._storage.new_oid(), data='brokenpickle')
-        self.assertRaises(UnpicklingError, self._storage.pack,
+        self.assertRaises(unpick_errs, self._storage.pack,
             time.time() + 10000, referencesf)
 
     def checkBackwardTimeTravelWithoutRevertWhenStale(self):

--- a/relstorage/tests/test_zodbconvert.py
+++ b/relstorage/tests/test_zodbconvert.py
@@ -129,3 +129,6 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(ZODBConvertTests))
     return suite
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ setup(
     install_requires=[
         'perfmetrics',
         'ZODB >= 4.3.0, <5.0',
+        # ZEO is needed for blob layout
+        'ZEO >= 4.2.0b1, <5.0',
         'zope.interface',
         'zc.lockfile',
     ],

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     zip_safe=False,  # otherwise ZConfig can't see component.xml
     install_requires=[
         'perfmetrics',
-        'ZODB3>=3.7.0',
+        'ZODB >= 4.3.0, <5.0',
         'zope.interface',
         'zc.lockfile',
     ],


### PR DESCRIPTION
This needed updating of the ZODB dependency, which was agreed to be OK in IRC. (This is also needed for PyPy.)

I'm not entirely sure about the fix for the new test from ZODB 4.3.1; reviews and comments are welcome!

Note the mysql tests still fail on a 16MB object (the server disconnects). I suspect this is a fundamental limitation of Travis we'll have to workaround (I vaguely recall some parameter you have to tune for that in certain versions). I'm leaving that to a future PR (we might also want to disable the 2GB Postgres blob test to be a good citizen of Travis).

I left all the BWC code for old ZODB <= 3.8, we can remove that in a future PR (and start using zodbpickle internally). Right now, only the tests should be broken on old ZODBs (I'm guessing) and an enterprising user could still upgrade RelStorage, but that's likely to gradually rot further since we don't test those.