### PR TITLE
`rsc_eden_add_many` failed to set sentinel values on some rejected nodes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@
   compatibility with transaction 1.x. In particular, the ``history``
   method consistently returns bytes for username and description.
 
+- In very rare cases, persistent cache files could result in a corrupt
+  cache state in memory after loading them, resulting in
+  AttributeErrors until the cache files were removed and the instance
+  restarted. Reported in :issue:`140` by Carlos Sanchez.
+
 2.0.0b8 (2016-10-02)
 ====================
 

--- a/relstorage/cache/cache_ring.c
+++ b/relstorage/cache/cache_ring.c
@@ -371,7 +371,7 @@ int rsc_eden_add_many(RSCache* cache,
         // _eden_add *always* adds, but it may or may not be able to
         // rebalance.
         added_count += 1;
-        RSRingNode add_rejects = _eden_add(cache, entry_array + i, _SPILL_NO_VICTIMS);
+        RSRingNode add_rejects = _eden_add(cache, incoming, _SPILL_NO_VICTIMS);
         if (add_rejects.u.entry.frequency) {
             // We would have rejected something, so we must be full.
             // Well, this isn't strictly true. It could be one really
@@ -382,6 +382,13 @@ int rsc_eden_add_many(RSCache* cache,
             // one's already in here, so quit.
             break;
         }
+    }
+
+    // Anything left is because we broke out of the loop. They're
+    // rejects and need to be marked as such.
+    for (i += 1; i < entry_count; i++) {
+        RSRingNode* rejected = entry_array + i;
+        rejected->u.entry.r_parent = -1;
     }
 
     return added_count;

--- a/relstorage/cache/cache_ring.h
+++ b/relstorage/cache/cache_ring.h
@@ -44,7 +44,7 @@ typedef struct RSRingNode_struct {
             rs_counter_t frequency;
             // The weight of this item.
             rs_counter_t weight;
-            // The number of the parent generation
+            // The number of the parent (containing) generation
             int r_parent;
         } entry;
         struct head_t {
@@ -54,7 +54,10 @@ typedef struct RSRingNode_struct {
             rs_counter_t sum_weights;
             // The maximum allowed weight
             rs_counter_t max_weight;
-            // The generation number
+            // The generation number. We don't make any use of this
+            // number other than ensuring it is copied to r_parent
+            // as needed. You can use any value except for negative
+            // values in your RSCache generations.
             int generation;
         } head;
     } u;

--- a/relstorage/cache/local_client.py
+++ b/relstorage/cache/local_client.py
@@ -95,13 +95,13 @@ class LocalClient(object):
 
     def save(self):
         options = self.options
-        if options.cache_local_dir and self._bucket0.size:
+        if options.cache_local_dir and self.__bucket.size:
             _Loader.save_local_cache(options, self.prefix, self)
 
     def write_to_stream(self, stream):
         with self._lock:
             options = self.options
-            return self._bucket0.write_to_stream(stream, options.cache_local_dir_write_max_size)
+            return self.__bucket.write_to_stream(stream, options.cache_local_dir_write_max_size)
 
     def restore(self):
         options = self.options
@@ -110,7 +110,7 @@ class LocalClient(object):
 
     def read_from_stream(self, stream):
         with self._lock:
-            return self._bucket0.read_from_stream(stream)
+            return self.__bucket.read_from_stream(stream)
 
     @property
     def _bucket0(self):

--- a/relstorage/cache/mapping.py
+++ b/relstorage/cache/mapping.py
@@ -244,6 +244,7 @@ class SizedLRUMapping(object):
 
             for e in added_entries:
                 assert e.key not in data
+                assert e.cffi_entry.r_parent != 0, e.key
                 data[e.key] = e
                 stored += 1
             return stored


### PR DESCRIPTION
This only happened when the cache entries were sized in such a way that
when a new entry could fit we would still like to reject an old entry
from a different ring.

The result was that the Python code thought that there was an entry in the cache that the C code didn't know about, and that entry wasn't correctly initialized by the C code, leading to AttributeErrors.

Also some minor code cleanup and commenting.

Fixes #140.