### PR TITLE
 Rename column transaction.empty to transaction.is_empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 language: python
 dist: xenial
 group: travis_latest
-python:
-  - 2.7
-  - 3.5
-  - 3.6
-  - 3.7
-  - pypy
-  - pypy3
-
 services:
   - mysql
   - postgresql
@@ -19,7 +11,24 @@ addons:
 # Use postgresql 9.5 to get support for INSERT ON CONFLICT UPDATE
 # Use postgresql 9.6 ... just because
   postgresql: "9.6"
+# The default mysql is 5.7; we have a specific test for 8.0.
 
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+    - python: pypy
+    - python: pypy3
+    - python: 3.7
+      services:
+        - docker
+        - postgresql
+        - memcached
+      before_install:
+        - docker pull mysql:8.0
+        - docker run -d --publish 3306:3306 --rm --name mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8.0
+        - cp .travis/docker.cnf ~/.my.cnf
 env:
     global:
         - PYTHONHASHSEED=8675309
@@ -45,6 +54,7 @@ before_install:
   - python --version
 before_script:
   - ccache -s
+  - mysql -uroot -e 'select version()'
 
 install:
   - pip install -U pip

--- a/.travis/docker.cnf
+++ b/.travis/docker.cnf
@@ -1,0 +1,4 @@
+[client]
+host = 127.0.0.1
+port = 3306
+protocol = tcp

--- a/.travis/mysql.sh
+++ b/.travis/mysql.sh
@@ -1,10 +1,17 @@
-mysql -uroot -e "CREATE USER 'relstoragetest'@'localhost' IDENTIFIED BY 'relstoragetest';"
-mysql -uroot -e "CREATE DATABASE relstoragetest;"
-mysql -uroot -e "GRANT ALL ON relstoragetest.* TO 'relstoragetest'@'localhost';"
-mysql -uroot -e "CREATE DATABASE relstoragetest2;"
-mysql -uroot -e "GRANT ALL ON relstoragetest2.* TO 'relstoragetest'@'localhost';"
-mysql -uroot -e "CREATE DATABASE relstoragetest_hf;"
-mysql -uroot -e "GRANT ALL ON relstoragetest_hf.* TO 'relstoragetest'@'localhost';"
-mysql -uroot -e "CREATE DATABASE relstoragetest2_hf;"
-mysql -uroot -e "GRANT ALL ON relstoragetest2_hf.* TO 'relstoragetest'@'localhost';"
-mysql -uroot -e "FLUSH PRIVILEGES;"
+# To be able to successfully test against a MySQL on a different host,
+# it's best to set up a proxy: socat tcp-listen:3306,reuseaddr,fork tcp:192.168.99.100:3306
+# This can arise when running mysql in docker on macOS, which doesn't
+# correctly handle the `docker run` `-p` option to forward ports to the local host;
+# specify the address of the virtual machine.
+# docker run  --publish 3306:3306 --rm --name mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8.0
+HOST="-h ${RS_DB_HOST-localhost}"
+mysql -uroot $HOST -e "CREATE USER 'relstoragetest' IDENTIFIED BY 'relstoragetest';"
+mysql -uroot $HOST -e "CREATE DATABASE relstoragetest;"
+mysql -uroot $HOST -e "GRANT ALL ON relstoragetest.* TO 'relstoragetest';"
+mysql -uroot $HOST -e "CREATE DATABASE relstoragetest2;"
+mysql -uroot $HOST -e "GRANT ALL ON relstoragetest2.* TO 'relstoragetest';"
+mysql -uroot $HOST -e "CREATE DATABASE relstoragetest_hf;"
+mysql -uroot $HOST -e "GRANT ALL ON relstoragetest_hf.* TO 'relstoragetest';"
+mysql -uroot $HOST -e "CREATE DATABASE relstoragetest2_hf;"
+mysql -uroot $HOST -e "GRANT ALL ON relstoragetest2_hf.* TO 'relstoragetest';"
+mysql -uroot $HOST -e "FLUSH PRIVILEGES;"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,10 @@
 
   .. note:: This migration has not been tested for Oracle.
 
+- Stop getting a warning about invalid optimizer syntax when packing a
+  MySQL database (especially with the PyMySQL driver). See
+  :issue:`163`.
+
 2.1.1 (2019-01-07)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,12 @@
 
   .. note:: This migration has not been tested for Oracle.
 
+  .. note:: You must run this migration *before* attempting to upgrade
+            a MySQL 5 database to MySQL 8. If you cannot run the
+            upgrade through opening the storage, the statement is
+            ``ALTER TABLE transaction CHANGE empty is_empty BOOLEAN
+            NOT NULL DEFAULT FALSE``.
+
 - Stop getting a warning about invalid optimizer syntax when packing a
   MySQL database (especially with the PyMySQL driver). See
   :issue:`163`.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,12 @@
 - Make driver names in RelStorage configurations case-insensitive
   (e.g., 'MySQLdb' and 'mysqldb' are both valid). See :issue:`227`.
 
+- Rename the column ``transaction.empty`` to ``transaction.is_empty``
+  for compatibility with MySQL 8.0, where ``empty`` is now a reserved
+  word. The migration will happen automatically when a storage is
+  first opened, unless it is configured not to create the schema.
+
+  .. note:: This migration has not been tested for Oracle.
 
 2.1.1 (2019-01-07)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 
 RelStorage is a storage implementation for ZODB that stores pickles in
 a relational database. PostgreSQL 9.0 and above (performance is best
-with 9.5 and above), MySQL 5.0.32+ / 5.1.34+, and Oracle 10g and 11g
+with 9.5 and above), MySQL 5.7 / 8.0, and Oracle 10g and 11g
 are currently supported. RelStorage replaced the PGStorage project.
 
 

--- a/docs/db-specific-options.rst
+++ b/docs/db-specific-options.rst
@@ -126,6 +126,15 @@ driver
       The same as above, but RelStorage will only use the C extension.
       This is not compatible with gevent.
 
+      .. note::
+
+         At least through version 8.0.16, this is not compatible with
+         `CPython 3.7's development mode
+         <https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDEVMODE>`_;
+         trying to use it with development mode enabled will crash the
+         interpreter with "Fatal Python error: Python memory allocator
+         called without holding the GIL."
+
 host
     string, host to connect
 

--- a/src/relstorage/adapters/mysql/packundo.py
+++ b/src/relstorage/adapters/mysql/packundo.py
@@ -53,12 +53,12 @@ class MySQLHistoryPreservingPackUndo(HistoryPreservingPackUndo):
         DELETE FROM object_refs_added
         USING object_refs_added
             JOIN transaction USING (tid)
-        WHERE transaction.empty = true;
+        WHERE transaction.is_empty = true;
 
         DELETE FROM object_ref
         USING object_ref
             JOIN transaction USING (tid)
-        WHERE transaction.empty = true
+        WHERE transaction.is_empty = true
         """
 
     _script_create_temp_undo = """
@@ -72,7 +72,7 @@ class MySQLHistoryPreservingPackUndo(HistoryPreservingPackUndo):
     _script_delete_empty_transactions_batch = """
         DELETE FROM transaction
         WHERE packed = %(TRUE)s
-          AND empty = %(TRUE)s
+          AND is_empty = %(TRUE)s
         LIMIT 1000
         """
 

--- a/src/relstorage/adapters/mysql/schema.py
+++ b/src/relstorage/adapters/mysql/schema.py
@@ -64,10 +64,13 @@ class MySQLSchemaInstaller(AbstractSchemaInstaller):
 
     # As usual, MySQL has an annoying implementation of this and we
     # have to re-specify *everything* about the column.
-    _rename_transaction_empty_stmt = """
-        ALTER TABLE transaction CHANGE empty is_empty
-        BOOLEAN NOT NULL DEFAULT FALSE
-    """
+    # Careful: Some database versions and driver combos (MySQL 8 with PyMySQL)
+    # are very sensitive to newlines and will fail if they are included in this statement.
+    _rename_transaction_empty_stmt = (
+        "ALTER TABLE transaction CHANGE empty is_empty "
+        "BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+
 
     def _create_new_oid(self, cursor):
         stmt = """

--- a/src/relstorage/adapters/mysql/schema.py
+++ b/src/relstorage/adapters/mysql/schema.py
@@ -63,9 +63,8 @@ class MySQLSchemaInstaller(AbstractSchemaInstaller):
     TRANSACTIONAL_TABLE_SUFFIX = 'ENGINE = InnoDB'
 
     # As usual, MySQL has an annoying implementation of this and we
-    # have to re-specify *everything* about the column.
-    # Careful: Some database versions and driver combos (MySQL 8 with PyMySQL)
-    # are very sensitive to newlines and will fail if they are included in this statement.
+    # have to re-specify *everything* about the column. MySQL 8 supports the
+    # simple 'RENAME ... TO ... syntax that everyone else does.
     _rename_transaction_empty_stmt = (
         "ALTER TABLE transaction CHANGE empty is_empty "
         "BOOLEAN NOT NULL DEFAULT FALSE"

--- a/src/relstorage/adapters/oracle/packundo.py
+++ b/src/relstorage/adapters/oracle/packundo.py
@@ -25,6 +25,14 @@ def _oracle_fetchmany(self, cursor): # pylint:disable=unused-argument
     # See https://github.com/zodb/relstorage/issues/30
     return cursor
 
+
+
+# Oracle fails to notice that pack_object is now filled and chooses
+# the wrong execution plan, completely killing this query on large
+# RelStorage databases, unless these hints are included.
+_oracle_traverse_graph_optimizer_hint = "/*+ FULL(object_ref) FULL(pack_object) */"
+
+
 class OracleHistoryPreservingPackUndo(HistoryPreservingPackUndo):
 
     _script_choose_pack_transaction = """
@@ -62,6 +70,8 @@ class OracleHistoryPreservingPackUndo(HistoryPreservingPackUndo):
     # tests don't fail without it.
     _fetchmany = _oracle_fetchmany
 
+    _traverse_graph_optimizer_hint = _oracle_traverse_graph_optimizer_hint
+
 
 class OracleHistoryFreePackUndo(HistoryFreePackUndo):
 
@@ -75,3 +85,4 @@ class OracleHistoryFreePackUndo(HistoryFreePackUndo):
     _script_create_temp_pack_visit = None
 
     _fetchmany = _oracle_fetchmany
+    _traverse_graph_optimizer_hint = _oracle_traverse_graph_optimizer_hint

--- a/src/relstorage/adapters/oracle/schema.py
+++ b/src/relstorage/adapters/oracle/schema.py
@@ -227,7 +227,7 @@ class OracleSchemaInstaller(AbstractSchemaInstaller):
             CREATE TABLE transaction (
                 tid         NUMBER(20) NOT NULL PRIMARY KEY,
                 packed      CHAR DEFAULT 'N' CHECK (packed IN ('N', 'Y')),
-                empty       CHAR DEFAULT 'N' CHECK (empty IN ('N', 'Y')),
+                is_empty    CHAR DEFAULT 'N' CHECK (empty IN ('N', 'Y')),
                 username    RAW(500),
                 description RAW(2000),
                 extension   RAW(2000)

--- a/src/relstorage/adapters/packundo.py
+++ b/src/relstorage/adapters/packundo.py
@@ -232,13 +232,13 @@ class HistoryPreservingPackUndo(PackUndo):
         WHERE tid IN (
             SELECT tid
             FROM transaction
-            WHERE empty = %(TRUE)s
+            WHERE is_empty = %(TRUE)s
             );
         DELETE FROM object_ref
         WHERE tid IN (
             SELECT tid
             FROM transaction
-            WHERE empty = %(TRUE)s
+            WHERE is_empty = %(TRUE)s
             )
         """
 
@@ -249,7 +249,7 @@ class HistoryPreservingPackUndo(PackUndo):
         WHERE tid = any(array(
             SELECT tid FROM transaction
             WHERE packed = %(TRUE)s
-              AND empty = %(TRUE)s
+              AND is_empty = %(TRUE)s
             LIMIT 1000
         ))
         """
@@ -775,10 +775,10 @@ class HistoryPreservingPackUndo(PackUndo):
 
         # mark the transaction packed and possibly empty
         if empty:
-            clause = 'empty = %(TRUE)s'
+            clause = 'is_empty = %(TRUE)s'
             state = 'empty'
         else:
-            clause = 'empty = %(FALSE)s'
+            clause = 'is_empty = %(FALSE)s'
             state = 'not empty'
         stmt = "UPDATE transaction SET packed = %(TRUE)s, " + clause
         stmt += " WHERE tid = %(tid)s"

--- a/src/relstorage/adapters/postgresql/schema.py
+++ b/src/relstorage/adapters/postgresql/schema.py
@@ -204,20 +204,6 @@ class PostgreSQLSchemaInstaller(AbstractSchemaInstaller):
     def _create_pack_lock(self, cursor):
         return
 
-    def _create_transaction(self, cursor):
-        if self.keep_history:
-            stmt = """
-            CREATE TABLE transaction (
-                tid         BIGINT NOT NULL PRIMARY KEY,
-                packed      BOOLEAN NOT NULL DEFAULT FALSE,
-                empty       BOOLEAN NOT NULL DEFAULT FALSE,
-                username    BYTEA NOT NULL,
-                description BYTEA NOT NULL,
-                extension   BYTEA
-            );
-            """
-            self.runner.run_script(cursor, stmt)
-
     def _create_new_oid(self, cursor):
         stmt = """
         CREATE SEQUENCE zoid_seq;

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -82,12 +82,14 @@ class AbstractSchemaInstaller(ABC):
         return value
 
     def _column_descriptions(self, cursor):
-
+        __traceback_info__ = cursor.description
         return [ResultDescription(self._metadata_to_native_str(r[0]),
                                   # Not all drivers return lists or tuples
                                   # or things that can be sliced; psycopg2/cffi returns
                                   # an arbitrary sequence.
-                                  *list(r)[1:])
+                                  # MySqlConnector-Python has been observed to provide
+                                  # extra attributes.
+                                  *list(r)[1:7])
                 for r in cursor.description]
 
     def _rows_as_dicts(self, cursor):

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -16,6 +16,7 @@ Database schema installers
 """
 import abc
 import logging
+from collections import namedtuple
 
 from ZODB.POSException import StorageError
 
@@ -23,6 +24,13 @@ from .._compat import ABC
 
 log = logging.getLogger("relstorage")
 
+ResultDescription = namedtuple(
+    'ResultDescription',
+    # First two are mandatory, remaining five may be None
+    # Example:
+    # ('Name', 253, 17, 192, 192, 0, 0),
+    ('name', 'type_code', 'display_size',
+     'internal_size', 'precision', 'scale', 'null_ok'))
 
 class AbstractSchemaInstaller(ABC):
 
@@ -64,6 +72,41 @@ class AbstractSchemaInstaller(ABC):
     @abc.abstractmethod
     def get_database_name(self, cursor):
         raise NotImplementedError()
+
+    def _metadata_to_native_str(self, value):
+        # Some drivers, in some configurations, notably older versions
+        # of MySQLdb (mysqlclient) on Python 3 in 'NAMES binary' mode,
+        # can return column names and the like as bytes when we want str.
+        if not isinstance(value, str):
+            value = value.decode('ascii')
+        return value
+
+    def _column_descriptions(self, cursor):
+
+        return [ResultDescription(self._metadata_to_native_str(r[0]),
+                                  # Not all drivers return lists or tuples
+                                  # or things that can be sliced; psycopg2/cffi returns
+                                  # an arbitrary sequence.
+                                  *list(r)[1:])
+                for r in cursor.description]
+
+    def _rows_as_dicts(self, cursor):
+        """
+        An iterator of the rows as dictionaries, named by the
+        lower-case column name.
+
+        Some drivers offer the ability to do this directly when
+        the statement is executed or the cursor is created;
+        this is a lowest-common denominator way to do it utilizing
+        DB-API 2.0 attributes.
+        """
+        column_descrs = self._column_descriptions(cursor)
+        for row in cursor:
+            result = {
+                column_descr.name.lower(): column_value
+                for column_descr, column_value in zip(column_descrs, row)
+            }
+            yield result
 
     @abc.abstractmethod
     def _create_commit_lock(self, cursor):
@@ -294,8 +337,40 @@ class AbstractSchemaInstaller(ABC):
                 "See migration instructions for RelStorage 1.5."
             )
 
-    def update_schema(self, cursor, tables):
-        pass
+    def update_schema(self, cursor, tables): # pylint:disable=unused-argument
+        """
+        Perform any migration steps that are needed to make a schema
+        that has already been created some time in the past match
+        what would currently be installed.
+
+        Subclasses may override.
+        """
+
+        # Currently we only take care of renaming the `transaction.empty`
+        # column (from RelStorage 2.x and earlier) to `transaction.is_empty`
+        # as used in RelStorage 3.x.
+        if self._needs_transaction_empty_update(cursor):
+            cursor.execute(self._rename_transaction_empty_stmt)
+
+    def _needs_transaction_empty_update(self, cursor):
+        # Get a description of the table, but don't actually return
+        # any rows.
+        if not self.keep_history:
+            return False
+
+        cursor.execute('SELECT * FROM transaction WHERE tid < 0')
+
+        columns = self._column_descriptions(cursor)
+        for column_descr in columns:
+            if column_descr.name.lower() == 'is_empty':
+                # Yay, nothing to do.
+                return False
+
+        # If we get here, the is_empty column isn't present.
+        # Must rename it.
+        return True
+
+    _rename_transaction_empty_stmt = 'ALTER TABLE transaction RENAME COLUMN empty TO is_empty'
 
     _zap_all_tbl_stmt = 'DELETE FROM %s'
 

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -363,6 +363,10 @@ class AbstractSchemaInstaller(ABC):
         cursor.execute('SELECT * FROM transaction WHERE tid < 0')
 
         columns = self._column_descriptions(cursor)
+        # Make sure to read the (empty) result, some drivers (CMySQLConnector)
+        # are picky about that and won't let you close a cursore without reading
+        # everything.
+        cursor.fetchall()
         for column_descr in columns:
             if column_descr.name.lower() == 'is_empty':
                 # Yay, nothing to do.

--- a/src/relstorage/tests/hptestbase.py
+++ b/src/relstorage/tests/hptestbase.py
@@ -319,7 +319,15 @@ class HistoryPreservingRelStorageTests(GenericRelStorageTests,
         stmt = stmt.replace('empty', 'is_empty')
         stmt = stmt.replace("FOOBAR", 'empty')
 
-        test_cursor.execute(stmt)
+        __traceback_info__ = stmt
+        try:
+            test_cursor.execute(stmt)
+        except Exception as e:
+            # XXX: This should be more strict. We really just
+            # want to catch the db-api specific ProgrammingError,
+            # and only on MySQL 8.0+. But we don't have a good way to do that.
+            raise unittest.SkipTest(str(e))
+
         self.assertTrue(schema._needs_transaction_empty_update(test_cursor))
 
         schema.update_schema(test_cursor, None)

--- a/src/relstorage/tests/testmysql.py
+++ b/src/relstorage/tests/testmysql.py
@@ -109,7 +109,6 @@ class MySQLTestSuiteBuilder(AbstractTestSuiteBuilder):
                     base):
             @skipOnCI("Travis MySQL goes away error 2006")
             def check16MObject(self):
-                raise unittest.SkipTest("XXX")
                 # NOTE: If your mySQL goes away, check the server's value for
                 # `max_allowed_packet`, you probably need to increase it.
                 # JAM uses 64M.

--- a/src/relstorage/tests/testmysql.py
+++ b/src/relstorage/tests/testmysql.py
@@ -23,6 +23,7 @@ from relstorage.options import Options
 
 from .util import skipOnCI
 from .util import AbstractTestSuiteBuilder
+from .util import DEFAULT_DATABASE_SERVER_HOST
 
 
 class MySQLAdapterMixin(object):
@@ -41,17 +42,7 @@ class MySQLAdapterMixin(object):
             'db': dbname,
             'user': 'relstoragetest',
             'passwd': 'relstoragetest',
-            # mysqlclient (aka MySQLdb) and possibly other things that
-            # use libmysqlclient.so will try to connect over the
-            # default Unix socket that was established when that
-            # library was compiled if no host is given. But that
-            # server may not be running, or may not be the one we want
-            # to use for testing, so explicitly ask it to use TCP
-            # socket by giving an IP address (using 'localhost' will
-            # still try to use the socket.) (The TCP port can be bound
-            # by non-root, but the default Unix socket often requires
-            # root permissions to open.)
-            'host': '127.0.0.1',
+            'host': DEFAULT_DATABASE_SERVER_HOST,
         }
 
     def make_adapter(self, options, db=None):
@@ -118,6 +109,7 @@ class MySQLTestSuiteBuilder(AbstractTestSuiteBuilder):
                     base):
             @skipOnCI("Travis MySQL goes away error 2006")
             def check16MObject(self):
+                raise unittest.SkipTest("XXX")
                 # NOTE: If your mySQL goes away, check the server's value for
                 # `max_allowed_packet`, you probably need to increase it.
                 # JAM uses 64M.

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -52,6 +52,20 @@ USE_SMALL_BLOBS = ((RUNNING_ON_CI # slow here
                     or os.environ.get("RS_SMALL_BLOB")) # define
                    and not os.environ.get('RS_LARGE_BLOB'))
 
+# mysqlclient (aka MySQLdb) and possibly other things that
+# use libmysqlclient.so will try to connect over the
+# default Unix socket that was established when that
+# library was compiled if no host is given. But that
+# server may not be running, or may not be the one we want
+# to use for testing, so explicitly ask it to use TCP
+# socket by giving an IP address (using 'localhost' will
+# still try to use the socket.) (The TCP port can be bound
+# by non-root, but the default Unix socket often requires
+# root permissions to open.)
+DEFAULT_DATABASE_SERVER_HOST = os.environ.get('RS_DB_HOST',
+                                              '127.0.0.1')
+
+
 TEST_UNAVAILABLE_DRIVERS = not bool(os.environ.get('RS_SKIP_UNAVAILABLE_DRIVERS'))
 if RUNNING_ON_CI:
     TEST_UNAVAILABLE_DRIVERS = False


### PR DESCRIPTION
Fixes #201 

Includes an automatic migration when a storage is opened.

Adds testing with MySQL 8.0 (has to use docker for now, doesn't seem to be available natively on travis).

Also, since we were working on MySQL specific things, fix #163 