### PR TITLE
MySQL: Drop the commit lock after fill_object_refs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 - MySQL and Postgres now use the same optimized methods to get the
   latest TID at transaction commit time as they do at poll time. This
   is similar to :issue:`89`.
+- MySQL now releases the commit lock (if acquired) during pre-pack
+  with GC of a history-free storage at the same time as PostgreSQL and
+  Oracle did (much earlier). Reported and initial fix provided in
+  :pr:`9` by jplouis.
 
 
 2.0.0rc1 (2016-12-12)

--- a/doc/developing/packing.rst
+++ b/doc/developing/packing.rst
@@ -35,16 +35,16 @@ What does this mean for each object?
 
 1
   Revisions 14, 13 and 12 are kept, while revision 10 is dropped.
-  The prev_tid of revision 12 is set to 0. Until the current revision,
+  The ``prev_tid`` of revision 12 is set to 0. Until the current revision,
   this object referred to object 9.
 2
   Both revisions (13 and 11) are kept. This object is keeping object
   3 alive. Although nothing refers to this object, packing does not
-  remove objects with revisions beyond pack_tid.
+  remove objects with revisions beyond ``pack_tid``.
 3
   Since a current revision of object 2 refers to this object,
   revision 12 is kept, but its history is cut short (revision 11 is
-  dropped and the prev_tid for revision 12 is set to 0).
+  dropped and the ``prev_tid`` for revision 12 is set to 0).
 5
   Nothing refers to this object, so the OID is completely removed from
   the database.
@@ -59,7 +59,7 @@ What does this mean for each object?
 0
   This is the root object since its OID is 0. The root object is
   never removed from the database, but its history will be cut short:
-  revision 10 will be removed and the prev_tid of revision 11 will be
+  revision 10 will be removed and the ``prev_tid`` of revision 11 will be
   set to 0.
 
 Notes

--- a/relstorage/adapters/mysql/locker.py
+++ b/relstorage/adapters/mysql/locker.py
@@ -29,6 +29,23 @@ class CommitLockQueryFailedError(UnableToAcquireCommitLockError):
 
 @implementer(ILocker)
 class MySQLLocker(AbstractLocker):
+    """
+    MySQL locks.
+
+    Unlike PostgreSQL and Oracle locks which are implicitly released
+    at the end of a transaction, MySQL locks **must** be released explicitly.
+
+    .. caution::
+       Prior to MySQL 5.7.5, it is not possible to hold more
+       than one lock in a single session. Thus, the pack lock must be
+       held by a different connection than the commit lock during the
+       packing process (otherwise when
+       :meth:`relstorage.adapters.packundo.HistoryFreePackUndo.fill_object_refs`
+       acquires the commit lock, the pack lock held by :meth:`relstorage.storage.RelStorage.pack`
+       would be dropped).
+
+       http://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
+    """
 
     @metricmethod
     def hold_commit_lock(self, cursor, ensure_current=False, nowait=False):

--- a/relstorage/adapters/oracle/locker.py
+++ b/relstorage/adapters/oracle/locker.py
@@ -44,7 +44,7 @@ class OracleLocker(AbstractLocker):
                 self.commit_lock_id,
                 6,  # exclusive (X_MODE)
                 timeout,
-                True,
+                True, # release on commit, yes please
             ))
         if status != 0:
             if nowait and status == 1:

--- a/relstorage/storage.py
+++ b/relstorage/storage.py
@@ -1259,6 +1259,7 @@ class RelStorage(UndoLogCompatible,
     @metricmethod
     def pack(self, t, referencesf, prepack_only=False, skip_prepack=False,
              sleep=None):
+        """Pack the storage. Holds the pack lock for the duration."""
         # pylint:disable=too-many-branches
         if self._is_read_only:
             raise ReadOnlyError()

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -643,8 +643,9 @@ class GenericRelStorageTests(
             packtime = time.time()
             self._storage.pack(packtime, referencesf)
 
-            self.assertEqual(len(expect_oids), 2,
-                             "The on_filling_object_refs hook should have been called once")
+            # "The on_filling_object_refs hook should have been called once")
+            self.assertEqual(len(expect_oids), 2, expect_oids)
+
             # Both children should still exist.
             self._storage.load(expect_oids[0], '')
             self._storage.load(expect_oids[1], '')


### PR DESCRIPTION
In pre-pack gc in a history free storage.

Oracle and PostgreSQL were already doing this (because the included COMMIT automatically dropped the lock), so this should be a safe change to make.

Fixes #9 