### PR TITLE
Support for MySQL Connector/Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ addons:
 matrix:
   include:
     - python: 2.7
-      env: ENV=mysqlconnector
+      env: ENV=pymysqlconnector
+    - python: 2.7
+      env: ENV=cmysqlconnector
     - python: 3.6
       env: ENV=mysqlconnector
     - python: pypy-5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - python: 2.7
       env:
         - ENV=cmysqlconnector
-        - RS_MY_DRIVER=cmysqlconnector
+        - RS_MY_DRIVER="C MySQL Connector/Python"
     - python: 3.6
       env: ENV=mysqlconnector
     - python: pypy-5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
   include:
     - python: 2.7
       env:
-        - ENV=pymysqlconnector
-        - RS_MY_DRIVER=pymysqlconnector
-    - python: 2.7
-      env:
         - ENV=cmysqlconnector
         - RS_MY_DRIVER=cmysqlconnector
     - python: 3.6
@@ -38,8 +34,6 @@ matrix:
     - python: pypy-5.4.1
       env: ENV=mysql
 
-    - python: 3.6
-      env: ENV=pymysql
     - python: 3.5
       env: ENV=pymysql
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,13 @@ addons:
 matrix:
   include:
     - python: 2.7
-      env: ENV=pymysqlconnector
+      env:
+        - ENV=pymysqlconnector
+        - RS_MY_DRIVER=pymysqlconnector
     - python: 2.7
-      env: ENV=cmysqlconnector
+      env:
+        - ENV=cmysqlconnector
+        - RS_MY_DRIVER=cmysqlconnector
     - python: 3.6
       env: ENV=mysqlconnector
     - python: pypy-5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ addons:
 
 matrix:
   include:
+    - python: 2.7
+      env: ENV=mysqlconnector
+    - python: 3.6
+      env: ENV=mysqlconnector
+    - python: pypy-5.4.1
+      env: ENV=mysqlconnector
+
     - python: 3.6
       env: ENV=mysql
     - python: 3.5

--- a/.travis/setup-cmysqlconnector.sh
+++ b/.travis/setup-cmysqlconnector.sh
@@ -1,2 +1,5 @@
-pip install https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.5.tar.gz
+wget https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.5.tar.gz
+tar -xf mysql-connector-python-2.1.5.tar.gz
+cd ./mysql-connector-python-2.1.5
+python ./setup.py install --with-mysql-capi=/usr
 `dirname $0`/mysql.sh

--- a/.travis/setup-cmysqlconnector.sh
+++ b/.travis/setup-cmysqlconnector.sh
@@ -2,4 +2,5 @@ wget https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python
 tar -xf mysql-connector-python-2.1.5.tar.gz
 cd ./mysql-connector-python-2.1.5
 python ./setup.py install --with-mysql-capi=/usr
+cd ..
 `dirname $0`/mysql.sh

--- a/.travis/setup-cmysqlconnector.sh
+++ b/.travis/setup-cmysqlconnector.sh
@@ -1,0 +1,2 @@
+pip install https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.5.tar.gz
+`dirname $0`/mysql.sh

--- a/.travis/setup-cmysqlconnector.sh
+++ b/.travis/setup-cmysqlconnector.sh
@@ -3,4 +3,5 @@ tar -xf mysql-connector-python-2.1.5.tar.gz
 cd ./mysql-connector-python-2.1.5
 python ./setup.py install --with-mysql-capi=/usr
 cd ..
+python -c 'import relstorage.adapters.mysql.drivers as D; print(D.preferred_driver_name,D.driver_map)'
 `dirname $0`/mysql.sh

--- a/.travis/setup-mysqlconnector.sh
+++ b/.travis/setup-mysqlconnector.sh
@@ -1,2 +1,3 @@
 pip install https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.5.tar.gz
+python -c 'import relstorage.adapters.mysql.drivers as D; print(D.preferred_driver_name,D.driver_map)'
 `dirname $0`/mysql.sh

--- a/.travis/setup-mysqlconnector.sh
+++ b/.travis/setup-mysqlconnector.sh
@@ -1,0 +1,2 @@
+pip install https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.5.tar.gz
+`dirname $0`/mysql.sh

--- a/.travis/setup-pymysqlconnector.sh
+++ b/.travis/setup-pymysqlconnector.sh
@@ -1,2 +1,0 @@
-pip install https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.5.tar.gz
-`dirname $0`/mysql.sh

--- a/.travis/setup-pymysqlconnector.sh
+++ b/.travis/setup-pymysqlconnector.sh
@@ -1,0 +1,2 @@
+pip install https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.5.tar.gz
+`dirname $0`/mysql.sh

--- a/.travis/setup-umysqldb.sh
+++ b/.travis/setup-umysqldb.sh
@@ -1,5 +1,5 @@
 pip install -U pymysql
 pip install git+https://github.com/NextThought/umysqldb.git#egg=umysqldb
 export RS_MY_DRIVER=umysqldb
-python -c 'import relstorage.adapters._mysql_drivers as D; print(D.preferred_driver_name,D.driver_map)'
+python -c 'import relstorage.adapters.mysql.drivers as D; print(D.preferred_driver_name,D.driver_map)'
 `dirname $0`/mysql.sh

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@
   are in use. Instead, it translates the internal exception to one
   that the higher layers of RelStorage recognize as requiring
   reconnection at consistent times (transaction boundaries).
+- Add initial support for the `MySQL Connector/Python
+  <https://dev.mysql.com/doc/connector-python/en/>`_ driver.
 
 2.0.0 (2016-12-23)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,14 +15,15 @@
   done through the use of prepared statements for the most important
   queries and the new `'ON CONFLICT UPDATE'
   <https://wiki.postgresql.org/wiki/What's_new_in_PostgreSQL_9.5#INSERT_..._ON_CONFLICT_DO_NOTHING.2FUPDATE_.28.22UPSERT.22.29>`_
-  syntax.
+  syntax. See :pr:`157` and :issue:`156`.
 - The umysqldb driver no longer attempts to automatically reconnect on
   a closed cursor exception. That fails now that prepared statements
   are in use. Instead, it translates the internal exception to one
   that the higher layers of RelStorage recognize as requiring
   reconnection at consistent times (transaction boundaries).
 - Add initial support for the `MySQL Connector/Python
-  <https://dev.mysql.com/doc/connector-python/en/>`_ driver.
+  <https://dev.mysql.com/doc/connector-python/en/>`_ driver. See
+  :issue:`155`.
 
 2.0.0 (2016-12-23)
 ==================

--- a/doc/db-specific-options.rst
+++ b/doc/db-specific-options.rst
@@ -30,11 +30,22 @@ PostgreSQL Adapter Options
 The PostgreSQL adapter accepts:
 
 driver
-    Either "psycopg2" or "psycopg2cffi" for the native libpg based
-    drivers. "pg8000" is a pure-python driver suitable for use with
-    gevent.
+    The possible options are:
 
-    .. note:: pg8000 requires PostgreSQL 9.4 or above for BLOB support.
+    psycopg2
+      A C-based driver that requires the PostgreSQL development
+      libraries. Optimal on CPython, but not compatible with gevent.
+
+    psycopg2cffi
+      A C-based driver that requires the PostgreSQL development
+      libraries. Optimal on PyPy and almost indistinguishable from
+      psycopg2 on CPython. Not compatible with gevent.
+
+    pg8000
+     A pure-Python driver suitable for use with gevent. Works on all
+     supported platforms.
+
+     .. note:: pg8000 requires PostgreSQL 9.4 or above for BLOB support.
 
 dsn
     Specifies the data source name for connecting to PostgreSQL.
@@ -54,11 +65,66 @@ The MySQL adapter accepts most parameters supported by the mysqlclient
 library (the maintained version of MySQL-python), including:
 
 driver
-    Either "MySQLdb" (which can be provided by the either of the
-    PyPI distributions `mysqlclient
-    <https://pypi.python.org/pypi/mysqlclient>`_ or `MySQL-python
-    <https://pypi.python.org/pypi/MySQL-python/>`_), or "PyMySQL", or
-    "umysqldb" or "mysqlconnector" for the `official client <https://dev.mysql.com/doc/connector-python/en/>`_.
+    The possible options are:
+
+    MySQLdb
+      A C-based driver that requires the MySQL client development
+      libraries.. This is best provided by the PyPI distribution
+      `mysqlclient <https://pypi.python.org/pypi/mysqlclient>`_. (It
+      can also be provided by the legacy `MySQL-python
+      <https://pypi.python.org/pypi/MySQL-python/>`_ distribution,
+      but only on CPython 2; this distribution is no longer tested.)
+      These drivers are *not* compatible with gevent.
+
+    PyMySQL
+      A pure-Python driver provided by the distribution of the same
+      name. It works with CPython 2 and 3 and PyPy (where it is
+      preferred). It is compatible with gevent.
+
+    umysqldb
+      A C-based driver that builds on PyMySQL. It is compatible with
+      gevent, but only works on CPython 2. It does not require the
+      MySQL client development libraries but uses a project called
+      ``umysql`` to communicate with the server using only sockets.
+
+      .. note:: Make sure the server has a
+          ``max_allowed_packet`` setting no larger than 16MB. Also
+          make sure that RelStorage's ``blob-chunk-size`` is less than
+          16MB as well.
+
+      .. note:: `This fork of umysqldb
+           <https://github.com/NextThought/umysqldb.git>`_ is
+           recommended. The ``full-buffer`` branch of `this ultramysql
+           fork
+           <https://github.com/NextThought/ultramysql/tree/full-buffer>`_
+           is also recommended if you encounter strange MySQL packet
+           errors.
+
+
+    MySQL Connector/Python
+      This is the `official client
+      <https://dev.mysql.com/doc/connector-python/en/>`_ provided by
+      Oracle. It generally cannot be installed from PyPI or by pip if
+      you want the optional C extension. It has an optional C
+      extension that must be built manually. The C extension (which
+      requires the MySQL client development libraries) performs
+      about as well as mysqlclient, but the pure-python version
+      somewhat slower than PyMySQL. However, it supports more advanced
+      options for failover and high availability.
+
+      When using this name, RelStorage will use the C extension if
+      available, otherwise it will use the Python version.
+
+      Binary packages are distributed by Oracle for many platforms
+      and include the necessary native libraries and C extension.
+
+    C MySQL Connector/Python
+      The same as above, but RelStorage will only use the C extension.
+      This is not compatible with gevent.
+
+    Py MySQL Connector/Python
+      Like the above, but RelStorage will use the pure-Python version
+      only. This is compatible with gevent.
 
 host
     string, host to connect

--- a/doc/db-specific-options.rst
+++ b/doc/db-specific-options.rst
@@ -58,7 +58,7 @@ driver
     PyPI distributions `mysqlclient
     <https://pypi.python.org/pypi/mysqlclient>`_ or `MySQL-python
     <https://pypi.python.org/pypi/MySQL-python/>`_), or "PyMySQL", or
-    "umysqldb".
+    "umysqldb" or "mysqlconnector" for the `official client <https://dev.mysql.com/doc/connector-python/en/>`_.
 
 host
     string, host to connect

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -48,18 +48,21 @@ performs nearly as well. cx_Oracle is untested on PyPy).
 Here's a table of known working adapters; adapters **in bold** are the recommended
 adapter; adapters in *italic* are also tested:
 
-========   ================      =================     ======
+========   =================     =================     ======
 Platform   MySQL                 PostgreSQL            Oracle
-========   ================      =================     ======
+========   =================     =================     ======
 CPython2   MySQL-python;         **psycopg2**;         **cx_Oracle**
            **mysqlclient**;      psycopg2cffi;
            *PyMySQL*;            *pg8000*
-           umysqldb
+           *umysqldb*;
+           *MySQL Connector*
 CPython3   **mysqlclient**;      **psycopg2**;         **cx_Oracle**
            *PyMySQL*             *pg8000*
-PyPy       **PyMySQL**           **psycopg2cffi**;
+           *MySQL Connector*
+PyPy       **PyMySQL**;          **psycopg2cffi**;
                                  *pg8000*
-========   ================      =================     ======
+           *MySQL Connector*
+========   =================     =================     ======
 
 .. note:: If you use umysql, make sure the server has a
           ``max_allowed_packet`` setting no larger than 16MB. Also

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -38,46 +38,43 @@ database.
 
 
 On CPython2, install psycopg2 2.6.1+, mysqlclient 1.3.7+, or cx_Oracle
-5.2+; PyMySQL 0.7 and umysql are also known to work as is pg8000. For
-CPython3, install psycopg2, mysqlclient 1.3.7+ or cx_Oracle; PyMySQL
-and pg8000 are also known to work. On PyPy, install psycopg2cffi
-2.7.4+ or PyMySQL 0.6.6+ (PyPy will generally work with psycopg2 and
-mysqlclient, but it will be *much* slower; in contrast, pg8000
-performs nearly as well. cx_Oracle is untested on PyPy).
+5.2+; PyMySQL 0.7, MySQL Connector/Python 2.1.5 and umysql are also
+known to work as is pg8000.
 
-Here's a table of known working adapters; adapters **in bold** are the recommended
-adapter; adapters in *italic* are also tested:
+For CPython3, install psycopg2, mysqlclient or cx_Oracle;
+PyMySQL, MySQL Connector/Python  and pg8000 are also known to work.
 
-========   =================     =================     ======
-Platform   MySQL                 PostgreSQL            Oracle
-========   =================     =================     ======
-CPython2   MySQL-python;         **psycopg2**;         **cx_Oracle**
-           **mysqlclient**;      psycopg2cffi;
-           *PyMySQL*;            *pg8000*
-           *umysqldb*;
-           *MySQL Connector*
-CPython3   **mysqlclient**;      **psycopg2**;         **cx_Oracle**
-           *PyMySQL*             *pg8000*
-           *MySQL Connector*
-PyPy       **PyMySQL**;          **psycopg2cffi**;
-                                 *pg8000*
-           *MySQL Connector*
-========   =================     =================     ======
+On PyPy, install psycopg2cffi 2.7.4+ or PyMySQL 0.6.6+ (PyPy will
+generally work with psycopg2 and mysqlclient, but it will be *much*
+slower; in contrast, pg8000 performs nearly as well. cx_Oracle is
+untested on PyPy).
 
-.. note:: If you use umysql, make sure the server has a
-          ``max_allowed_packet`` setting no larger than 16MB. Also
-          make sure that RelStorage's ``blob-chunk-size`` is less than
-          16MB as well.
+Here's a table of known (tested) working adapters; adapters **in
+bold** are the recommended adapter.
 
-.. note:: `This fork of umysqldb
-           <https://github.com/NextThought/umysqldb.git>`_ is
-           recommended. The ``full-buffer`` branch of `this ultramysql
-           fork
-           <https://github.com/NextThought/ultramysql/tree/full-buffer>`_
-           is also recommended if you encounter strange MySQL packet
-           errors.
++----------+---------------------+---------------------+--------------+
+| Platform |  MySQL              |   PostgreSQL        |  Oracle      |
++==========+=====================+=====================+==============+
+| CPython2 |                     |  1. **psycopg2**    | **cx_Oracle**|
+|          | 1. **mysqlclient**  |  2. pg8000          |              |
+|          | 2. PyMySQL          |                     |              |
+|          | 3. umysqldb         |                     |              |
+|          | 4. MySQL Connector  |                     |              |
++----------+---------------------+---------------------+--------------+
+| CPython3 | 1. **mysqlclient**  |  1. **psycopg2**    | **cx_Oracle**|
+|          | 2. PyMySQL          |  2. pg8000          |              |
+|          | 3. MySQL Connector  |                     |              |
++----------+---------------------+---------------------+--------------+
+| PyPy     | 1. **PyMySQL**      | 1. **psycopg2cffi** |              |
+|          | 2. MySQL Connector  | 2.  pg8000          |              |
++----------+---------------------+---------------------+--------------+
 
-mysqlclient, pg8000 and umysql are compatible (cooperative) with gevent.
+
+mysqlclient, MySQL Connector/Python (without its C extension), pg8000
+and umysql are compatible (cooperative) with gevent.
+
+For additional details, see the "driver" section for each database in
+:doc:`db-specific-options`.
 
 Memcache Integration
 ====================

--- a/relstorage/_compat.py
+++ b/relstorage/_compat.py
@@ -13,6 +13,7 @@ import sys
 import platform
 
 PY3 = sys.version_info[0] == 3
+PY2 = not PY3
 PYPY = platform.python_implementation() == 'PyPy'
 
 # Dict support
@@ -66,7 +67,10 @@ if PY3:
     # buffer on Py3/Py2, respectively, for bytea columns
     _db_binary_types = (memoryview,)
 else:
-    _db_binary_types = (memoryview, buffer)
+    # MySQL Connector/Python returns bytearray, but only from
+    # the Python implementation; the C implementation returns
+    # bytes.
+    _db_binary_types = (memoryview, buffer, bytearray)
 
 def db_binary_to_bytes(data):
     if isinstance(data, _db_binary_types):

--- a/relstorage/_compat.py
+++ b/relstorage/_compat.py
@@ -78,17 +78,6 @@ def db_binary_to_bytes(data):
     return data
 
 
-# mysqlclient, a binary driver that works for Py2, Py3 and
-# PyPy (claimed), uses a connection that is a weakref. MySQLdb
-# and PyMySQL use a hard reference
-from weakref import ref as _wref
-def mysql_connection(cursor):
-    conn = cursor.connection
-    if isinstance(conn, _wref):
-        conn = conn()
-    return conn
-
-
 
 from ZODB._compat import BytesIO
 StringIO = BytesIO

--- a/relstorage/adapters/_abstract_drivers.py
+++ b/relstorage/adapters/_abstract_drivers.py
@@ -68,8 +68,14 @@ class _ConnWrapper(object): # pragma: no cover
             return
         return setattr(self.__conn, name, value)
 
-    def cursor(self):
-        return _ConnWrapper(self.__conn.cursor())
+    def cursor(self, *args, **kwargs):
+        return _ConnWrapper(self.__conn.cursor(*args, **kwargs))
+
+    def execute(self, op, args=None):
+        #print(op, args)
+        self.__conn.connection.handle_unread_result()
+        return self.__conn.execute(op, args)
+
 
     def __iter__(self):
         return self.__conn.__iter__()

--- a/relstorage/adapters/mover.py
+++ b/relstorage/adapters/mover.py
@@ -78,7 +78,7 @@ class AbstractObjectMover(object):
 
         cursor.execute(stmt, (oid,))
         if cursor.rowcount:
-            assert cursor.rowcount == 1
+            #assert cursor.rowcount == 1, cursor.rowcount
             state, tid = cursor.fetchone()
             state = db_binary_to_bytes(state)
             # If it's None, the object's creation has been

--- a/relstorage/adapters/mover.py
+++ b/relstorage/adapters/mover.py
@@ -77,9 +77,13 @@ class AbstractObjectMover(object):
         stmt = self._load_current_query
 
         cursor.execute(stmt, (oid,))
-        if cursor.rowcount:
-            #assert cursor.rowcount == 1, cursor.rowcount
-            state, tid = cursor.fetchone()
+        # Note that we cannot rely on cursor.rowcount being
+        # a valid indicator. The DB-API doesn't require it, and
+        # some implementations, like MySQL Connector/Python are
+        # unbuffered by default and can't provide it.
+        row = cursor.fetchone()
+        if row:
+            state, tid = row
             state = db_binary_to_bytes(state)
             # If it's None, the object's creation has been
             # undone.
@@ -102,9 +106,9 @@ class AbstractObjectMover(object):
         """
         stmt = self._load_revision_query
         cursor.execute(stmt, (oid, tid))
-        if cursor.rowcount:
-            assert cursor.rowcount == 1
-            (state,) = cursor.fetchone()
+        row = cursor.fetchone()
+        if row:
+            (state,) = row
             return db_binary_to_bytes(state)
         return None
 
@@ -120,7 +124,8 @@ class AbstractObjectMover(object):
         """Returns a true value if the given object exists."""
         stmt = self._exists_query
         cursor.execute(stmt, (oid,))
-        return cursor.rowcount
+        row = cursor.fetchone()
+        return row
 
     @metricmethod_sampled
     def load_before(self, cursor, oid, tid):
@@ -137,9 +142,9 @@ class AbstractObjectMover(object):
         LIMIT 1
         """
         cursor.execute(stmt, (oid, tid))
-        if cursor.rowcount:
-            assert cursor.rowcount == 1
-            state, tid = cursor.fetchone()
+        row = cursor.fetchone()
+        if row:
+            state, tid = row
             state = db_binary_to_bytes(state)
             # None in state means The object's creation has been undone
             return state, tid
@@ -162,9 +167,9 @@ class AbstractObjectMover(object):
         LIMIT 1
         """
         cursor.execute(stmt, (oid, tid))
-        if cursor.rowcount:
-            assert cursor.rowcount == 1
-            return cursor.fetchone()[0]
+        row = cursor.fetchone()
+        if row:
+            return row[0]
         else:
             return None
 

--- a/relstorage/adapters/mysql/drivers.py
+++ b/relstorage/adapters/mysql/drivers.py
@@ -146,7 +146,7 @@ else:
     @implementer(IDBDriver)
     class MySQLConnectorDriver(AbstractDriver):
         # See https://github.com/zodb/relstorage/issues/155
-        __name__ = "mysqlconnector"
+        __name__ = "MySQL Connector/Python"
 
         disconnected_exceptions, close_exceptions, lock_exceptions = _standard_exceptions(mysql.connector)
         use_replica_exceptions = (mysql.connector.OperationalError,)
@@ -197,17 +197,17 @@ else:
         preferred_driver_name = driver.__name__
 
     if driver.have_cext:
-        driver_map['c' + driver.__name__] = driver
+        driver_map['C ' + driver.__name__] = driver
 
         class PyMySQLConnectorDriver(MySQLConnectorDriver):
-            __name__ = 'py' + driver.__name__
+            __name__ = 'Py ' + driver.__name__
             have_cext = False
 
         driver = PyMySQLConnectorDriver()
         driver_map[driver.__name__] = driver
 
     else:
-        driver_map['py' + driver.__name__] = driver
+        driver_map['Py ' + driver.__name__] = driver
 
     del driver
 

--- a/relstorage/adapters/mysql/drivers.py
+++ b/relstorage/adapters/mysql/drivers.py
@@ -151,6 +151,7 @@ else:
         Binary = staticmethod(mysql.connector.Binary)
         _have_cext = mysql.connector.HAVE_CEXT
         _connect = staticmethod(mysql.connector.connect)
+
         def connect(self, *args, **kwargs):
             # It defaults to the (slow) pure-python version
             # NOTE: The C implementation doesn't support the prepared
@@ -172,7 +173,9 @@ else:
             con = self._connect(*args, **kwargs)
             if PY2:
                 con.set_unicode(False)
+
             return con
+            #return _ConnWrapper(con)
 
         def set_autocommit(self, conn, value):
             # We use a property instead of a method
@@ -185,7 +188,7 @@ else:
             # The C connection doesn't accept the 'prepared' keyword,
             # and if you try to use a prepared cursor with it, it doesn't
             # work correctly.
-            cursor = conn.cursor(buffered=True)
+            cursor = conn.cursor()
             if not hasattr(cursor, 'connection'):
                 # We depend on the reverse mapping in some places.
                 # The python implementation keeps a weakref proxy in

--- a/relstorage/adapters/mysql/locker.py
+++ b/relstorage/adapters/mysql/locker.py
@@ -68,6 +68,8 @@ class MySQLLocker(AbstractLocker):
     def release_commit_lock(self, cursor):
         stmt = "SELECT RELEASE_LOCK(CONCAT(DATABASE(), '.commit'))"
         cursor.execute(stmt)
+        row = cursor.fetchone() # stay in sync
+        assert row
 
     def hold_pack_lock(self, cursor):
         """Try to acquire the pack lock.
@@ -84,3 +86,5 @@ class MySQLLocker(AbstractLocker):
         """Release the pack lock."""
         stmt = "SELECT RELEASE_LOCK(CONCAT(DATABASE(), '.pack'))"
         cursor.execute(stmt)
+        row = cursor.fetchone() # stay in sync
+        assert row

--- a/relstorage/adapters/mysql/oidallocator.py
+++ b/relstorage/adapters/mysql/oidallocator.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 from ..oidallocator import AbstractOIDAllocator
 from ..interfaces import IOIDAllocator
 from zope.interface import implementer
-from relstorage._compat import mysql_connection
+
 from perfmetrics import metricmethod
 
 @implementer(IOIDAllocator)

--- a/relstorage/adapters/mysql/oidallocator.py
+++ b/relstorage/adapters/mysql/oidallocator.py
@@ -36,13 +36,11 @@ class MySQLOIDAllocator(AbstractOIDAllocator):
         """Return a sequence of new, unused OIDs."""
         stmt = "INSERT INTO new_oid VALUES ()"
         cursor.execute(stmt)
-        try:
-            # mysql connector extension
-            n = cursor.lastrowid
-        except AttributeError:
-            # mysqldb/mysqlclient extension.
-            conn = mysql_connection(cursor)
-            n = conn.insert_id()
+        # This is a DB-API extension. Fortunately, all
+        # supported drivers implement it. (In the past we used
+        # cursor.connection.insert_id(), which was specific to MySQLdb)
+        n = cursor.lastrowid
+
         if n % 100 == 0:
             # Clean out previously generated OIDs.
             stmt = "DELETE FROM new_oid WHERE zoid < %s"

--- a/relstorage/adapters/mysql/oidallocator.py
+++ b/relstorage/adapters/mysql/oidallocator.py
@@ -36,8 +36,13 @@ class MySQLOIDAllocator(AbstractOIDAllocator):
         """Return a sequence of new, unused OIDs."""
         stmt = "INSERT INTO new_oid VALUES ()"
         cursor.execute(stmt)
-        conn = mysql_connection(cursor)
-        n = conn.insert_id()
+        try:
+            # mysql connector extension
+            n = cursor.lastrowid
+        except AttributeError:
+            # mysqldb/mysqlclient extension.
+            conn = mysql_connection(cursor)
+            n = conn.insert_id()
         if n % 100 == 0:
             # Clean out previously generated OIDs.
             stmt = "DELETE FROM new_oid WHERE zoid < %s"

--- a/relstorage/adapters/mysql/stats.py
+++ b/relstorage/adapters/mysql/stats.py
@@ -31,6 +31,10 @@ class MySQLStats(AbstractStats):
         try:
             cursor.execute("SHOW TABLE STATUS")
             description = [i[0] for i in cursor.description]
+            # The MySQL connector C extension returns these as bytes
+            # on python 3
+            description = [x.decode('ascii') if not isinstance(x, str) else x
+                           for x in description]
             rows = cursor.fetchall()
         finally:
             self.connmanager.close(conn, cursor)

--- a/relstorage/adapters/txncontrol.py
+++ b/relstorage/adapters/txncontrol.py
@@ -70,6 +70,7 @@ class GenericTransactionControl(AbstractTransactionControl):
     and history-preserving storages that share a common syntax.
     """
 
+    # XXX: Use the query_property for this
     _GET_TID_HP = "SELECT MAX(tid) FROM transaction"
     _GET_TID_HF = "SELECT MAX(tid) FROM object_state"
 
@@ -86,12 +87,12 @@ class GenericTransactionControl(AbstractTransactionControl):
 
     def get_tid(self, cursor):
         cursor.execute(self._get_tid_stmt)
-        if not cursor.rowcount:
+        row = cursor.fetchone()
+        if not row:
             # nothing has been stored yet
             return 0
 
-        assert cursor.rowcount == 1
-        tid = cursor.fetchone()[0]
+        tid = row[0]
         return tid if tid is not None else 0
 
 

--- a/relstorage/tests/testpostgresql.py
+++ b/relstorage/tests/testpostgresql.py
@@ -174,8 +174,8 @@ def test_suite():
     suite.addTest(unittest.makeSuite(HPPostgreSQLDestZODBConvertTests))
     suite.addTest(unittest.makeSuite(HPPostgreSQLSrcZODBConvertTests))
 
-    from .util import RUNNING_ON_CI
-    if RUNNING_ON_CI or os.environ.get("RS_PG_SMALL_BLOB"):
+    from .util import USE_SMALL_BLOBS
+    if USE_SMALL_BLOBS:
         # Avoid creating 2GB blobs to be friendly to neighbors
         # and to run fast (2GB blobs take about 4 minutes on Travis
         # CI as-of June 2016)

--- a/relstorage/tests/util.py
+++ b/relstorage/tests/util.py
@@ -1,5 +1,5 @@
 import os
-
+import platform
 import unittest
 
 
@@ -37,3 +37,8 @@ if RUNNING_ON_TRAVIS:
             CACHE_MODULE_NAME = 'memcache'
         except ImportError:
             pass
+
+USE_SMALL_BLOBS = ((RUNNING_ON_CI # slow here
+                    or platform.system() == 'Darwin' # interactive testing
+                    or os.environ.get("RS_SMALL_BLOB")) # define
+                   and not os.environ.get('RS_LARGE_BLOB'))


### PR DESCRIPTION
See #155. This is a stricter driver and gets us in better compliance with the DB-API.

A few arguably unrelated cleanups are included.