### PR TITLE
Use InnoDB temp tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@
   <https://github.com/zopefoundation/ZODB/pull/140>`_ to older
   versions of ZODB. This improves write performance, especially in
   multi-threaded scenarios, by up to 10%. See :pr:`160`.
+- MySQL temporary tables now use the InnoDB engine instead of MyISAM.
+  See :pr:`162`.
 
 2.0.0 (2016-12-23)
 ==================


### PR DESCRIPTION
And truncate them.

For most things this seems to speed up writes by around 10% (or more!), possibly due
to the way the temp tables are allocated.

Tested against both MySQL 5.5 and 5.7.

I think the dropping was an attempt to make the tables statement-level
replication compatible, but since they weren't transactianal I don't
think that worked. They were also variable sized so I don't think there
were any speed benefits. It also didn't implicitly end the transaction,
but that's not a concern where this is called.

Here's a complete set of benchmarks against 5.7, comparing zodbshootout
with -c2 and -c6, -n 1000 and '-n 100 -s 256 --test-reps 200'. This
compares 2.0.0 with current master (45f3489b7533af6a61769a7aba19f499613b5e07) and this change, in that order.
```
** c=2,s=256 **                2.0.0   master   InnoDB
"Transaction",               mysql_hf
"Add 100 Objects",               8883     9199    10157
"Update 100 Objects",            9380     9169    10318

** c=6,s=256 **                 2.0.0    master   InnoDB
"Transaction",               mysql_hf
"Add 100 Objects",               ----     14913   15524
"Update 100 Objects",            ----     14914   15077

** c=6,s=128 **                 2.0.0    master   InnoDB
"Transaction",                mysql_hf
"Add 1000 Objects",              29815    31704    38506
"Update 1000 Objects",           28978    29030    29137
```

In all cases, InnoDB temp tables outperform, in some cases
substantially.

An earlier set of benchmarks taken against 5.5 (but prior to a rebase on
master, so not easily replicated). The absolute value difference in
numbers versus above is that these were taken with Py 3.4 while above
was py 2.7.

zodbshootout -c 2 shootout.conf -n 100 --test-reps 200 -r 1 -s 256
```
Before

** concurrency=2 **
"Transaction",               mysql_hf
"Add 100 Objects",               6493
"Update 100 Objects",            9636

** concurrency=6 **
"Transaction",               mysql_hf
"Add 100 Objects",              10574
"Update 100 Objects",           15492

After

** concurrency=2 **
"Transaction",               mysql_hf
"Add 100 Objects",               7079
"Update 100 Objects",            9782

c=6
** concurrency=6 **
"Transaction",               mysql_hf
"Add 100 Objects",              10612
"Update 100 Objects",           15789


zodbshootout -c 2 shootout.conf -n 100 --test-reps 200 -r 1 -s 96

Before
** concurrency=2 **
"Transaction",               mysql_hf
"Add 100 Objects",              15547
"Update 100 Objects",           14337

After
"Transaction",               mysql_hf
"Add 100 Objects",              16968
"Update 100 Objects",           16184
```