### PR TITLE
Use TRUNCATE CASCADE to zap_all on Postgres.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
   fast_finish: true
 script:
 # coverage slows PyPy down from 2minutes to 12+.
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then python -m relstorage.tests.alltests; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then coverage run -m relstorage.tests.alltests; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then python -m relstorage.tests.alltests -v; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then coverage run -m relstorage.tests.alltests -v; fi
 after_success:
   - coveralls
 notifications:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -57,6 +57,12 @@
 
 .. _`issue 30`: https://github.com/zodb/relstorage/issues/30
 
+- PostgreSQL: ``zodbconvert --clear`` should be much faster when the
+  destination is a PostgreSQL schema containing lots of data. Partial
+  fix for `issue 16`_ reported by Chris McDonough.
+
+.. _`issue 16`: https://github.com/zodb/relstorage/issues/16
+
 1.6.0b3 (2014-12-08)
 --------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,8 +44,12 @@
   Jacobs.
 
 - PostgreSQL: ``zodbconvert --clear`` should be much faster when the
-  destination is a PostgreSQL schema containing lots of data. Partial
-  fix for `issue 16`_ reported by Chris McDonough.
+  destination is a PostgreSQL schema containing lots of data. *NOTE*:
+  There can be no other open RelStorage connections to the destination,
+  or any PostgreSQL connection in general that might be holding locks
+  on the RelStorage tables, or ``zodbconvert`` will block indefinitely
+  waiting for the locks to be release. Partial fix for `issue 16`_
+  reported by Chris McDonough.
 
 .. _`PR 18`: https://github.com/zodb/relstorage/pull/18/
 .. _`PR 20`: https://github.com/zodb/relstorage/pull/20

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,8 +17,6 @@
 - Updated the buildout configuration to just run relstorage tests and
   to select which databases to use at build time.
 
-.. _`PR 23`: https://github.com/zodb/relstorage/pull/23/
-
 - zodbconvert: The ``--incremental`` option is supported with a
   FileStorage (or any storage that implements
   ``IStorage.lastTransaction()``) as a destination, not just
@@ -29,19 +27,11 @@
   Sylvain Viollon, Mauro Amico, and Peter Jacobs. Originally reported
   by Jan-Wijbrand Kolman.
 
-.. _`PR 22`: https://github.com/zodb/relstorage/pull/22
-
-
 - Raise a specific exception when acquiring the commit or pack locks
   fails. See `PR 18`_.
 
-.. _`PR 18`: https://github.com/zodb/relstorage/pull/18/
-
-
 - PostgreSQL 9.3: Support ``commit-lock-timeout``. Contributed in `PR
   20`_ by Sean Upton.
-
-.. _`PR 20`: https://github.com/zodb/relstorage/pull/20
 
 - ``RelStorage.lastTransaction()`` is more consistent with FileStorage
   and ClientStorage, returning a useful value in more cases.
@@ -49,19 +39,21 @@
 - Oracle: Add support for getting the database size. Contributed in
   `PR 21`_ by Mauro Amico.
 
-.. _`PR 21`: https://github.com/zodb/relstorage/pull/21
-
 - Oracle: Packing should no longer produce LOB errors. This partially
   reverts the speedups in 1.6.0b2. Reported in `issue 30`_ by Peter
   Jacobs.
-
-.. _`issue 30`: https://github.com/zodb/relstorage/issues/30
 
 - PostgreSQL: ``zodbconvert --clear`` should be much faster when the
   destination is a PostgreSQL schema containing lots of data. Partial
   fix for `issue 16`_ reported by Chris McDonough.
 
+.. _`PR 18`: https://github.com/zodb/relstorage/pull/18/
+.. _`PR 20`: https://github.com/zodb/relstorage/pull/20
+.. _`PR 21`: https://github.com/zodb/relstorage/pull/21
+.. _`issue 30`: https://github.com/zodb/relstorage/issues/30
 .. _`issue 16`: https://github.com/zodb/relstorage/issues/16
+.. _`PR 22`: https://github.com/zodb/relstorage/pull/22
+.. _`PR 23`: https://github.com/zodb/relstorage/pull/23/
 
 1.6.0b3 (2014-12-08)
 --------------------

--- a/README.txt
+++ b/README.txt
@@ -639,7 +639,7 @@ underscores instead of dashes in the option names.
 
         The MySQL and Oracle adapters support this option. The
         PostgreSQL adapter supports this when the PostgreSQL server is
-		at least version 9.3; otherwise it is ignored.
+        at least version 9.3; otherwise it is ignored.
 
 ``commit-lock-id``
         During commit, RelStorage acquires a database-wide lock. This

--- a/relstorage/adapters/schema.py
+++ b/relstorage/adapters/schema.py
@@ -886,9 +886,16 @@ class AbstractSchemaInstaller(object):
 
     _zap_all_tbl_stmt = 'DELETE FROM %s'
 
-    def zap_all(self, reset_oid=True):
-        """Clear all data out of the database."""
-        stmt = self._zap_all_tbl_stmt
+    def zap_all(self, reset_oid=True, slow=False):
+        """
+        Clear all data out of the database.
+
+        :keyword bool slow: If True (*not* the default) then database
+            specific optimizations will be skipped and rows will simply be
+            DELETEd. This is helpful when other connections might be open and
+            holding some kind of locks.
+        """
+        stmt = self._zap_all_tbl_stmt if not slow else AbstractSchemaInstaller._zap_all_tbl_stmt
 
         def callback(_conn, cursor):
             existent = set(self.list_tables(cursor))

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -362,12 +362,12 @@ class RelStorage(
             log.info("Reconnected.")
             return f(self._store_conn, self._store_cursor, *args, **kw)
 
-    def zap_all(self, reset_oid=True):
+    def zap_all(self, **kwargs):
         """Clear all objects and transactions out of the database.
 
         Used by the test suite and the ZODBConvert script.
         """
-        self._adapter.schema.zap_all(reset_oid=reset_oid)
+        self._adapter.schema.zap_all(**kwargs)
         self._rollback_load_connection()
         self._cache.clear()
 

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -894,6 +894,8 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
 
 class AbstractRSDestZodbConvertTests(AbstractRSZodbConvertTests):
 
+    zap_supported_by_dest = True
+
     @property
     def filestorage_file(self):
         return self.srcfile

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -48,7 +48,11 @@ class StorageCreatingMixin(object):
         storage = RelStorage(adapter, options=options)
         storage._batcher_row_limit = 1
         if zap:
-            storage.zap_all()
+            # XXX: Some ZODB tests, possibly check4ExtStorageThread and
+            # check7StorageThreads don't close storages when done with them?
+            # This leads to connections remaining open with locks on PyPy, so on PostgreSQL
+            # we can't TRUNCATE tables and have to go the slow route.
+            storage.zap_all(slow=True)
         return storage
 
 

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -698,7 +698,7 @@ class GenericRelStorageTests(
         # on whether the accelerated implementation is in use. Also ,the pure-python
         # version on PyPy can raise IndexError
         from zodbpickle.pickle import UnpicklingError as pUnpickErr
-        unpick_errs = (pUnpickErr,IndexError)
+        unpick_errs = (pUnpickErr, IndexError)
         try:
             from zodbpickle.fastpickle import UnpicklingError as fUnpickErr
         except ImportError:
@@ -709,7 +709,7 @@ class GenericRelStorageTests(
 
         self._dostoreNP(self._storage.new_oid(), data=b'brokenpickle')
         self.assertRaises(unpick_errs, self._storage.pack,
-            time.time() + 10000, referencesf)
+                          time.time() + 10000, referencesf)
 
     def checkBackwardTimeTravelWithoutRevertWhenStale(self):
         # If revert_when_stale is false (the default), when the database
@@ -743,7 +743,7 @@ class GenericRelStorageTests(
                 transaction.commit()
                 self.assertTrue('beta' in r)
 
-                c._storage.zap_all(reset_oid=False)
+                c._storage.zap_all(reset_oid=False, slow=True)
                 c._storage.copyTransactionsFrom(fs)
 
                 fs.close()
@@ -794,7 +794,7 @@ class GenericRelStorageTests(
                 transaction.commit()
                 self.assertTrue('beta' in r)
 
-                c._storage.zap_all(reset_oid=False)
+                c._storage.zap_all(reset_oid=False, slow=True)
                 c._storage.copyTransactionsFrom(fs)
 
                 fs.close()

--- a/relstorage/tests/test_zodbconvert.py
+++ b/relstorage/tests/test_zodbconvert.py
@@ -27,6 +27,7 @@ def skipIfZapNotSupportedByDest(func):
     def test(self):
         if not self.zap_supported_by_dest:
             raise unittest.SkipTest("zap_all not supported")
+        func(self)
     return test
 
 class AbstractZODBConvertBase(unittest.TestCase):

--- a/relstorage/tests/testpostgresql.py
+++ b/relstorage/tests/testpostgresql.py
@@ -216,7 +216,7 @@ def test_suite():
                         **kw)
                     adapter = PostgreSQLAdapter(dsn=dsn, options=options)
                     storage = RelStorage(adapter, name=name, options=options)
-                    storage.zap_all()
+                    storage.zap_all(slow=True)
                     return storage
 
                 prefix = 'PostgreSQL%s%s' % (


### PR DESCRIPTION
This should make ``zodbconvert --clear`` much faster for large (Postgres) destinations.

Addresses #16 partially.