### PR TITLE
Implement get_object_count exactly.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@
 - MySQL: Workaround a rare issue that could lead to a ``TypeError``
   when getting new OIDs. See :issue:`173`.
 
+- The ``len`` of a RelStorage instance now correctly reflects the
+  approximate number of objects in the database. Previously it
+  returned a hardcoded 0. See :issue:`178`.
+
 2.1a1 (2017-02-01)
 ==================
 

--- a/relstorage/adapters/mysql/adapter.py
+++ b/relstorage/adapters/mysql/adapter.py
@@ -160,6 +160,7 @@ class MySQLAdapter(object):
 
         self.stats = MySQLStats(
             connmanager=self.connmanager,
+            keep_history=self.keep_history
         )
 
     _get_latest_tid_queries = (

--- a/relstorage/adapters/mysql/stats.py
+++ b/relstorage/adapters/mysql/stats.py
@@ -20,11 +20,6 @@ from ..stats import AbstractStats
 
 class MySQLStats(AbstractStats):
 
-    def get_object_count(self):
-        """Returns the number of objects in the database"""
-        # do later
-        return 0
-
     def get_db_size(self):
         """Returns the approximate size of the database in bytes"""
         conn, cursor = self.connmanager.open()

--- a/relstorage/adapters/oracle/adapter.py
+++ b/relstorage/adapters/oracle/adapter.py
@@ -158,6 +158,7 @@ class OracleAdapter(object):
 
         self.stats = OracleStats(
             connmanager=self.connmanager,
+            keep_history=self.keep_history
         )
 
     def new_instance(self):

--- a/relstorage/adapters/oracle/stats.py
+++ b/relstorage/adapters/oracle/stats.py
@@ -19,31 +19,6 @@ from ..stats import AbstractStats
 
 class OracleStats(AbstractStats):
 
-    def get_object_count(self):
-        """Returns the number of objects in the database"""
-        # The tests expect an exact number, but the code below generates
-        # an estimate, so this is disabled for now.
-        return 0
-
-    def _estimate_object_count(self):
-        conn, cursor = self.connmanager.open(
-            self.connmanager.isolation_read_only)
-        try:
-            stmt = """
-            SELECT NUM_ROWS
-            FROM USER_TABLES
-            WHERE TABLE_NAME = 'CURRENT_OBJECT'
-            """
-            cursor.execute(stmt)
-            res = cursor.fetchone()[0]
-            if res is None:
-                res = 0
-            else:
-                res = int(res)
-            return res
-        finally:
-            self.connmanager.close(conn, cursor)
-
     def get_db_size(self):
         """Returns the approximate size of the database in bytes"""
         conn, cursor = self.connmanager.open(

--- a/relstorage/adapters/postgresql/adapter.py
+++ b/relstorage/adapters/postgresql/adapter.py
@@ -135,6 +135,7 @@ class PostgreSQLAdapter(object):
 
         self.stats = PostgreSQLStats(
             connmanager=self.connmanager,
+            keep_history=self.keep_history
         )
 
     _get_latest_tid_queries = (

--- a/relstorage/adapters/postgresql/stats.py
+++ b/relstorage/adapters/postgresql/stats.py
@@ -21,11 +21,6 @@ from ..stats import AbstractStats
 
 class PostgreSQLStats(AbstractStats):
 
-    def get_object_count(self):
-        """Returns the number of objects in the database"""
-        # do later
-        return 0
-
     def get_db_size(self):
         """Returns the approximate size of the database in bytes"""
         def callback(_conn, cursor):

--- a/relstorage/tests/reltestbase.py
+++ b/relstorage/tests/reltestbase.py
@@ -149,6 +149,21 @@ class GenericRelStorageTests(
         ReadOnlyStorage.ReadOnlyStorage,
     ):
 
+    def checkLen(self):
+        # Override the version from BasicStorage because we
+        # actually do guarantee to keep track of the counts.
+
+        # len(storage) reports the number of objects.
+        # check it is zero when empty
+        self.assertEqual(len(self._storage), 0)
+        # check it is correct when the storage contains two object.
+        # len may also be zero, for storages that do not keep track
+        # of this number
+        self._dostore(data=PersistentMapping())
+        self._dostore(data=PersistentMapping())
+        self.assertEqual(len(self._storage), 2)
+
+
     def checkDropAndPrepare(self):
         # Under PyPy, this test either takes a very long time (PyMySQL)
         # or hangs (psycopg2cffi) longer than I want to wait (10+ minutes).


### PR DESCRIPTION
Fixes #178.

Note this changes the constructor signature for the *Stats classes to take the `keep_history` flag.