### PR TITLE
Cache simplifications

### DIFF
--- a/relstorage/adapters/schema.py
+++ b/relstorage/adapters/schema.py
@@ -960,7 +960,15 @@ class PostgreSQLSchemaInstaller(AbstractSchemaInstaller):
     def get_database_name(self, cursor):
         cursor.execute("SELECT current_database()")
         for (name,) in cursor:
-            return name if isinstance(name, str) else name.decode('ascii')
+            if isinstance(name, str):
+                return name
+            if hasattr(name, 'encode'):
+                # OK, name must be a unicode object, and we must be on Py2.
+                # pg8000 does this.
+                assert isinstance(name, unicode) # pylint:disable=undefined-variable
+                return name.encode('ascii')
+            assert isinstance(name, bytes)
+            return name.decode('ascii')
 
     def prepare(self):
         """Create the database schema if it does not already exist."""

--- a/relstorage/cache.py
+++ b/relstorage/cache.py
@@ -725,32 +725,6 @@ class LocalClient(object):
     def add(self, key, value):
         self.set_multi({key: value}, allow_replace=False)
 
-    def incr(self, key):
-        if not self._bucket_limit:
-            # don't bother
-            return None
-        decompress = self._decompress
-        with self._lock:
-            cvalue = self._bucket0.get(key)
-            if cvalue is None:
-                cvalue = self._bucket1.get(key)
-                if cvalue is None:
-                    return None
-                # this key is active, so move it to bucket0
-                del self._bucket1[key]
-
-            if decompress is not None:
-                if isinstance(cvalue, bytes):
-                    value = decompress(cvalue)
-                else:
-                    value = cvalue
-            else:
-                value = cvalue
-
-            res = int(value) + 1
-            self._set_one(key, res)
-            return res
-
     def disconnect_all(self):
         # Compatibility with memcache.
         pass

--- a/relstorage/cache.py
+++ b/relstorage/cache.py
@@ -11,23 +11,27 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from relstorage.autotemp import AutoTemporaryFile
 from ZODB.utils import p64
 from ZODB.utils import u64
 from ZODB.POSException import ReadConflictError
 from persistent.TimeStamp import TimeStamp
 
+import importlib
 import logging
-import random
 import threading
+
 from relstorage._compat import string_types
 from relstorage._compat import iteritems
 from relstorage._compat import unicode
 
 log = logging.getLogger(__name__)
 
+class _UsedAfterRelease(object):
+    pass
+_UsedAfterRelease = _UsedAfterRelease()
 
 class StorageCache(object):
     """RelStorage integration with memcached or similar.
@@ -69,7 +73,7 @@ class StorageCache(object):
 
         if options.cache_servers:
             module_name = options.cache_module_name
-            module = __import__(module_name, {}, {}, ['Client'])
+            module = importlib.import_module(module_name)
             servers = options.cache_servers
             if isinstance(servers, string_types):
                 servers = servers.split()
@@ -97,12 +101,12 @@ class StorageCache(object):
 
     def new_instance(self):
         """Return a copy of this instance sharing the same local client"""
+        local_client = None
         if self.options.share_local_cache:
             local_client = self.clients_local_first[0]
-            return StorageCache(self.adapter, self.options, self.prefix,
-                                local_client)
-        else:
-            return StorageCache(self.adapter, self.options, self.prefix)
+
+        return type(self)(self.adapter, self.options, self.prefix,
+                          local_client)
 
     def release(self):
         """
@@ -113,10 +117,12 @@ class StorageCache(object):
         for client in self.clients_local_first:
             client.disconnect_all()
 
-        if not self.options.share_local_cache:
-            # If we have our own local cache not shared with anyone,
-            # go ahead and clear it to release any memory it's holding.
-            self.clients_local_first[0].flush_all()
+        # Release our clients. If we had a non-shared local cache,
+        # this will also allow it to release any memory its holding.
+        # Set them to non-iterables to make it obvious if we are used
+        # after release.
+        self.clients_local_first = _UsedAfterRelease
+        self.clients_global_first = _UsedAfterRelease
 
     def clear(self):
         """Remove all data from the cache.  Called by speed tests."""
@@ -569,10 +575,12 @@ class SizeOverflow(Exception):
     """Too much memory would be consumed by a new key"""
 
 class LocalClientBucket(dict):
-    """A map that keeps a record of its approx. size.
-
-    keys must be strings and most values are strings.
     """
+    A map that keeps a record of its approx. size.
+
+    keys must be `str`` and values must be bytestrings.
+    """
+    __slots__ = ('size', 'limit')
 
     def __init__(self, limit):
         dict.__init__(self)
@@ -580,23 +588,25 @@ class LocalClientBucket(dict):
         self.limit = limit
 
     def __setitem__(self, key, value):
-        """Set an item.
+        """
+        Set an item.
 
         Throws SizeOverflow if the new item would cause this map to
         surpass its memory limit.
         """
-        assert not isinstance(value, unicode)
-        if isinstance(value, bytes):
-            # XXX PY3: Why do we accept non-bytes?
-            sizedelta = len(value)
-        else:
-            sizedelta = 0
+        # These types are gated by LocalClient, we don't need to double
+        # check.
+        #assert isinstance(key, str)
+        #assert isinstance(value, bytes)
+
+        sizedelta = len(value)
+
         if key in self:
             oldvalue = self[key]
-            if isinstance(oldvalue, bytes):
-                sizedelta -= len(oldvalue)
+            sizedelta -= len(oldvalue)
         else:
             sizedelta += len(key)
+
         if self.size + sizedelta > self.limit:
             raise SizeOverflow()
         dict.__setitem__(self, key, value)
@@ -607,8 +617,7 @@ class LocalClientBucket(dict):
         oldvalue = self[key]
         dict.__delitem__(self, key)
         sizedelta = len(key)
-        if isinstance(oldvalue, bytes):
-            sizedelta += len(oldvalue)
+        sizedelta += len(oldvalue)
         self.size -= sizedelta
 
 
@@ -624,11 +633,10 @@ class LocalClient(object):
 
         compression_module = options.cache_local_compression
         if compression_module in ('', None, 'none'):
-            self._compress = None
-            self._decompress = None
+            self._compress = lambda x: x
+            self._decompress = lambda x: x
         else:
-            module = __import__(
-                compression_module, {}, {}, ['compress', 'decompress'])
+            module = importlib.import_module(compression_module)
             self._compress = module.compress
             self._decompress = module.decompress
 
@@ -654,15 +662,7 @@ class LocalClient(object):
                     del self._bucket1[key]
                     self._set_one(key, cvalue)
 
-                if decompress is not None:
-                    # XXX: PY3: When would we have non-bytes? Why would we?
-                    if isinstance(cvalue, bytes):
-                        value = decompress(cvalue)
-                    else:
-                        value = cvalue
-                else:
-                    value = cvalue
-
+                value = decompress(cvalue)
                 res[key] = value
         return res
 
@@ -695,20 +695,14 @@ class LocalClient(object):
         compress = self._compress
         with self._lock:
             for key, value in iteritems(d):
-                # XXX PY3 Shouldn't we assert isinstance(bytes)?
-                # Why do we allow non-bytes values? Do we use them outside
-                # of tests?
-                # On Py2, this used to check basestring
-                if isinstance(value, bytes):
-                    if len(value) >= self._value_limit:
-                        # This value is too big, so don't cache it.
-                        continue
-                    if compress is not None:
-                        cvalue = compress(value)
-                    else:
-                        cvalue = value
-                else:
-                    cvalue = value
+                # This used to allow non-byte values, but that's confusing
+                # on Py3 and wasn't used outside of tests, so we enforce it.
+                assert isinstance(key, str)
+                assert isinstance(value, bytes)
+                if len(value) >= self._value_limit:
+                    # This value is too big, so don't cache it.
+                    continue
+                cvalue = compress(value)
 
                 if key in self._bucket0:
                     if not allow_replace:

--- a/relstorage/pylibmc_wrapper.py
+++ b/relstorage/pylibmc_wrapper.py
@@ -31,7 +31,7 @@ def _catching(func):
     def wrapper(*args):
         try:
             return func(*args)
-        except MemcachedError as e:
+        except MemcachedError as e: # pragma: no cover
             log.debug("%s failed: %s", name, e)
             return None
     return wrapper
@@ -42,13 +42,13 @@ class Client(object):
         "ketama": True,
     }
 
+    min_compress_len = 0
+
     def __init__(self, servers):
         self._client = pylibmc.Client(servers, binary=True)
         self._client.set_behaviors(self.behaviors)
         if pylibmc.support_compression:
             self.min_compress_len = 1000
-        else: # pragma: no cover
-            self.min_compress_len = 0
 
     @_catching
     def get(self, key):
@@ -72,10 +72,6 @@ class Client(object):
     def add(self, key, value):
         return self._client.add(
             key, value, min_compress_len=self.min_compress_len)
-
-    @_catching
-    def incr(self, key):
-        return self._client.incr(key)
 
     @_catching
     def flush_all(self):

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -252,7 +252,7 @@ class RelStorage(UndoLogCompatible,
         if hasattr(self._adapter.packundo, 'deleteObject'):
             interface.alsoProvides(self, ZODB.interfaces.IExternalGC)
         else:
-            def deleteObject(*args):
+            def deleteObject(*_args):
                 raise AttributeError("deleteObject")
             self.deleteObject = deleteObject
 
@@ -267,7 +267,7 @@ class RelStorage(UndoLogCompatible,
             blobhelper = self.blobhelper.new_instance(adapter=adapter)
         else:
             blobhelper = None
-        other = RelStorage(adapter=adapter, name=self.__name__,
+        other = type(self)(adapter=adapter, name=self.__name__,
                            create=False, options=self._options, cache=cache,
                            blobhelper=blobhelper)
         self._instances.append(weakref.ref(other, self._instances.remove))
@@ -414,7 +414,8 @@ class RelStorage(UndoLogCompatible,
         Used by the test suite and the ZODBConvert script.
         """
         self._adapter.schema.zap_all(**kwargs)
-        self.release()
+        self._drop_load_connection()
+        self._drop_store_connection()
         self._cache.clear()
 
     def release(self):
@@ -425,7 +426,6 @@ class RelStorage(UndoLogCompatible,
         connections.
         """
         with self._lock:
-            #print("Dropping", self._load_conn, self._store_conn)
             self._drop_load_connection()
             self._drop_store_connection()
         self._cache.release()

--- a/relstorage/tests/alltests.py
+++ b/relstorage/tests/alltests.py
@@ -13,8 +13,12 @@
 ##############################################################################
 """Combines all the tests"""
 from __future__ import absolute_import, print_function
-import unittest
+
 import logging
+import sys
+import unittest
+
+_include_db = True
 
 def make_suite():
     suite = unittest.TestSuite()
@@ -29,10 +33,15 @@ def make_suite():
         'relstorage.tests.test_zodbconvert',
         'relstorage.tests.test_zodbpack',
         'relstorage.tests.test_zodburi',
+    ]
+    db_test_modules = [
         'relstorage.tests.testpostgresql',
         'relstorage.tests.testmysql',
         'relstorage.tests.testoracle',
     ]
+
+    if _include_db:
+        test_modules += db_test_modules
 
     for mod_name in test_modules:
         mod = __import__(mod_name, globals(),
@@ -42,6 +51,9 @@ def make_suite():
     return suite
 
 if __name__ == '__main__':
+    if '--no-db' in sys.argv:
+        _include_db = False
+        sys.argv.remove('--no-db')
     logging.basicConfig()
     # We get constant errors about failing to lock a blob file,
     # which really bloats the CI logs, so turn those off.

--- a/relstorage/tests/alltests.py
+++ b/relstorage/tests/alltests.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, print_function
 import logging
 import sys
 import unittest
+import importlib
 
 _include_db = True
 
@@ -44,8 +45,7 @@ def make_suite():
         test_modules += db_test_modules
 
     for mod_name in test_modules:
-        mod = __import__(mod_name, globals(),
-                         fromlist=['chicken'] if '.' in mod_name else [])
+        mod = importlib.import_module(mod_name)
         suite.addTest(mod.test_suite())
 
     return suite

--- a/relstorage/tests/test_cache.py
+++ b/relstorage/tests/test_cache.py
@@ -550,43 +550,6 @@ class LocalClientTests(unittest.TestCase):
         c.add('k1', b'ghi')
         self.assertEqual(c.get_multi(['k0', 'k1']), {'k0': b'abc', 'k1': b'ghi'})
 
-    def test_incr_normal(self):
-        c = self._makeOne()
-        c.set('k0', 41)
-        self.assertEqual(c.incr('k0'), 42)
-        self.assertEqual(c.incr('k1'), None)
-
-    def test_incr_string_with_compression(self):
-        c = self._makeOne(cache_local_compression='zlib')
-        c.set('k0', b'41')
-        self.assertEqual(c.incr('k0'), 42)
-        self.assertEqual(c.incr('k1'), None)
-
-    def test_incr_string_without_compression(self):
-        c = self._makeOne(cache_local_compression='none')
-        c.set('k0', b'41')
-        self.assertEqual(c.incr('k0'), 42)
-        self.assertEqual(c.incr('k1'), None)
-
-    def test_incr_hit_size_limit(self):
-        c = self._makeOne()
-        c._bucket_limit = 4
-        c.flush_all()
-        c.set('k0', 14)
-        c.set('key1', 27)
-        self.assertEqual(c._bucket0.size, 4)
-        self.assertEqual(c._bucket1.size, 2)
-        self.assertEqual(c.incr('k0'), 15)  # this moves k0 to bucket0
-        self.assertEqual(c._bucket0.size, 2)
-        self.assertEqual(c._bucket1.size, 4)
-
-    def test_incr_with_zero_space(self):
-        options = MockOptions()
-        options.cache_local_mb = 0
-        c = self.getClass()(options)
-        self.assertEqual(c.incr('abc'), None)
-
-
 class MockOptions(object):
     cache_module_name = ''
     cache_servers = ''

--- a/relstorage/tests/test_cache.py
+++ b/relstorage/tests/test_cache.py
@@ -387,18 +387,6 @@ class LocalClientBucketTests(unittest.TestCase):
         del b['abc']
         self.assertEqual(b.size, 0)
 
-    def test_set_integer_value(self):
-        b = self.getClass()(100)
-        self.assertEqual(b.size, 0)
-        b['abc'] = 5
-        self.assertEqual(b.size, 3)
-        b['abc'] = -7
-        self.assertEqual(b.size, 3)
-        b['abc'] = 0
-        self.assertEqual(b.size, 3)
-        del b['abc']
-        self.assertEqual(b.size, 0)
-
     def test_set_limit(self):
         from relstorage.cache import SizeOverflow
         b = self.getClass()(5)
@@ -438,11 +426,6 @@ class LocalClientTests(unittest.TestCase):
         c.set('abc', b'def')
         self.assertEqual(c.get('abc'), b'def')
         self.assertEqual(c.get('xyz'), None)
-
-    def test_set_and_get_tuple_compressed(self):
-        c = self._makeOne(cache_local_compression='zlib')
-        c.set('abc', (b'one', b'two'))
-        self.assertEqual(c.get('abc'), (b'one', b'two'))
 
     def test_set_and_get_object_too_large(self):
         c = self._makeOne(cache_local_compression='none')


### PR DESCRIPTION
- Drop the unused incr() operation and its tests
- Simplify the type checking since only tests used non-byte values.
- Simplify the import logic to use importlib.