### PR TITLE
Enable Travis for the 1.6 branch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+source = relstorage
+omit = relstorage/tests/*
+
+[report]
+# Coverage is run on Linux under cPython 2, so
+# exclude branches that are windows specific or pypy/python3
+# specific
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+    except ImportError:
+    if __name__ == .__main__.:
+    if PYPY:
+    if PY3:
+    if sys.platform == 'win32':
+    if mswindows:
+    if is_windows:
+    if sys.version_info.*>=.*3

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.egg-info
 *.pyc
 *.sublime-*
+.coverage
+htmlcov/
 bin/
 develop-eggs/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: python
+sudo: false
+services:
+  - mysql
+  - postgresql
+env:
+  matrix:
+    - ENV=mysql
+    - ENV=postgres
+matrix:
+  fast_finish: true
+script:
+  - coverage run -m relstorage.tests.alltests
+after_success:
+  - coveralls
+notifications:
+  email: false
+
+install:
+  - pip install -U pip
+  - pip install -U tox coveralls zope.testing mock coverage
+  - pip install -U -e .
+  - .travis/setup-$ENV.sh
+# cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.venv
+    - $HOME/.runtimes
+    - $HOME/.wheelhouse
+
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 services:
   - mysql
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 # setup.py because of the ZODB3 meta distribution being renamed back
 # to ZODB.
   - pip uninstall -y ZODB
-  - pip install 'ZODB<4.4'
+  - pip install 'ZODB<4.3'
 
 # cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 matrix:
   fast_finish: true
 script:
-  - python -c 'import ZODB; print ZODB '
   - coverage run -m relstorage.tests.alltests
 after_success:
   - coveralls
@@ -23,13 +22,15 @@ install:
   - pip install -U tox coveralls
   - pip install pylibmc
   - pip install -U -e ".[test]"
-# RecoveryStorage can't import handle_serials in 5.0, and there are
-# transaction changes that affect our tests in 4.4. It's hard to write
-# a requirement like this in setup.py because of the ZODB3 meta
-# distribution being renamed back to ZODB.
+  - .travis/setup-$ENV.sh
+# setup-ENV likes to update ZODB. But RecoveryStorage can't import
+# handle_serials in 5.0, and there are transaction changes that affect
+# our tests in 4.4. It's hard to write a requirement like this in
+# setup.py because of the ZODB3 meta distribution being renamed back
+# to ZODB.
   - pip uninstall -y ZODB
   - pip install 'ZODB<4.4'
-  - .travis/setup-$ENV.sh
+
 # cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - .travis/setup-$ENV.sh
 # setup-ENV likes to update ZODB. But RecoveryStorage can't import
 # handle_serials in 5.0, and there are transaction changes that affect
-# our tests in 4.4. It's hard to write a requirement like this in
+# our tests in 4.3+ (checkUndoCreationBranch1). It's hard to write a requirement like this in
 # setup.py because of the ZODB3 meta distribution being renamed back
 # to ZODB.
   - pip uninstall -y ZODB

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 matrix:
   fast_finish: true
 script:
+  - python -c 'import ZODB; print ZODB '
   - coverage run -m relstorage.tests.alltests
 after_success:
   - coveralls
@@ -26,6 +27,7 @@ install:
 # transaction changes that affect our tests in 4.4. It's hard to write
 # a requirement like this in setup.py because of the ZODB3 meta
 # distribution being renamed back to ZODB.
+  - pip uninstall -y ZODB
   - pip install 'ZODB<4.4'
   - .travis/setup-$ENV.sh
 # cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 services:
   - mysql
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 services:
   - mysql
   - postgresql
+  - memcached
 env:
   matrix:
     - ENV=mysql
@@ -17,9 +18,9 @@ notifications:
   email: false
 
 install:
-  - pip install -U pip
-  - pip install -U tox coveralls zope.testing mock coverage
-  - pip install -U -e .
+  - pip install -U pip setuptools
+  - pip install -U tox coveralls
+  - pip install -U -e ".[test]"
   - .travis/setup-$ENV.sh
 # cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,13 @@ notifications:
 install:
   - pip install -U pip setuptools
   - pip install -U tox coveralls
+  - pip install pylibmc
   - pip install -U -e ".[test]"
+# RecoveryStorage can't import handle_serials in 5.0, and there are
+# transaction changes that affect our tests in 4.4. It's hard to write
+# a requirement like this in setup.py because of the ZODB3 meta
+# distribution being renamed back to ZODB.
+  - pip install 'ZODB<4.4'
   - .travis/setup-$ENV.sh
 # cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
 cache:

--- a/.travis/setup-mysql.sh
+++ b/.travis/setup-mysql.sh
@@ -1,0 +1,11 @@
+pip install -U MySQL-python
+mysql -uroot -e "CREATE USER 'relstoragetest'@'localhost' IDENTIFIED BY 'relstoragetest';"
+mysql -uroot -e "CREATE DATABASE relstoragetest;"
+mysql -uroot -e "GRANT ALL ON relstoragetest.* TO 'relstoragetest'@'localhost';"
+mysql -uroot -e "CREATE DATABASE relstoragetest2;"
+mysql -uroot -e "GRANT ALL ON relstoragetest2.* TO 'relstoragetest'@'localhost';"
+mysql -uroot -e "CREATE DATABASE relstoragetest_hf;"
+mysql -uroot -e "GRANT ALL ON relstoragetest_hf.* TO 'relstoragetest'@'localhost';"
+mysql -uroot -e "CREATE DATABASE relstoragetest2_hf;"
+mysql -uroot -e "GRANT ALL ON relstoragetest2_hf.* TO 'relstoragetest'@'localhost';"
+mysql -uroot -e "FLUSH PRIVILEGES;"

--- a/.travis/setup-mysql.sh
+++ b/.travis/setup-mysql.sh
@@ -1,6 +1,4 @@
 pip install -U -e ".[mysql]"
-echo -e "[server]\nmax_allowed_packet=64M" | sudo tee -a /etc/mysql/conf.d/cope.cnf
-sudo service mysql restart
 mysql -uroot -e "CREATE USER 'relstoragetest'@'localhost' IDENTIFIED BY 'relstoragetest';"
 mysql -uroot -e "CREATE DATABASE relstoragetest;"
 mysql -uroot -e "GRANT ALL ON relstoragetest.* TO 'relstoragetest'@'localhost';"

--- a/.travis/setup-mysql.sh
+++ b/.travis/setup-mysql.sh
@@ -1,4 +1,6 @@
 pip install -U -e ".[mysql]"
+echo -e "[server]\nmax_allowed_packet=64M" | sudo tee -a /etc/mysql/conf.d/cope.cnf
+sudo service mysql restart
 mysql -uroot -e "CREATE USER 'relstoragetest'@'localhost' IDENTIFIED BY 'relstoragetest';"
 mysql -uroot -e "CREATE DATABASE relstoragetest;"
 mysql -uroot -e "GRANT ALL ON relstoragetest.* TO 'relstoragetest'@'localhost';"

--- a/.travis/setup-mysql.sh
+++ b/.travis/setup-mysql.sh
@@ -1,4 +1,4 @@
-pip install -U MySQL-python
+pip install -U -e ".[mysql]"
 mysql -uroot -e "CREATE USER 'relstoragetest'@'localhost' IDENTIFIED BY 'relstoragetest';"
 mysql -uroot -e "CREATE DATABASE relstoragetest;"
 mysql -uroot -e "GRANT ALL ON relstoragetest.* TO 'relstoragetest'@'localhost';"

--- a/.travis/setup-postgres.sh
+++ b/.travis/setup-postgres.sh
@@ -1,0 +1,6 @@
+pip install -U psycopg2
+psql -U postgres -c "CREATE USER relstoragetest WITH PASSWORD 'relstoragetest';"
+psql -U postgres -c "CREATE DATABASE relstoragetest OWNER relstoragetest;"
+psql -U postgres -c "CREATE DATABASE relstoragetest2 OWNER relstoragetest;"
+psql -U postgres -c "CREATE DATABASE relstoragetest_hf OWNER relstoragetest;"
+psql -U postgres -c "CREATE DATABASE relstoragetest2_hf OWNER relstoragetest;"

--- a/.travis/setup-postgres.sh
+++ b/.travis/setup-postgres.sh
@@ -1,4 +1,4 @@
-pip install -U psycopg2
+pip install -U -e ".[postgresql]"
 psql -U postgres -c "CREATE USER relstoragetest WITH PASSWORD 'relstoragetest';"
 psql -U postgres -c "CREATE DATABASE relstoragetest OWNER relstoragetest;"
 psql -U postgres -c "CREATE DATABASE relstoragetest2 OWNER relstoragetest;"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+1.6.1 (unreleased)
+------------------
+
+- Tests: Basic integration testing is done on Travis CI. Thanks to
+  Mauro Amico.
+
 1.6.0 (2016-06-09)
 ------------------
 

--- a/README.txt
+++ b/README.txt
@@ -46,6 +46,11 @@ The patches are also included in the source distribution of RelStorage.
 You need the Python database adapter that corresponds with your database.
 Install psycopg2, MySQLdb 1.2.2+, or cx_Oracle 4.3+.
 
+**CAUTION**: RelStorage 1.6 will *not* work with ZODB 5 or ZEO 5. You
+  will need a 4.x or older version of those two dependencies. The
+  setup.py distributed with RelStorage cannot enforce this due to the
+  legacy nature of its ZODB3 dependency.
+
 Configuring Your Database
 -------------------------
 

--- a/relstorage/adapters/mover.py
+++ b/relstorage/adapters/mover.py
@@ -1179,7 +1179,8 @@ class ObjectMover(object):
             f.close()
         return bytecount
 
-
+    # PostgreSQL only supports up to 2GB of data per BLOB.
+    postgresql_blob_chunk_maxsize = 1<<31
 
     @metricmethod_sampled
     def postgresql_upload_blob(self, cursor, oid, tid, filename):
@@ -1215,8 +1216,8 @@ class ObjectMover(object):
             """
 
         blob = None
-        # PostgreSQL only supports up to 2GB of data per BLOB.
-        maxsize = 1<<31
+
+        maxsize = self.postgresql_blob_chunk_maxsize
         filesize = os.path.getsize(filename)
 
         if filesize <= maxsize:

--- a/relstorage/tests/alltests.py
+++ b/relstorage/tests/alltests.py
@@ -28,7 +28,8 @@ def make_suite():
     return suite
 
 if __name__ == '__main__':
-    logging.basicConfig()
+    logging.basicConfig(level=logging.ERROR,
+                        format='%(asctime)s %(levelname)-5.5s [%(name)s][%(thread)d:%(process)d][%(threadName)s] %(message)s')
     # We get constant errors about failing to lock a blob file,
     # which really bloats the CI logs, so turn those off.
     logging.getLogger('zc.lockfile').setLevel(logging.CRITICAL)

--- a/relstorage/tests/alltests.py
+++ b/relstorage/tests/alltests.py
@@ -12,12 +12,13 @@
 #
 ##############################################################################
 """Combines the tests of all adapters"""
-
+from __future__ import absolute_import
 import unittest
+import logging
 
-from testpostgresql import test_suite as postgresql_test_suite
-from testmysql import test_suite as mysql_test_suite
-from testoracle import test_suite as oracle_test_suite
+from .testpostgresql import test_suite as postgresql_test_suite
+from .testmysql import test_suite as mysql_test_suite
+from .testoracle import test_suite as oracle_test_suite
 
 def make_suite():
     suite = unittest.TestSuite()
@@ -25,3 +26,10 @@ def make_suite():
     suite.addTest(mysql_test_suite())
     suite.addTest(oracle_test_suite())
     return suite
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    # We get constant errors about failing to lock a blob file,
+    # which really bloats the CI logs, so turn those off.
+    logging.getLogger('zc.lockfile').setLevel(logging.CRITICAL)
+    unittest.main(defaultTest='make_suite')

--- a/relstorage/tests/blob/testblob.py
+++ b/relstorage/tests/blob/testblob.py
@@ -56,6 +56,13 @@ def new_time():
     time.sleep(1)
     return new_time
 
+with open(__file__) as _f:
+    # Just use the this module as the source of our data
+    # Capture it at import time because test cases may
+    # chdir(), and we may not have an absolute path in __file__,
+    # depending on how they are run.
+    _random_file_data = _f.read().replace('\n', '').split()
+del _f
 
 def random_file(size, fd):
     """Create a random data of at least the given size, writing to fd.
@@ -68,8 +75,7 @@ def random_file(size, fd):
     """
     def fdata():
         seed = "1092384956781341341234656953214543219"
-        # Just use the this module as the source of our data
-        words = open(__file__, "r").read().replace("\n", '').split()
+        words = _random_file_data
         a = collections.deque(words)
         b = collections.deque(seed)
         while True:

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -77,7 +77,7 @@ class RelStorageTestBase(StorageTestBase.StorageTestBase):
             if util.CACHE_SERVERS and util.CACHE_MODULE_NAME:
                 kw['cache_servers'] = util.CACHE_SERVERS
                 kw['cache_module_name'] = util.CACHE_MODULE_NAME
-                kw['cache_prefix'] = type(self).__name__ + self._testMethodNa
+                kw['cache_prefix'] = type(self).__name__ + self._testMethodName
         options = Options(keep_history=self.keep_history, **kw)
         adapter = self.make_adapter(options)
         storage = RelStorage(adapter, options=options)

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -33,6 +33,9 @@ import random
 import time
 import transaction
 
+from . import util
+from relstorage.options import Options
+from relstorage.storage import RelStorage
 
 class RelStorageTestBase(StorageTestBase.StorageTestBase):
 
@@ -69,8 +72,12 @@ class RelStorageTestBase(StorageTestBase.StorageTestBase):
         raise NotImplementedError()
 
     def make_storage(self, zap=True, **kw):
-        from relstorage.options import Options
-        from relstorage.storage import RelStorage
+        if ('cache_servers' not in kw and 'cache_module_name' not in kw
+            and kw.get('share_local_cache', True)):
+            if util.CACHE_SERVERS and util.CACHE_MODULE_NAME:
+                kw['cache_servers'] = util.CACHE_SERVERS
+                kw['cache_module_name'] = util.CACHE_MODULE_NAME
+                kw['cache_prefix'] = type(self).__name__ + self._testMethodNa
         options = Options(keep_history=self.keep_history, **kw)
         adapter = self.make_adapter(options)
         storage = RelStorage(adapter, options=options)

--- a/relstorage/tests/testmysql.py
+++ b/relstorage/tests/testmysql.py
@@ -20,6 +20,7 @@ from relstorage.tests.hftestbase import HistoryFreeToFileStorage
 from relstorage.tests.hptestbase import HistoryPreservingFromFileStorage
 from relstorage.tests.hptestbase import HistoryPreservingRelStorageTests
 from relstorage.tests.hptestbase import HistoryPreservingToFileStorage
+from .util import skipOnCI
 import logging
 import os
 import unittest
@@ -111,8 +112,10 @@ class ZConfigTests:
 
 
 class HPMySQLTests(UseMySQLAdapter, HistoryPreservingRelStorageTests,
-        ZConfigTests):
-    pass
+                   ZConfigTests):
+    @skipOnCI("Travis MySQL goes away error 2006")
+    def check16MObject(self):
+        super(HPMySQLTests,self).check16MObject()
 
 class HPMySQLToFile(UseMySQLAdapter, HistoryPreservingToFileStorage):
     pass
@@ -121,8 +124,11 @@ class HPMySQLFromFile(UseMySQLAdapter, HistoryPreservingFromFileStorage):
     pass
 
 class HFMySQLTests(UseMySQLAdapter, HistoryFreeRelStorageTests,
-        ZConfigTests):
-    pass
+                   ZConfigTests):
+
+    @skipOnCI("Travis MySQL goes away error 2006")
+    def check16MObject(self):
+        super(HFMySQLTests,self).check16MObject()
 
 class HFMySQLToFile(UseMySQLAdapter, HistoryFreeToFileStorage):
     pass
@@ -222,4 +228,3 @@ def test_suite():
 if __name__=='__main__':
     logging.basicConfig()
     unittest.main(defaultTest="test_suite")
-

--- a/relstorage/tests/testpostgresql.py
+++ b/relstorage/tests/testpostgresql.py
@@ -167,7 +167,7 @@ def test_suite():
             # XXX: This is dirty.
             from relstorage.adapters.mover import ObjectMover
             assert hasattr(ObjectMover, 'postgresql_blob_chunk_maxsize')
-            ObjectMover.postgresql_blob_chunk_maxsize = 1024 * 1024 * 100
+            ObjectMover.postgresql_blob_chunk_maxsize = 1024 * 1024 * 10
             large_blob_size = ObjectMover.postgresql_blob_chunk_maxsize * 2
         else:
             large_blob_size = 1<<31

--- a/relstorage/tests/util.py
+++ b/relstorage/tests/util.py
@@ -49,3 +49,22 @@ else:
         def dec(f):
             return f
         return dec
+
+
+CACHE_SERVERS = None
+CACHE_MODULE_NAME = None
+
+if RUNNING_ON_TRAVIS:
+    # We expect to have access to a local memcache server
+    # on travis. Use it if we can import drivers.
+    try:
+        import pylibmc
+        CACHE_SERVERS = ["localhost:11211"]
+        CACHE_MODULE_NAME = 'relstorage.pylibmc_wrapper'
+    except ImportError:
+        try:
+            import memcache
+            CACHE_SERVERS = ["localhost:11211"]
+            CACHE_MODULE_NAME = 'memcache'
+        except ImportError:
+            pass

--- a/relstorage/tests/util.py
+++ b/relstorage/tests/util.py
@@ -1,5 +1,6 @@
-
+import os
 import time
+import unittest
 
 def wait_until(label=None, func=None, timeout=30, onfail=None):
     """Copied from ZEO.tests.forker, because it does not exist in ZODB 3.8"""
@@ -36,3 +37,15 @@ else:
     # ZODB >= 3.9.  The blob directory can be a private cache.
     shared_blob_dir_choices = (False, True)
     support_blob_cache = True
+
+RUNNING_ON_TRAVIS = os.environ.get('TRAVIS')
+RUNNING_ON_APPVEYOR = os.environ.get('APPVEYOR')
+RUNNING_ON_CI = RUNNING_ON_TRAVIS or RUNNING_ON_APPVEYOR
+
+if RUNNING_ON_CI:
+    skipOnCI = unittest.skip
+else:
+    def skipOnCI(reason):
+        def dec(f):
+            return f
+        return dec

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     zip_safe=False,  # otherwise ZConfig can't see component.xml
     install_requires=[
         'perfmetrics',
-        'ZODB3>=3.7.0',
+        'ZODB3>=3.7.0,<3.11.0',
         'zope.interface',
         'zc.lockfile',
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,12 @@ def read_file(*path):
     file_path = (base_dir, ) + tuple(path)
     return file(os.path.join(*file_path)).read()
 
+tests_require = [
+    'mock',
+    'zope.testing',
+    'ZODB3 [test]',
+]
+
 setup(
     name="RelStorage",
     version=VERSION,
@@ -74,15 +80,12 @@ setup(
         'zope.interface',
         'zc.lockfile',
     ],
-    tests_require=[
-        'mock',
-        'zope.testing',
-        'ZODB3[test]',
-    ],
+    tests_require=tests_require,
     extras_require={
         'mysql': ['MySQL-python>=1.2.2'],
         'postgresql': ['psycopg2>=2.0'],
         'oracle': ['cx_Oracle>=4.3.1'],
+        'test': tests_require,
     },
     entry_points = {
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     zip_safe=False,  # otherwise ZConfig can't see component.xml
     install_requires=[
         'perfmetrics',
-        'ZODB3>=3.7.0,<3.11.0',
+        'ZODB3>=3.7.0',
         'zope.interface',
         'zc.lockfile',
     ],

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     install_requires=[
         'perfmetrics',
         'ZODB3>=3.7.0',
+        'ZEO<=5.0', # ZEO.zrpc is gone
         'zope.interface',
         'zc.lockfile',
     ],

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,10 @@ setup(
         'zope.interface',
         'zc.lockfile',
     ],
-    tests_require=['mock'],
+    tests_require=[
+        'mock',
+        'zope.testing',
+    ],
     extras_require={
         'mysql': ['MySQL-python>=1.2.2'],
         'postgresql': ['psycopg2>=2.0'],

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     tests_require=[
         'mock',
         'zope.testing',
+        'ZODB3[test]',
     ],
     extras_require={
         'mysql': ['MySQL-python>=1.2.2'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py27-mysql,py27-postgres
+
+[testenv]
+deps = coverage
+commands =
+    coverage run -m relstorage.tests.alltests
+
+[testenv:py27-mysql]
+deps =
+    MySQL-python
+    {[testenv]deps}
+commands =
+    {[testenv]commands}
+
+[testenv:py27-postgres]
+deps =
+    psycopg2
+    {[testenv]deps}
+commands =
+    {[testenv]commands}


### PR DESCRIPTION
Like #113, but:
- enables memcache
- uses smaller blobs for postgres
- relaxes the version pins as much as possible without too many test changes (which turns out to be ZODB 4.2)