### PR TITLE
Fix packing in Oracle history-preserving databases. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@
   ``cache_delta_size_limit``.
 
   The internal implementation details of the cache have been
-  completely changed. Only the ``StorageCache`` public class remains
+  completely changed. Only the ``StorageCache`` class remains
   unchanged (though that's also an implementation class). CFFI is now
   required, and support for PyPy versions older than 2.6.1 has been dropped.
 
@@ -38,6 +38,9 @@
 - Persistent cache files use the latest TID in the cache as the file's
   modification time. This allows a more accurate choice of which file
   to read at startup. Fixes :issue:`126`.
+
+- Fix packing of history-preserving Oracle databases. Reported in
+  :issue:`135` by Peter Jacobs.
 
 2.0.0b6 (2016-09-08)
 ====================

--- a/relstorage/adapters/oracle/packundo.py
+++ b/relstorage/adapters/oracle/packundo.py
@@ -56,8 +56,9 @@ class OracleHistoryPreservingPackUndo(HistoryPreservingPackUndo):
           AND rownum <= 1000
         """
 
-    # XXX: This may not be necessary, the HP tests don't fail
-    # without it.
+    # XXX: This is necessary
+    # (https://github.com/zodb/relstorage/issues/135), but the HP
+    # tests don't fail without it.
     _fetchmany = _oracle_fetchmany
 
 

--- a/relstorage/adapters/packundo.py
+++ b/relstorage/adapters/packundo.py
@@ -416,7 +416,7 @@ class HistoryPreservingPackUndo(PackUndo):
         self.runner.run_script_stmt(cursor, stmt, {'tid': tid})
 
         add_rows = []  # [(from_oid, tid, to_oid)]
-        for from_oid, state in fetchmany(cursor):
+        for from_oid, state in self._fetchmany(cursor):
             state = db_binary_to_bytes(state)
             if hasattr(state, 'read'):
                 # Oracle
@@ -663,7 +663,7 @@ class HistoryPreservingPackUndo(PackUndo):
                 """
                 self.runner.run_script_stmt(
                     cursor, stmt, {'pack_tid': pack_tid})
-                tid_rows = list(fetchmany(cursor))
+                tid_rows = list(self._fetchmany(cursor))
                 tid_rows.sort()  # oldest first
 
                 total = len(tid_rows)
@@ -756,7 +756,7 @@ class HistoryPreservingPackUndo(PackUndo):
             WHERE pack_state.tid = %(tid)s
             """
             self.runner.run_script_stmt(cursor, stmt, {'tid': tid})
-            for (oid,) in fetchmany(cursor):
+            for (oid,) in self._fetchmany(cursor):
                 packed_list.append((oid, tid))
 
         # Find out whether the transaction is empty
@@ -881,7 +881,7 @@ class HistoryFreePackUndo(PackUndo):
             ORDER BY object_state.zoid
             """
             self.runner.run_script_stmt(cursor, stmt)
-            oids = [oid for (oid,) in fetchmany(cursor)]
+            oids = [oid for (oid,) in self._fetchmany(cursor)]
             log_at = time.time() + 60
             if oids:
                 if attempt == 1:
@@ -1056,7 +1056,7 @@ class HistoryFreePackUndo(PackUndo):
                 WHERE keep = %(FALSE)s
                 """
                 self.runner.run_script_stmt(cursor, stmt)
-                to_remove = list(fetchmany(cursor))
+                to_remove = list(self._fetchmany(cursor))
 
                 total = len(to_remove)
                 log.info("pack: will remove %d object(s)", total)


### PR DESCRIPTION
Unfortunately the unit tests don't cover this case well. Fixes #135.