### PR TITLE
Test compatibility with ZODB 5.2.2+

### DIFF
--- a/relstorage/tests/blob/testblob.py
+++ b/relstorage/tests/blob/testblob.py
@@ -33,6 +33,7 @@ import unittest
 import ZODB.blob
 import ZODB.interfaces
 from relstorage.tests.RecoveryStorage import IteratorDeepCompare
+from relstorage.tests.util import SUPPORTS_BLOB_PERMS
 import ZODB.tests.StorageTestBase
 import ZODB.tests.util
 from zope.testing import renormalizing
@@ -398,54 +399,81 @@ def packing_with_uncommitted_data_undoing():
     >>> blob_storage.close()
     """
 
+if SUPPORTS_BLOB_PERMS:
+    # ZODB < 5.2.2
+    def secure_blob_directory():
+        """
+        This is a test for secure creation and verification of secure settings of
+        blob directories.
 
-def secure_blob_directory():
-    """
-    This is a test for secure creation and verification of secure settings of
-    blob directories.
+        >>> blob_storage = create_storage(blob_dir='blobs')
 
-    >>> blob_storage = create_storage(blob_dir='blobs')
+        Two directories are created:
 
-    Two directories are created:
+        >>> os.path.isdir('blobs')
+        True
+        >>> tmp_dir = os.path.join('blobs', 'tmp')
+        >>> os.path.isdir(tmp_dir)
+        True
 
-    >>> os.path.isdir('blobs')
-    True
-    >>> tmp_dir = os.path.join('blobs', 'tmp')
-    >>> os.path.isdir(tmp_dir)
-    True
+        They are only accessible by the owner:
 
-    They are only accessible by the owner:
+        >>> os.stat('blobs').st_mode
+        16832
+        >>> os.stat(tmp_dir).st_mode
+        16832
 
-    >>> os.stat('blobs').st_mode
-    16832
-    >>> os.stat(tmp_dir).st_mode
-    16832
+        These settings are recognized as secure:
 
-    These settings are recognized as secure:
+        >>> blob_storage.fshelper.isSecure('blobs')
+        True
+        >>> blob_storage.fshelper.isSecure(tmp_dir)
+        True
 
-    >>> blob_storage.fshelper.isSecure('blobs')
-    True
-    >>> blob_storage.fshelper.isSecure(tmp_dir)
-    True
+        After making the permissions of tmp_dir more liberal, the directory is
+        recognized as insecure:
 
-    After making the permissions of tmp_dir more liberal, the directory is
-    recognized as insecure:
+        >>> os.chmod(tmp_dir, 0o40711)
+        >>> blob_storage.fshelper.isSecure(tmp_dir)
+        False
 
-    >>> os.chmod(tmp_dir, 0o40711)
-    >>> blob_storage.fshelper.isSecure(tmp_dir)
-    False
+        Clean up:
 
-    Clean up:
+        >>> blob_storage.close()
 
-    >>> blob_storage.close()
+        """
 
-    """
+    # On windows, we can't create secure blob directories, at least not
+    # with APIs in the standard library, so there's no point in testing
+    # this.
+    if sys.platform == 'win32':
+        del secure_blob_directory
 
-# On windows, we can't create secure blob directories, at least not
-# with APIs in the standard library, so there's no point in testing
-# this.
-if sys.platform == 'win32':
-    del secure_blob_directory
+else:
+    def test_blob_file_permissions():
+        """
+        >>> blob_storage = create_storage()
+        >>> conn = ZODB.connection(blob_storage)
+        >>> conn.root.x = ZODB.blob.Blob(b'test')
+        >>> conn.transaction_manager.commit()
+
+        Blobs have the readability of their parent directories:
+
+        >>> import stat
+        >>> READABLE = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+        >>> path = conn.root.x.committed()
+        >>> ((os.stat(path).st_mode & READABLE) ==
+        ...  (os.stat(os.path.dirname(path)).st_mode & READABLE))
+        True
+
+        The committed file isn't writable:
+        >>> WRITABLE = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
+        >>> os.stat(path).st_mode & WRITABLE
+        0
+
+        >>> conn.close()
+        """
+
 
 def loadblob_tmpstore():
     """

--- a/relstorage/tests/util.py
+++ b/relstorage/tests/util.py
@@ -12,7 +12,14 @@ RUNNING_ON_APPVEYOR = os.environ.get('APPVEYOR')
 RUNNING_ON_CI = RUNNING_ON_TRAVIS or RUNNING_ON_APPVEYOR
 
 # pylint:disable=no-member
-RUNNING_ON_ZODB4 = pkg_resources.get_distribution('ZODB').version[0] == '4'
+zodb_dist = pkg_resources.get_distribution('ZODB')
+zodb_dist_version = pkg_resources.parse_version(zodb_dist.version)
+RUNNING_ON_ZODB4 = zodb_dist.version[0] == '4'
+
+# Unfortunately there's no way to detect this short of running the
+# code and getting the runtime warning. So we do version detection
+# instead.
+SUPPORTS_BLOB_PERMS = zodb_dist_version < pkg_resources.parse_version('5.2.2')
 
 def _do_not_skip(reason): # pylint:disable=unused-argument
     def dec(f):
@@ -33,6 +40,7 @@ if RUNNING_ON_ZODB4:
     skipOnZODB4 = unittest.skip
 else:
     skipOnZODB4 = _do_not_skip
+
 
 CACHE_SERVERS = None
 CACHE_MODULE_NAME = None


### PR DESCRIPTION
Because it did break a test, as mentioned in
https://github.com/zopefoundation/ZODB/pull/156

This copies the new test for 5.2.2+ and leaves the old test for older versions.