### PR TITLE
Improve conflict resolution efficiency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,9 @@
   re-reading it from the database (they are guaranteed to be the
   same). See `issue 38`_.
 
+- Conflict resolution reads all conflicts from the database in one
+  query, instead of querying for each individual conflict. See `issue 39`_.
+
 .. _`PR 18`: https://github.com/zodb/relstorage/pull/18/
 .. _`PR 20`: https://github.com/zodb/relstorage/pull/20
 .. _`PR 21`: https://github.com/zodb/relstorage/pull/21
@@ -71,6 +74,7 @@
 .. _`PR 23`: https://github.com/zodb/relstorage/pull/23/
 .. _`issue 57`: https://github.com/zodb/relstorage/issues/57
 .. _`issue 38`: https://github.com/zodb/relstorage/issues/38
+.. _`issue 39`: https://github.com/zodb/relstorage/issues/39
 
 1.6.0b3 (2014-12-08)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,10 @@
 - MySQL: Use the "binary" character set to avoid producing "Invalid
   utf8 character string" warnings. See `issue 57`_.
 
+- Conflict resolution uses the locally cached state instead of
+  re-reading it from the database (they are guaranteed to be the
+  same). See `issue 38`_.
+
 .. _`PR 18`: https://github.com/zodb/relstorage/pull/18/
 .. _`PR 20`: https://github.com/zodb/relstorage/pull/20
 .. _`PR 21`: https://github.com/zodb/relstorage/pull/21
@@ -66,6 +70,7 @@
 .. _`PR 22`: https://github.com/zodb/relstorage/pull/22
 .. _`PR 23`: https://github.com/zodb/relstorage/pull/23/
 .. _`issue 57`: https://github.com/zodb/relstorage/issues/57
+.. _`issue 38`: https://github.com/zodb/relstorage/issues/38
 
 1.6.0b3 (2014-12-08)
 --------------------

--- a/relstorage/adapters/interfaces.py
+++ b/relstorage/adapters/interfaces.py
@@ -246,10 +246,9 @@ class IObjectMover(Interface):
         """
 
     def detect_conflict(cursor):
-        """Find one conflict in the data about to be committed.
+        """Find all conflict in the data about to be committed.
 
-        If there is a conflict, returns (oid, prev_tid, attempted_prev_tid,
-        attempted_data).  If there is no conflict, returns None.
+        If there is a conflict, returns a sequence of (oid, prev_tid, attempted_prev_tid).
         """
 
     def replace_temp(cursor, oid, prev_tid, data):

--- a/relstorage/adapters/mover.py
+++ b/relstorage/adapters/mover.py
@@ -718,8 +718,7 @@ class ObjectMover(object):
         """
         if self.keep_history:
             stmt = """
-            SELECT temp_store.zoid, current_object.tid, temp_store.prev_tid,
-                   temp_store.state
+            SELECT temp_store.zoid, current_object.tid, temp_store.prev_tid
             FROM temp_store
                 JOIN current_object ON (temp_store.zoid = current_object.zoid)
             WHERE temp_store.prev_tid != current_object.tid
@@ -727,8 +726,7 @@ class ObjectMover(object):
             """
         else:
             stmt = """
-            SELECT temp_store.zoid, object_state.tid, temp_store.prev_tid,
-                temp_store.state
+            SELECT temp_store.zoid, object_state.tid, temp_store.prev_tid
             FROM temp_store
                 JOIN object_state ON (temp_store.zoid = object_state.zoid)
             WHERE temp_store.prev_tid != object_state.tid
@@ -750,8 +748,7 @@ class ObjectMover(object):
         # Lock in share mode to ensure the data being read is up to date.
         if self.keep_history:
             stmt = """
-            SELECT temp_store.zoid, current_object.tid, temp_store.prev_tid,
-                temp_store.state
+            SELECT temp_store.zoid, current_object.tid, temp_store.prev_tid
             FROM temp_store
                 JOIN current_object ON (temp_store.zoid = current_object.zoid)
             WHERE temp_store.prev_tid != current_object.tid
@@ -760,8 +757,7 @@ class ObjectMover(object):
             """
         else:
             stmt = """
-            SELECT temp_store.zoid, object_state.tid, temp_store.prev_tid,
-                temp_store.state
+            SELECT temp_store.zoid, object_state.tid, temp_store.prev_tid
             FROM temp_store
                 JOIN object_state ON (temp_store.zoid = object_state.zoid)
             WHERE temp_store.prev_tid != object_state.tid
@@ -782,16 +778,14 @@ class ObjectMover(object):
         """
         if self.keep_history:
             stmt = """
-            SELECT temp_store.zoid, current_object.tid, temp_store.prev_tid,
-                temp_store.state
+            SELECT temp_store.zoid, current_object.tid, temp_store.prev_tid
             FROM temp_store
                 JOIN current_object ON (temp_store.zoid = current_object.zoid)
             WHERE temp_store.prev_tid != current_object.tid
             """
         else:
             stmt = """
-            SELECT temp_store.zoid, object_state.tid, temp_store.prev_tid,
-                temp_store.state
+            SELECT temp_store.zoid, object_state.tid, temp_store.prev_tid
             FROM temp_store
                 JOIN object_state ON (temp_store.zoid = object_state.zoid)
             WHERE temp_store.prev_tid != object_state.tid

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -771,13 +771,17 @@ class RelStorage(
         # Detect conflicting changes.
         # Try to resolve the conflicts.
         resolved = set()  # a set of OIDs
-        while True:
-            conflict = adapter.mover.detect_conflict(cursor)
-            if conflict is None:
-                break
+        # In the past, we didn't load all conflicts from the DB at once,
+        # just one at a time. This was because we also fetched the state data
+        # from the DB, and it could be large. But now we use the state we have in
+        # our local temp cache, so memory concerns are gone.
+        conflicts = adapter.mover.detect_conflict(cursor)
+        if conflicts:
+            log.debug("Attempting to resolve %d conflicts", len(conflicts))
 
+        for conflict in conflicts:
             oid_int, prev_tid_int, serial_int = conflict
-            data = self.cache.read_temp(oid_int)
+            data = self._cache.read_temp(oid_int)
             oid = p64(oid_int)
             prev_tid = p64(prev_tid_int)
             serial = p64(serial_int)

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -776,8 +776,8 @@ class RelStorage(
             if conflict is None:
                 break
 
-            oid_int, prev_tid_int, serial_int, data = conflict
-            assert isinstance(data, bytes) # XXX PY3 porting
+            oid_int, prev_tid_int, serial_int = conflict
+            data = self.cache.read_temp(oid_int)
             oid = p64(oid_int)
             prev_tid = p64(prev_tid_int)
             serial = p64(serial_int)


### PR DESCRIPTION
- Use the local cache state to resolve conflicts instead of reading from the DB. Fixes #38.
- Query all conflicts at once. Fixes #39 
