### PR TITLE
Implement IExternalGC for history-free schemas. Fixes #47.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,9 @@ Other Enhancements
 - ``zodbconvert`` and ``zodbpack`` use :mod:`argparse` instead of
   :mod:`optparse` for command line handling.
 
+- Support :class:`ZODB.interfaces.IExternalGC` for history-free
+  databases, allowing multi-database garbage collection with
+  ``zc.zodbdgc``. See :issue:`47`.
 
 1.6.0 (2016-06-09)
 ==================

--- a/relstorage/tests/hptestbase.py
+++ b/relstorage/tests/hptestbase.py
@@ -288,6 +288,10 @@ class HistoryPreservingRelStorageTests(
 
         db.close()
 
+    def checkImplementsExternalGC(self):
+        import ZODB.interfaces
+        self.assertFalse(ZODB.interfaces.IExternalGC.providedBy(self._storage))
+        self.assertRaises(AttributeError, self._storage.deleteObject)
 
 class HistoryPreservingToFileStorage(
         RelStorageTestBase,


### PR DESCRIPTION
Unless some one speaks up about needing this for history-preserving databases, I'll go ahead with this.