### PR TITLE
Elide storage locks by default.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,15 @@
   that most sites won't notice any performance difference. A larger
   discussion can be found in :issue:`87`.
 
+- Instances of :class:`.RelStorage` no longer use threading locks and
+  hence are not thread safe. A ZODB Connection is documented as not
+  being thread-safe and must be used only by a single thread at a
+  time. Because RelStorage natively implements MVCC ,each Connection
+  has a unique storage object. It follows that the storage object is
+  used only by a single thread. Using locks just adds unneeded
+  overhead to the common case. If this is a breaking change for you,
+  please open an issue. See :pr:`91`.
+
 2.0.0b1 (2016-06-28)
 ====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@
 - Instances of :class:`.RelStorage` no longer use threading locks and
   hence are not thread safe. A ZODB Connection is documented as not
   being thread-safe and must be used only by a single thread at a
-  time. Because RelStorage natively implements MVCC ,each Connection
+  time. Because RelStorage natively implements MVCC, each Connection
   has a unique storage object. It follows that the storage object is
   used only by a single thread. Using locks just adds unneeded
   overhead to the common case. If this is a breaking change for you,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,13 +19,14 @@
   discussion can be found in :issue:`87`.
 
 - Instances of :class:`.RelStorage` no longer use threading locks and
-  hence are not thread safe. A ZODB Connection is documented as not
-  being thread-safe and must be used only by a single thread at a
-  time. Because RelStorage natively implements MVCC, each Connection
-  has a unique storage object. It follows that the storage object is
-  used only by a single thread. Using locks just adds unneeded
-  overhead to the common case. If this is a breaking change for you,
-  please open an issue. See :pr:`91`.
+  hence are not thread safe. A ZODB :class:`Connection
+  <ZODB.interfaces.IConnection>` is documented as not being
+  thread-safe and must be used only by a single thread at a time.
+  Because RelStorage natively implements MVCC, each Connection has a
+  unique storage object. It follows that the storage object is used
+  only by a single thread. Using locks just adds unneeded overhead to
+  the common case. If this is a breaking change for you, please open
+  an issue. See :pr:`91`.
 
 2.0.0b1 (2016-06-28)
 ====================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -373,7 +373,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None,
-                       'http://www.zodb.org/en/latest/': None}
+                       'http://zodb.readthedocs.io/en/latest/': None}
 
 extlinks = {'issue': ('https://github.com/zodb/relstorage/issues/%s',
                       'issue #'),

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -86,6 +86,11 @@ class RelStorageTestBase(StorageCreatingMixin,
         'check2StorageThreads',
         'check7StorageThreads',
         'check4ExtStorageThread',
+        # XXX These two MTStorage tests don't actually need locks. But
+        # on TravisCI, both Python 2.7 and 3.4 segfaulted (sometimes!) in one of
+        # these tests when run under Coverage, so we include them anyway.
+        'check2ZODBThreads',
+        'check7ZODBThreads',
         # PackableStorage
         'checkPackWhileWriting',
         'checkPackNowWhileWriting',

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -40,6 +40,9 @@ from relstorage.storage import RelStorage
 
 class StorageCreatingMixin(object):
 
+    keep_history = None # Override
+    use_locked_storage = None # override
+
     def make_adapter(self, options):
         # abstract method
         raise NotImplementedError()
@@ -57,7 +60,7 @@ class StorageCreatingMixin(object):
 
         options = Options(keep_history=self.keep_history, **kw)
         adapter = self.make_adapter(options)
-        storage = RelStorage(adapter, options=options)
+        storage = RelStorage(adapter, options=options, _use_locks=self.use_locked_storage)
         storage._batcher_row_limit = 1
         if zap:
             # XXX: Some ZODB tests, possibly check4ExtStorageThread and
@@ -73,17 +76,40 @@ class RelStorageTestBase(StorageCreatingMixin,
 
     keep_history = None  # Override
     _storage_created = None
+    _locked_tests = (
+        # These tests know nothing of IMVCCStorage and so don't
+        # create a new_instance for each thread, as of ZODB 4.3.1.
+        # BasicStorage
+        'check_checkCurrentSerialInTransaction',
+        'check_tid_ordering_w_commit',
+        # MTStorage
+        'check2StorageThreads',
+        'check7StorageThreads',
+        'check4ExtStorageThread',
+        # PackableStorage
+        'checkPackWhileWriting',
+        'checkPackNowWhileWriting',
+        'checkPackLotsWhileWriting',
+    )
 
     def setUp(self):
-        pass
+        if self._testMethodName in self._locked_tests:
+            self.use_locked_storage = True
+        # Note that we're deliberately NOT calling super's setup.
+        # It does stuff on disk, etc, that's not necessary for us
+        # and just slows us down by ~10%.
+        #super(RelStorageTestBase, self).setUp()
 
     def tearDown(self):
+        self.use_locked_storage = False
         transaction.abort()
         storage = self._storage
         if storage is not None:
             self._storage = None
             storage.close()
             storage.cleanup()
+        # See comments in setUp.
+        #super(RelStorageTestBase, self).tearDown()
 
     def get_storage(self):
         # Create a storage with default options

--- a/relstorage/tests/testpostgresql.py
+++ b/relstorage/tests/testpostgresql.py
@@ -183,7 +183,7 @@ def test_suite():
         # XXX: This is dirty.
         from relstorage.adapters.mover import ObjectMover
         assert hasattr(ObjectMover, 'postgresql_blob_chunk_maxsize')
-        ObjectMover.postgresql_blob_chunk_maxsize = 1024 * 1024 * 100
+        ObjectMover.postgresql_blob_chunk_maxsize = 1024 * 1024 * 10
         large_blob_size = ObjectMover.postgresql_blob_chunk_maxsize * 2
     else:
         large_blob_size = 1<<31


### PR DESCRIPTION
I'll quote the comment:

> A ZODB Connection is documented as not
  being thread-safe and must be used only by a single thread at a
  time. Because RelStorage natively implements MVCC ,each Connection
  has a unique storage object. It follows that the storage object is
  used only by a single thread. Using locks just adds unneeded
  overhead to the common case. If this is a breaking change for you,
  please open an issue.

I'll add that there are 8 ZODB base tests that assume the storage is thread safe. To keep them working, we have the ability to choose to use real locks when we create the storage (so none of the actual locking was removed, we just use a dummy lock by default). So there's an escape hatch in the wild if this turns out to cause major problems and it's easily reversed.