### PR TITLE
registerDB and new_instance cooperate with storage wrappers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ notifications:
 
 install:
   - pip install -U pip
-  - pip install -U tox coveralls zope.testing mock coverage
-  - pip install -U -e .
+  - pip install -U tox coveralls
+  - pip install -U -e ".[test]"
   - .travis/setup-$ENV.sh
 # cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ notifications:
   email: false
 
 install:
-  - pip install -U pip
+  - pip install -U pip setuptools
   - pip install -U tox coveralls
   - pip install -U -e ".[test]"
   - .travis/setup-$ENV.sh

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,10 @@ Bug Fixes
   reverts the speedups in 1.6.0b2. Reported in :issue:`30` by Peter
   Jacobs.
 
+- :meth:`.RelStorage.registerDB` and :meth:`.RelStorage.new_instance`
+  now work with storage wrappers like zc.zlibstorage. See :issue:`70`
+  and :issue:`71`.
+
 Included Utilities
 ------------------
 

--- a/relstorage/adapters/schema.py
+++ b/relstorage/adapters/schema.py
@@ -926,6 +926,7 @@ class AbstractSchemaInstaller(object):
 
         self.connmanager.open_and_call(callback)
 
+
     def drop_all(self):
         """Drop all tables and sequences."""
         def callback(conn, cursor):

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -372,7 +372,7 @@ class RelStorage(
         Used by the test suite and the ZODBConvert script.
         """
         self._adapter.schema.zap_all(**kwargs)
-        self._rollback_load_connection()
+        self.release()
         self._cache.clear()
 
     def release(self):
@@ -395,6 +395,7 @@ class RelStorage(
                 instance = wref()
                 if instance is not None:
                     instance.close()
+            self._instances = []
 
     def __len__(self):
         return self._adapter.stats.get_object_count()
@@ -422,6 +423,8 @@ class RelStorage(
             # We special-case zlibstorage for speed
             if hasattr(wrapper, 'base') and hasattr(wrapper, 'copied_methods'):
                 type(wrapper).new_instance = _zlibstorage_new_instance
+                # NOTE that zlibstorage has a custom copyTransactionsFrom that overrides
+                # our own implementation.
             else:
                 wrapper.new_instance = lambda s: type(wrapper)(self.new_instance())
 

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -237,6 +237,14 @@ class RelStorage(
                            create=False, options=self._options, cache=cache,
                            blobhelper=blobhelper)
         self._instances.append(weakref.ref(other, self._instances.remove))
+
+        if '_crs_transform_record_data' in self.__dict__:
+            # registerDB has been called on us but isn't called on
+            # our children. Make sure any wrapper that needs to transform
+            # records can do so.
+            # See https://github.com/zodb/relstorage/issues/71
+            other._crs_transform_record_data = self._crs_transform_record_data
+            other._crs_untransform_record_data = self._crs_untransform_record_data
         return other
 
     try:
@@ -406,8 +414,19 @@ class RelStorage(
         """Return database size in bytes"""
         return self._adapter.stats.get_db_size()
 
-    def registerDB(self, db, limit=None):
-        pass  # we don't care
+    def registerDB(self, wrapper):
+        if (ZODB.interfaces.IStorageWrapper.providedBy(wrapper)
+                and not ZODB.interfaces.IDatabase.providedBy(wrapper)
+                and not hasattr(type(wrapper), 'new_instance')):
+            # Fixes for https://github.com/zopefoundation/zc.zlibstorage/issues/2
+            # We special-case zlibstorage for speed
+            if hasattr(wrapper, 'base') and hasattr(wrapper, 'copied_methods'):
+                type(wrapper).new_instance = _zlibstorage_new_instance
+            else:
+                wrapper.new_instance = lambda s: type(wrapper)(self.new_instance())
+
+        # Prior to ZODB 4.3.1, ConflictResolvingStorage would raise an AttributeError
+        super(RelStorage, self).registerDB(wrapper)
 
     def isReadOnly(self):
         return self._is_read_only
@@ -1564,3 +1583,16 @@ class Record(DataRecord):
         if data is not None:
             assert isinstance(data, bytes)
         DataRecord.__init__(self, p64(oid_int), tid, data, None)
+
+def _zlibstorage_new_instance(self):
+    new_self = type(self).__new__(type(self))
+    # Preserve _transform, etc
+    new_self.__dict__ = self.__dict__.copy()
+    new_self.base = self.base.new_instance()
+    # Because these are bound methods, we must re-copy
+    # them or ivars might be wrong, like _transaction
+    for name in self.copied_methods:
+        v = getattr(new_self.base, name, None)
+        if v is not None:
+            setattr(new_self, name, v)
+    return new_self

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -894,10 +894,11 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
         """ % (self.filestorage_name, self.filestorage_file,
                self.relstorage_name, self._relstorage_contents())
         self._write_cfg(cfg)
-        self.make_storage(zap=True)
+
+        self.make_storage(zap=True).close()
 
     def _wrap_storage(self, storage):
-        return ZlibStorage(storage)
+        return self._closing(ZlibStorage(storage))
 
     def _create_dest_storage(self):
         return self._wrap_storage(super(AbstractRSZodbConvertTests, self)._create_dest_storage())
@@ -906,8 +907,8 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
         return self._wrap_storage(super(AbstractRSZodbConvertTests, self)._create_src_storage())
 
     def test_new_instance_still_zlib(self):
-        storage = self.make_storage()
-        new_storage = storage.new_instance()
+        storage = self._closing(self.make_storage())
+        new_storage = self._closing(storage.new_instance())
         self.assertIsInstance(new_storage,
                               ZlibStorage)
 
@@ -916,7 +917,6 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
 
         self.assertIn('_crs_untransform_record_data', new_storage.base.__dict__)
         self.assertIn('_crs_transform_record_data', new_storage.base.__dict__)
-
 
 class AbstractRSDestZodbConvertTests(AbstractRSZodbConvertTests):
 
@@ -927,7 +927,7 @@ class AbstractRSDestZodbConvertTests(AbstractRSZodbConvertTests):
         return self.srcfile
 
     def _create_dest_storage(self):
-        return self.make_storage(zap=False)
+        return self._closing(self.make_storage(zap=False))
 
 class AbstractRSSrcZodbConvertTests(AbstractRSZodbConvertTests):
 
@@ -939,7 +939,7 @@ class AbstractRSSrcZodbConvertTests(AbstractRSZodbConvertTests):
         return self.destfile
 
     def _create_src_storage(self):
-        return self.make_storage(zap=False)
+        return self._closing(self.make_storage(zap=False))
 
 class DoubleCommitter(Persistent):
     """A crazy persistent class that changes self in __getstate__"""

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -899,6 +899,12 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
     def _wrap_storage(self, storage):
         return ZlibStorage(storage)
 
+    def _create_dest_storage(self):
+        return self._wrap_storage(super(AbstractRSZodbConvertTests, self)._create_dest_storage())
+
+    def _create_src_storage(self):
+        return self._wrap_storage(super(AbstractRSZodbConvertTests, self)._create_src_storage())
+
     def test_new_instance_still_zlib(self):
         storage = self.make_storage()
         new_storage = storage.new_instance()
@@ -931,7 +937,6 @@ class AbstractRSSrcZodbConvertTests(AbstractRSZodbConvertTests):
     @property
     def filestorage_file(self):
         return self.destfile
-
 
     def _create_src_storage(self):
         return self.make_storage(zap=False)

--- a/relstorage/tests/test_zodbconvert.py
+++ b/relstorage/tests/test_zodbconvert.py
@@ -19,6 +19,7 @@ import tempfile
 import transaction
 import unittest
 import functools
+import gc
 
 from ZODB.FileStorage import FileStorage
 from ZODB.DB import DB
@@ -40,6 +41,28 @@ class AbstractZODBConvertBase(unittest.TestCase):
     # Set to True in a subclass if the destination can be zapped
     zap_supported_by_dest = False
 
+    def setUp(self):
+        self._to_close = []
+
+    def tearDown(self):
+        for i in self._to_close:
+            i.close()
+        self._to_close = []
+        # XXX: On PyPy with psycopg2cffi, running these two tests will result
+        # in a hang: HPPostgreSQLDestZODBConvertTests.test_clear_empty_dest HPPostgreSQLDestZODBConvertTests.test_clear_full_dest
+        # test_clear_full_dest will hang in the zodbconvert call to zap_all(), in the C code of the
+        # PG driver. Presumably some connection with some lock got left open and was preventing
+        # the TRUNCATE statements from taking out a lock. The same tests do not hang with psycopg2cffi on
+        # C Python. Manually running the gc (twice!) here fixes the issue. Note that this only started when
+        # we wrapped the destination storage in ZlibStorage (which copies methods into its own dict) so there's
+        # something weird going on with the GC. Seen in PyPy 2.5.0 and 5.3.
+        gc.collect()
+        gc.collect()
+
+    def _closing(self, thing):
+        self._to_close.append(thing)
+        return thing
+
     def _create_src_storage(self):
         raise NotImplementedError()
 
@@ -47,10 +70,10 @@ class AbstractZODBConvertBase(unittest.TestCase):
         raise NotImplementedError()
 
     def _create_src_db(self):
-        return DB(self._create_src_storage())
+        return self._closing(DB(self._closing(self._create_src_storage())))
 
     def _create_dest_db(self):
-        return DB(self._create_dest_storage())
+        return self._closing(DB(self._closing(self._create_dest_storage())))
 
     @contextmanager
     def __conn(self, name):

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,12 @@ def read_file(*path):
         result = f.read()
     return result
 
-tests_require = ['mock', 'zope.testing', 'ZODB [test]']
+tests_require = [
+    'mock',
+    'zope.testing',
+    'ZODB [test]',
+    'zc.zlibstorage'
+]
 
 setup(
     name="RelStorage",


### PR DESCRIPTION
Fixes #70 and fixes #71.

Add tests for this.