### PR TITLE
Finer LRU

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,9 +58,13 @@
   longer has the side-effect of registering ``PyMySQL`` as ``MySQLdb`` and
   ``psycopg2cffi`` as ``psycopg2``.) See :issue:`86`.
 
-- The in-memory cache allows for much higher levels of concurrent
+- The in-memory cache allows for higher levels of concurrent
   operation via finer-grained locks. For example, compression and
   decompression are no longer done while holding a lock.
+
+- The in-memory cache now uses a better approximation of a LRU
+  algorithm with less overhead, so more data should fit in the same
+  size cache. (For best performance, CFFI should be installed.)
 
 2.0.0b1 (2016-06-28)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,7 +56,11 @@
   be important when there is a large performance difference between
   drivers, and more than one might be installed. (Also, RelStorage no
   longer has the side-effect of registering ``PyMySQL`` as ``MySQLdb`` and
-  ``psycopg2cffi`` as ``psycopg2``.) See :issue:`86`.`
+  ``psycopg2cffi`` as ``psycopg2``.) See :issue:`86`.
+
+- The in-memory cache allows for much higher levels of concurrent
+  operation via finer-grained locks. For example, compression and
+  decompression are no longer done while holding a lock.
 
 2.0.0b1 (2016-06-28)
 ====================

--- a/relstorage/cache.py
+++ b/relstorage/cache.py
@@ -695,9 +695,6 @@ class LocalClient(object):
             # in bucket1; we never try to add to bucket 1
             # so we can't get an overflow there, and the dict
             # is unlikely to shrink so we don't save any memory.
-            # There are some tests that check this though; they can
-            # go away.
-            del bucket1[k]
             buckets = self._set_one(k, res[k], buckets)
             bucket0, bucket1 = buckets
 

--- a/relstorage/tests/test_cache.py
+++ b/relstorage/tests/test_cache.py
@@ -481,15 +481,16 @@ class LocalClientTests(unittest.TestCase):
         self.assertEqual(c.get('x4'), b'01234567')
         self.assertEqual(c._bucket0.size, 50)
         self.assertEqual(c._bucket1.size, 20)
-        self.assertEqual(c.get('k0'), b'01234567')
-        self.assertEqual(c.get('k1'), b'01234567')
+
+        self.assertEqual(c.get('k0'), None)
+        self.assertEqual(c.get('k1'), None)
         self.assertEqual(c.get('k2'), b'01234567')
-        self.assertEqual(c.get('k3'), b'01234567')
-        self.assertEqual(c.get('k4'), b'01234567')
+        self.assertEqual(c.get('k3'), None)
+        self.assertEqual(c.get('k4'), None)
         self.assertEqual(c.get('k5'), b'01234567')
 
         self.assertEqual(c._bucket0.size, 70)
-        self.assertEqual(c._bucket1.size, 40)
+        self.assertEqual(c._bucket1.size, 0)
 
         c.set('z0', b'01234567')
         self.assertEqual(c._bucket0.size, 10)

--- a/relstorage/tests/test_cache.py
+++ b/relstorage/tests/test_cache.py
@@ -28,7 +28,7 @@ class StorageCacheTests(unittest.TestCase):
 
     def _makeOne(self):
         return self.getClass()(MockAdapter(), MockOptionsWithFakeCache(),
-            'myprefix')
+                               'myprefix')
 
     def test_ctor(self):
         from relstorage.tests.fakecache import Client
@@ -388,15 +388,16 @@ class LocalClientBucketTests(unittest.TestCase):
         self.assertEqual(b.size, 0)
 
     def test_set_limit(self):
-        from relstorage.cache import SizeOverflow
         b = self.getClass()(5)
         self.assertEqual(b.size, 0)
         b['abc'] = b'xy'
         self.assertEqual(b.size, 5)
         b['abc'] = b'z'
         self.assertEqual(b.size, 4)
-        self.assertRaises(SizeOverflow, b.__setitem__, 'abc', b'xyz')
-        self.assertEqual(b['abc'], b'z')
+        b['abcd'] = 'xyz'
+        self.assertEqual(b.size, 7)
+        self.assertEqual(b.get('abc'), None)
+        self.assertEqual(b.get("abcd"), 'xyz')
 
 
 class LocalClientTests(unittest.TestCase):
@@ -412,7 +413,7 @@ class LocalClientTests(unittest.TestCase):
 
     def test_ctor(self):
         c = self._makeOne()
-        self.assertEqual(c._bucket_limit, 500000)
+        self.assertEqual(c._bucket_limit, 1000000)
         self.assertEqual(c._value_limit, 16384)
 
     def test_set_and_get_string_compressed(self):
@@ -459,42 +460,41 @@ class LocalClientTests(unittest.TestCase):
             # add 10 bytes
             c.set('k%d' % i, b'01234567')
         self.assertEqual(c._bucket0.size, 50)
-        self.assertEqual(c._bucket1.size, 0)
+
         c.set('k5', b'01234567')
-        self.assertEqual(c._bucket0.size, 10)
-        self.assertEqual(c._bucket1.size, 50)
+        self.assertEqual(c._bucket0.size, 50)
+
         v = c.get('k2')
         self.assertEqual(v, b'01234567')
-        self.assertEqual(c._bucket0.size, 20)
-        self.assertEqual(c._bucket1.size, 40)
-        for i in range(5):
+        self.assertEqual(c._bucket0.size, 50)
+
+        for i in range(4):
             # add 10 bytes
             c.set('x%d' % i, b'01234567')
-        self.assertEqual(c._bucket0.size, 20)
-        self.assertEqual(c._bucket1.size, 50)
-        # Bubble these up through the cache tree, which
-        # doesn't shrink the nodes.
+        self.assertEqual(c._bucket0.size, 50)
+
         self.assertEqual(c.get('x0'), b'01234567')
         self.assertEqual(c.get('x1'), b'01234567')
         self.assertEqual(c.get('x2'), b'01234567')
         self.assertEqual(c.get('x3'), b'01234567')
-        self.assertEqual(c.get('x4'), b'01234567')
+        self.assertEqual(c.get('k2'), b'01234567')
         self.assertEqual(c._bucket0.size, 50)
-        self.assertEqual(c._bucket1.size, 20)
+
 
         self.assertEqual(c.get('k0'), None)
         self.assertEqual(c.get('k1'), None)
         self.assertEqual(c.get('k2'), b'01234567')
         self.assertEqual(c.get('k3'), None)
         self.assertEqual(c.get('k4'), None)
-        self.assertEqual(c.get('k5'), b'01234567')
+        self.assertEqual(c.get('k5'), None)
 
-        self.assertEqual(c._bucket0.size, 70)
-        self.assertEqual(c._bucket1.size, 0)
+
+        self.assertEqual(c._bucket0.size, 50)
+
 
         c.set('z0', b'01234567')
-        self.assertEqual(c._bucket0.size, 10)
-        self.assertEqual(c._bucket1.size, 70)
+        self.assertEqual(c._bucket0.size, 50)
+
 
     def test_bucket_sizes_with_compression(self):
         c = self._makeOne(cache_local_compression='zlib')
@@ -503,34 +503,23 @@ class LocalClientTests(unittest.TestCase):
 
         c.set('k0', b'01234567' * 10)
         self.assertEqual(c._bucket0.size, 21)
-        self.assertEqual(c._bucket1.size, 0)
 
         c.set('k1', b'76543210' * 10)
         self.assertEqual(c._bucket0.size, 21 * 2)
-        self.assertEqual(c._bucket1.size, 0)
 
-        # Cause a bucket shift
         c.set('k2', b'abcdefgh' * 10)
-        self.assertEqual(c._bucket0.size, 21)
-        self.assertEqual(c._bucket1.size, 21 * 2)
-
-        # Bubble this one up
-        v = c.get('k0')
-        self.assertEqual(v, b'01234567' * 10)
         self.assertEqual(c._bucket0.size, 21 * 2)
-        self.assertEqual(c._bucket1.size, 21)
 
-        # Bubble up again. Note that we don't shrink the top node on a bubble
-        # but we do shrink the end nodes
+        v = c.get('k0')
+        self.assertEqual(v, None) # This one got evicted :(
+
         v = c.get('k1')
         self.assertEqual(v, b'76543210' * 10)
-        self.assertEqual(c._bucket0.size, 63)
-        self.assertEqual(c._bucket1.size, 0)
+        self.assertEqual(c._bucket0.size, 42)
 
         v = c.get('k2')
         self.assertEqual(v, b'abcdefgh' * 10)
-        self.assertEqual(c._bucket0.size, 63)
-        self.assertEqual(c._bucket1.size, 0)
+        self.assertEqual(c._bucket0.size, 42)
 
     def test_add(self):
         c = self._makeOne()
@@ -592,8 +581,9 @@ def local_benchmark():
         key_groups.append(keys)
 
     def populate():
-        for k in range(120):
-            client.set(str(k), random_data)
+        data = {str(k): random_data for k in range(120)}
+        for k, v in data.items():
+            client.set(k, v)
 
     def read():
         for keys in key_groups:
@@ -601,12 +591,23 @@ def local_benchmark():
 
     import timeit
     import statistics
+    #import cProfile, pstats
     number = 10000
     pop_timer = timeit.Timer(populate)
+    #pr = cProfile.Profile()
+    #pr.enable()
     pop_times = pop_timer.repeat(number=number)
+    #pr.disable()
+    #ps = pstats.Stats(pr).sort_stats('cumulative')
+    #ps.print_stats()
 
     read_timer = timeit.Timer(read)
+    #pr = cProfile.Profile()
+    #pr.enable()
     read_times = read_timer.repeat(number=number)
+    #pr.disable()
+    #ps = pstats.Stats(pr).sort_stats('cumulative')
+    #ps.print_stats()
 
 
     print("pop average", statistics.mean(pop_times), "stddev", statistics.stdev(pop_times))

--- a/relstorage/tests/test_cache.py
+++ b/relstorage/tests/test_cache.py
@@ -466,7 +466,7 @@ class LocalClientTests(unittest.TestCase):
         v = c.get('k2')
         self.assertEqual(v, b'01234567')
         self.assertEqual(c._bucket0.size, 20)
-        self.assertEqual(c._bucket1.size, 40)
+        self.assertEqual(c._bucket1.size, 50) # don't shrink
         for i in range(5):
             # add 10 bytes
             c.set('x%d' % i, b'01234567')
@@ -478,7 +478,7 @@ class LocalClientTests(unittest.TestCase):
         self.assertEqual(c.get('x3'), b'01234567')
         self.assertEqual(c.get('x4'), b'01234567')
         self.assertEqual(c._bucket0.size, 50)
-        self.assertEqual(c._bucket1.size, 20)
+        self.assertEqual(c._bucket1.size, 50) # don't shrink
         self.assertEqual(c.get('k0'), None)
         self.assertEqual(c.get('k1'), None)
         self.assertEqual(c.get('k2'), b'01234567')
@@ -513,7 +513,7 @@ class LocalClientTests(unittest.TestCase):
         v = c.get('k0')
         self.assertEqual(v, b'01234567' * 10)
         self.assertEqual(c._bucket0.size, 21 * 2)
-        self.assertEqual(c._bucket1.size, 21)
+        self.assertEqual(c._bucket1.size, 21 * 2) # don't shrink bucket1
 
         v = c.get('k1')
         self.assertEqual(v, b'76543210' * 10)
@@ -523,7 +523,7 @@ class LocalClientTests(unittest.TestCase):
         v = c.get('k2')
         self.assertEqual(v, b'abcdefgh' * 10)
         self.assertEqual(c._bucket0.size, 21 * 2)
-        self.assertEqual(c._bucket1.size, 21)
+        self.assertEqual(c._bucket1.size, 21 * 2)
 
     def test_add(self):
         c = self._makeOne()


### PR DESCRIPTION
This uses `persistent.ring.Ring`, a linked-list-like structure already optimized for both PyPy and CPython to manage an actual LRU list and individually discard the LRU items on memory pressure. This should let us actually store more useful data in the pickle cache. (Ring is documented, but also considered an implementation detail; however, I wrote it and consider it safe to use here.)

It also minimizes the amount of time we spend locked.

On benchmarks, it is generally at least as fast as the prior implementation. When it comes to reading, it is faster; writing may be just a hair slower. Practically, it will depend on how many reads and writes there are done in a call to `set/get_multi` because the lock overhead seems to dominate the bookkeeping overhead.

There's some interesting history in the commits so I'm keeping them.