### PR TITLE
Extra safety writing temporary cache files.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,10 @@
 2.0.0b10 (unreleased)
 =====================
 
-- Nothing changed yet.
+- Writing persistent cache files has been changed to reduce the risk
+  of stale temporary files remaining. Also, files are kept open for a
+  shorter period of time and removed in a way that should work better
+  on Windows.
 
 
 2.0.0b9 (2016-11-29)


### PR DESCRIPTION
Take more care with exception handling and being extra sure to clean up
temporary files.

Refactor to make this more obvious.

In addition, don't open files unless we're going to read them, not just
to stat them. This may open some small race conditions, but we should be
robust to them. It makes it more likely that this process will work on
Windows. It does use more system calls, but this shouldn't be a
bottleneck for reasonably sized cache directories.

Let the system generate cache file names for us, and replace old files
instead of renaming on top of them. This should be less racy overall.