### PR TITLE
Enable all the unittests in alltests.

### DIFF
--- a/relstorage/tests/alltests.py
+++ b/relstorage/tests/alltests.py
@@ -11,22 +11,30 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Combines the tests of all adapters"""
-from __future__ import absolute_import
+"""Combines all the tests"""
+from __future__ import absolute_import, print_function
 import unittest
 import logging
 
-from .testpostgresql import test_suite as postgresql_test_suite
-from .testmysql import test_suite as mysql_test_suite
-from .testoracle import test_suite as oracle_test_suite
-from .test_zodbconvert import test_suite as zodbconvert_test_suite
-
 def make_suite():
     suite = unittest.TestSuite()
-    suite.addTest(zodbconvert_test_suite())
-    suite.addTest(postgresql_test_suite())
-    suite.addTest(mysql_test_suite())
-    suite.addTest(oracle_test_suite())
+    modules = [
+        'test_autotemp',
+        'test_blobhelper',
+        'test_cache',
+        'test_treemark',
+        'test_zodbconvert',
+        'test_zodbpack',
+        'test_zodburi',
+        'testpostgresql',
+        'testmysql',
+        'testoracle',
+    ]
+    for mod_name in modules:
+        mod = __import__(mod_name, globals())
+        print(mod)
+        suite.addTest(mod.test_suite())
+
     return suite
 
 if __name__ == '__main__':

--- a/relstorage/tests/test_treemark.py
+++ b/relstorage/tests/test_treemark.py
@@ -84,3 +84,8 @@ class TestTreeMarker(unittest.TestCase):
         ])
         obj.mark([5])
         self.assertEqual(set(obj.reachable), set([5, 7, 8 << 32, 9 << 32]))
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestTreeMarker))
+    return suite

--- a/relstorage/tests/test_zodburi.py
+++ b/relstorage/tests/test_zodburi.py
@@ -18,7 +18,10 @@ class TestPostgreSQLURIResolver(unittest.TestCase):
         self.patcher1 = mock.patch('relstorage.zodburi_resolver.RelStorage')
         self.patcher2 = mock.patch('relstorage.adapters.postgresql.PostgreSQLAdapter')
         self.RelStorage = self.patcher1.start()
-        self.PostgreSQLAdapter = self.patcher2.start()
+        try:
+            self.PostgreSQLAdapter = self.patcher2.start()
+        except ImportError as e:
+            raise unittest.SkipTest(str(e))
 
     def tearDown(self):
         self.patcher1.stop()
@@ -115,3 +118,9 @@ class TestEntryPoints(unittest.TestCase):
                 import warnings
                 warnings.warn('%s not found, skipping the zodburi test for %s'%
                               (e[0], name))
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestPostgreSQLURIResolver))
+    suite.addTest(unittest.makeSuite(TestEntryPoints))
+    return suite


### PR DESCRIPTION
This should see our coverage numbers go up, which is important for merging future PRs and Python 3 porting.