### PR TITLE
Improve implementation of storage.lastTransaction()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,8 +18,8 @@
 
 - zodbconvert: The ``--incremental`` option is supported with a
   FileStorage (or any storage that implements
-  ``IStorage.lastTransaction()``)
-  as a destination, not just RelStorages.
+  ``IStorage.lastTransaction()``) as a destination, not just
+  RelStorages.
 
 - zodbconvert: The ``--incremental`` option is supported with a
   RelStorage as a destination. See `PR 22`_. With contributions by
@@ -34,10 +34,14 @@
 
 .. _`PR 18`: https://github.com/zodb/relstorage/pull/18/
 
+
 - PostgreSQL 9.3: Support ``commit-lock-timeout``. Contributed in `PR
   20`_ by Sean Upton.
 
 .. _`PR 20`: https://github.com/zodb/relstorage/pull/20
+
+- ``RelStorage.lastTransaction()`` is more consistent with FileStorage
+  and ClientStorage, returning a useful value in more cases.
 
 1.6.0b3 (2014-12-08)
 --------------------

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -969,7 +969,7 @@ class RelStorage(
                 # so our MVCC state is "floating".
                 # Read directly from the database to get the latest value,
                 self._before_load() # connect if needed
-                return self._adapter.txncontrol.get_tid(self._load_cursor)
+                return p64(self._adapter.txncontrol.get_tid(self._load_cursor))
 
             return max(self._ltid, p64(self._prev_polled_tid or 0))
         finally:

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -964,12 +964,11 @@ class RelStorage(
         self._lock_acquire()
         try:
             if (self._ltid == z64
-                and self._prev_polled_tid is None
-                and self._load_transaction_open):
+                and self._prev_polled_tid is None):
                 # We haven't committed *or* polled for transactions,
                 # so our MVCC state is "floating".
                 # Read directly from the database to get the latest value,
-                # but don't force a connection just to do that (just like ClientStorage).
+                self._before_load() # connect if needed
                 return self._adapter.txncontrol.get_tid(self._load_cursor)
 
             return max(self._ltid, p64(self._prev_polled_tid or 0))

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -963,7 +963,16 @@ class RelStorage(
     def lastTransaction(self):
         self._lock_acquire()
         try:
-            return self._ltid
+            if (self._ltid == z64
+                and self._prev_polled_tid is None
+                and self._load_transaction_open):
+                # We haven't committed *or* polled for transactions,
+                # so our MVCC state is "floating".
+                # Read directly from the database to get the latest value,
+                # but don't force a connection just to do that (just like ClientStorage).
+                return self._adapter.txncontrol.get_tid(self._load_cursor)
+
+            return max(self._ltid, p64(self._prev_polled_tid or 0))
         finally:
             self._lock_release()
 

--- a/relstorage/tests/test_zodbconvert.py
+++ b/relstorage/tests/test_zodbconvert.py
@@ -76,7 +76,6 @@ class AbstractZODBConvertBase(unittest.TestCase):
         main(['', '--dry-run', self.cfgfile])
         self._check_value_of_x_in_dest(None)
 
-
     def test_incremental(self):
         x = 10
         self._write_value_for_x_in_src(x)
@@ -88,6 +87,10 @@ class AbstractZODBConvertBase(unittest.TestCase):
         main(['', '--incremental', self.cfgfile])
         self._check_value_of_x_in_dest(x)
 
+    def test_incremental_empty_src_dest(self):
+        # Should work and not raise a POSKeyError
+        main(['', '--incremental', self.cfgfile])
+        self._check_value_of_x_in_dest(None)
 
     def test_no_overwrite(self):
         db = self._create_src_db() # create the root object

--- a/relstorage/zodbconvert.py
+++ b/relstorage/zodbconvert.py
@@ -117,8 +117,7 @@ def main(argv=sys.argv):
             # anything is loaded with it.
             last_tid = destination.lastTransaction()
             if isinstance(last_tid, bytes):
-                # FileStorage returns a byte string, everything else
-                # returns an int
+                # This *should* be a byte string.
                 last_tid = u64(last_tid)
 
             next_tid = p64(last_tid+1)

--- a/relstorage/zodbconvert.py
+++ b/relstorage/zodbconvert.py
@@ -113,12 +113,8 @@ def main(argv=sys.argv):
         if not storage_has_data(destination):
             log.warning("Destination empty, start conversion from the beginning.")
         else:
-            # First, make sure the connection is fully connected. This
-            # matters for ClientStorage (connects async) and RelStorage
-            # (connects on demand).
-            # If we hadn't already checked that the destination has data,
-            # this would raise a POSKeyError.
-            destination.load(z64)
+            # This requires that the storage produce a valid (not z64) value before
+            # anything is loaded with it.
             last_tid = destination.lastTransaction()
             if isinstance(last_tid, bytes):
                 # FileStorage returns a byte string, everything else

--- a/relstorage/zodbconvert.py
+++ b/relstorage/zodbconvert.py
@@ -116,6 +116,8 @@ def main(argv=sys.argv):
             # First, make sure the connection is fully connected. This
             # matters for ClientStorage (connects async) and RelStorage
             # (connects on demand).
+            # If we hadn't already checked that the destination has data,
+            # this would raise a POSKeyError.
             destination.load(z64)
             last_tid = destination.lastTransaction()
             if isinstance(last_tid, bytes):

--- a/relstorage/zodbconvert.py
+++ b/relstorage/zodbconvert.py
@@ -105,7 +105,7 @@ def main(argv=sys.argv):
     log.info("Storages opened successfully.")
 
     if options.incremental:
-        if not hasattr(destination, '_adapter') and not hasattr(destination, 'lastTransaction'):
+        if not hasattr(destination, 'lastTransaction'):
             msg = ("Error: no API is known for determining the last committed "
                    "transaction of the destination storage. Aborting "
                    "conversion.")
@@ -113,25 +113,21 @@ def main(argv=sys.argv):
         if not storage_has_data(destination):
             log.warning("Destination empty, start conversion from the beginning.")
         else:
-            wrap_source = False
-            if hasattr(destination, '_adapter'):
-                # RelStorage. Note that we implement lastTransaction(), but
-                # only in-memory, local to the particular object. (We should probably
-                # change that?) So order matters.
-                destination.load(z64) # prime the connection
-                wrap_source = True # compensate for our bug
-                last_tid = destination._adapter.txncontrol.get_tid(
-                    destination._load_cursor)
-            else:
-                # IStorage, like FileStorage
-                last_tid_s = destination.lastTransaction()
-                last_tid = u64(last_tid_s)
+            # First, make sure the connection is fully connected. This
+            # matters for ClientStorage (connects async) and RelStorage
+            # (connects on demand).
+            destination.load(z64)
+            last_tid = destination.lastTransaction()
+            if isinstance(last_tid, bytes):
+                # FileStorage returns a byte string, everything else
+                # returns an int
+                last_tid = u64(last_tid)
 
             next_tid = p64(last_tid+1)
-            if wrap_source:
-                source = _DefaultStartStorageIteration(source, next_tid)
-            else:
-                source = source.iterator(start=next_tid)
+            # Compensate for the RelStorage bug(?) and get a reusable iterator
+            # that starts where we want it to. There's no harm in wrapping it for
+            # other sources like FileStorage too.
+            source = _DefaultStartStorageIteration(source, next_tid)
             log.info("Resuming ZODB copy from %s", readable_tid_repr(next_tid))
 
 


### PR DESCRIPTION
Discussed in https://github.com/zopefoundation/ZODB/issues/50 this makes it more consistent with ClientStorage and FileStorage.

Adjust zodbconvert to use this fact and remove all the special casing. This should guarantee that zodbconvert works with ClientStorage (although this is not covered by unit tests).