### PR TITLE
Test on ZODB 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,10 @@ matrix:
     - python: 3.5
       env: ENV=mysql
     - python: 2.7
-      env: ENV=mysql
+      env:
+        - ENV=mysql
+        - OLDZODB=true
+
     - python: pypy-5.4.1
       env: ENV=mysql
 
@@ -82,6 +85,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install -U pylibmc cffi; fi
   - pip install -U -e ".[test]"
   - .travis/setup-$ENV.sh
+  - if [[ $OLDZODB == true ]]; then .travis/setup-oldzodb.sh; fi
 
 cache: pip
 

--- a/.travis/setup-oldzodb.sh
+++ b/.travis/setup-oldzodb.sh
@@ -1,0 +1,2 @@
+pip uninstall -y ZODB ZEO transaction
+pip install "ZODB[test] == 4.4.3" "ZEO == 4.3.1" "transaction == 1.7.0"

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,11 +14,11 @@ supported platform (OS X, Windows or "manylinx"), you can get a
 pre-built binary wheel. If you install from source or on a different
 platform, you will need to have a functioning C compiler.
 
-RelStorage requires a modern version of ZODB; it is tested with ZODB
-4.3 and 5.0 but *might* work with ZODB as old as 3.10. If you need to
-use an older version of ZODB, install RelStorage 1.6. Likewise, if
-you need Python 2.6 support, install RelStorage 1.6 (note that 1.6
-*does not* run on Python 3 or PyPy).
+RelStorage requires a modern version of ZODB and ZEO; it is tested
+with ZODB 4.4 and 5.x and ZEO 4.3 and 5.x. If you need to use an older
+version of ZODB/ZEO, install RelStorage 1.6. Likewise, if you need
+Python 2.6 support, install RelStorage 1.6 (note that 1.6 *does not*
+run on Python 3 or PyPy).
 
 Database Adapter
 ================

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -256,6 +256,8 @@ class GenericRelStorageTests(
         finally:
             db.close()
 
+    @util.skipOnZODB4("ZODB/tests/StorageTestBase"
+                      "expects different results from handle_all_serials")
     def checkResolveConflictBetweenConnections(self):
         # Verify that conflict resolution works between storage instances
         # bound to connections.

--- a/relstorage/tests/util.py
+++ b/relstorage/tests/util.py
@@ -1,7 +1,7 @@
 import os
 import platform
 import unittest
-
+import pkg_resources
 
 # ZODB >= 3.9.  The blob directory can be a private cache.
 shared_blob_dir_choices = (False, True)
@@ -10,6 +10,9 @@ support_blob_cache = True
 RUNNING_ON_TRAVIS = os.environ.get('TRAVIS')
 RUNNING_ON_APPVEYOR = os.environ.get('APPVEYOR')
 RUNNING_ON_CI = RUNNING_ON_TRAVIS or RUNNING_ON_APPVEYOR
+
+# pylint:disable=no-member
+RUNNING_ON_ZODB4 = pkg_resources.get_distribution('ZODB').version[0] == '4'
 
 def _do_not_skip(reason): # pylint:disable=unused-argument
     def dec(f):
@@ -25,6 +28,11 @@ if RUNNING_ON_APPVEYOR:
     skipOnAppveyor = unittest.skip
 else:
     skipOnAppveyor = _do_not_skip
+
+if RUNNING_ON_ZODB4:
+    skipOnZODB4 = unittest.skip
+else:
+    skipOnZODB4 = _do_not_skip
 
 CACHE_SERVERS = None
 CACHE_MODULE_NAME = None

--- a/setup.py
+++ b/setup.py
@@ -125,22 +125,22 @@ setup(
             'cx_Oracle>=5.0.0'
         ],
         ":python_full_version >= '2.7.9'": [
-            'ZODB >= 4.4.2',
-            'ZEO >= 4.2.0',
+            'ZODB >= 4.4.3',
+            'ZEO >= 4.3.1',
         ],
         ":python_full_version == '3.6.0rc1'": [
             # For some reason ZEO isn't getting installed
             # on 3.6rc1/pip 9.0.1/tox 2.5.1. Looks like the
             # version selection <, >= environment markers aren't working.
             # So we give a full version spec, which seems to work.
-            'ZODB >= 4.4.2',
-            'ZEO >= 4.2.0',
+            'ZODB >= 4.4.3',
+            'ZEO >= 4.3.1',
         ],
         ":python_full_version < '2.7.9'": [
             # We must pin old versions prior to 2.7.9 because ZEO
             # 5 only runs on versions with good SSL support.
-            'ZODB >= 4.4.2, <5.0',
-            'ZEO >= 4.2.0, <5.0'
+            'ZODB >= 4.4.3, <5.0',
+            'ZEO >= 4.3.1, <5.0'
         ],
         'test': tests_require,
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-mysql,py27-postgres,pypy-mysql,pypy-postgres,py34-mysql,py34-postgres,py36-mysql,py36-postgres
+envlist = py27-mysql,py27-oldzodb,py27-postgres,pypy-mysql,pypy-postgres,py34-mysql,py34-postgres,py36-mysql,py36-postgres
 
 [testenv]
 # Our top-level 'relstorage' directory screws up imports.
@@ -9,12 +9,20 @@ deps =
      coverage
      .[test]
 commands =
-    coverage run -m relstorage.tests.alltests
+    coverage run -m relstorage.tests.alltests -f -v
 
 [testenv:py27-mysql]
 deps =
     .[mysql]
     {[testenv]deps}
+
+[testenv:py27-oldzodb]
+deps =
+    .[postgresql]
+    {[testenv]deps}
+    ZODB[test] == 4.4.3
+    ZEO == 4.3.1
+    transaction == 1.7.0
 
 [testenv:py27-postgres]
 deps =


### PR DESCRIPTION
Fixes #169.

We need this version for IMultiCommitStorage and the registerDB fix in
ConflictResolvingStorage. Since these versions run on Python 2.7.8,
there's no motivation for trying to go back farther.