### PR TITLE
Reduce cache locking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,7 +56,11 @@
   be important when there is a large performance difference between
   drivers, and more than one might be installed. (Also, RelStorage no
   longer has the side-effect of registering ``PyMySQL`` as ``MySQLdb`` and
-  ``psycopg2cffi`` as ``psycopg2``.) See :issue:`86`.`
+  ``psycopg2cffi`` as ``psycopg2``.) See :issue:`86`.
+
+- The in-memory cache allows for much higher levels of concurrent
+  operation via finer-grained locks. For example, compression and
+  decompression are no longer done while holding a lock.
 
 2.0.0b1 (2016-06-28)
 ====================

--- a/relstorage/cache.py
+++ b/relstorage/cache.py
@@ -695,9 +695,6 @@ class LocalClient(object):
             # in bucket1; we never try to add to bucket 1
             # so we can't get an overflow there, and the dict
             # is unlikely to shrink so we don't save any memory.
-            # There are some tests that check this though; they can
-            # go away.
-            del bucket1[k]
             buckets = self._set_one(k, res[k], buckets)
             bucket0, bucket1 = buckets
 

--- a/relstorage/tests/test_cache.py
+++ b/relstorage/tests/test_cache.py
@@ -466,7 +466,7 @@ class LocalClientTests(unittest.TestCase):
         v = c.get('k2')
         self.assertEqual(v, b'01234567')
         self.assertEqual(c._bucket0.size, 20)
-        self.assertEqual(c._bucket1.size, 40)
+        self.assertEqual(c._bucket1.size, 50) # don't shrink
         for i in range(5):
             # add 10 bytes
             c.set('x%d' % i, b'01234567')
@@ -478,7 +478,7 @@ class LocalClientTests(unittest.TestCase):
         self.assertEqual(c.get('x3'), b'01234567')
         self.assertEqual(c.get('x4'), b'01234567')
         self.assertEqual(c._bucket0.size, 50)
-        self.assertEqual(c._bucket1.size, 20)
+        self.assertEqual(c._bucket1.size, 50) # don't shrink
         self.assertEqual(c.get('k0'), None)
         self.assertEqual(c.get('k1'), None)
         self.assertEqual(c.get('k2'), b'01234567')
@@ -513,7 +513,7 @@ class LocalClientTests(unittest.TestCase):
         v = c.get('k0')
         self.assertEqual(v, b'01234567' * 10)
         self.assertEqual(c._bucket0.size, 21 * 2)
-        self.assertEqual(c._bucket1.size, 21)
+        self.assertEqual(c._bucket1.size, 21 * 2) # don't shrink bucket1
 
         v = c.get('k1')
         self.assertEqual(v, b'76543210' * 10)
@@ -523,7 +523,7 @@ class LocalClientTests(unittest.TestCase):
         v = c.get('k2')
         self.assertEqual(v, b'abcdefgh' * 10)
         self.assertEqual(c._bucket0.size, 21 * 2)
-        self.assertEqual(c._bucket1.size, 21)
+        self.assertEqual(c._bucket1.size, 21 * 2)
 
     def test_add(self):
         c = self._makeOne()


### PR DESCRIPTION
This uses CAS-like steps and a careful locking strategy to reduce the total amount of time that the local cache is locked during reads and writes. Semantics shouldn't be any different than interleaved reads/writes to memcache. Technically there are some possible different semantics in a single instance, but by being careful about where bucket shifts occur they should be no worse.

Reading and writing both benchmark faster in single-threaded scenarios. (2.69 vs 3.19 for writing and 0.36 vs 0.44 for reading.)

This is an intermediate step towards trying for finer LRU semantics.