### PR TITLE
Add a MySQL driver that uses mysqlclient and explicitly waits using gevent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,10 @@
   MySQL database (especially with the PyMySQL driver). See
   :issue:`163`.
 
+- Add ``gevent MySQLdb``, a new driver that cooperates with gevent
+  while still using the C extensions of ``mysqlclient`` to communicate
+  with MySQL. This is now recommended over ``umysqldb``.
+
 2.1.1 (2019-01-07)
 ==================
 

--- a/docs/db-specific-options.rst
+++ b/docs/db-specific-options.rst
@@ -72,22 +72,32 @@ driver
     MySQLdb
       A C-based driver that requires the MySQL client development
       libraries.. This is best provided by the PyPI distribution
-      `mysqlclient <https://pypi.python.org/pypi/mysqlclient>`_. (It
-      can also be provided by the legacy `MySQL-python
-      <https://pypi.python.org/pypi/MySQL-python/>`_ distribution,
-      but only on CPython 2; this distribution is no longer tested.)
-      These drivers are *not* compatible with gevent.
+      `mysqlclient <https://pypi.python.org/pypi/mysqlclient>`_.
+      This driver is *not* compatible with gevent.
+
+    gevent MySQLdb
+      Like ``MySQLdb``, but explicitly uses's gevent's event loop to
+      avoid blocking on the socket as much as possible when
+      communicating with MySQL.
+
+      Note that this is fairly coarse-grained: When sending a query,
+      we can only yield until the socket is ready to write, and then
+      we must write the entire query (because that portion is
+      implemented in C). Likewise, we can only yield until results are
+      ready to be read, and then we must read the entire query.
 
     PyMySQL
       A pure-Python driver provided by the distribution of the same
       name. It works with CPython 2 and 3 and PyPy (where it is
-      preferred). It is compatible with gevent.
+      preferred). It is compatible with gevent if gevent's
+      monkey-patching is used.
 
     umysqldb
       A C-based driver that builds on PyMySQL. It is compatible with
-      gevent, but only works on CPython 2. It does not require the
-      MySQL client development libraries but uses a project called
-      ``umysql`` to communicate with the server using only sockets.
+      gevent if monkey-patching is used, but only works on CPython 2.
+      It does not require the MySQL client development libraries but
+      uses a project called ``umysql`` to communicate with the server
+      using only sockets.
 
       .. note:: Make sure the server has a
           ``max_allowed_packet`` setting no larger than 16MB. Also

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -80,8 +80,10 @@ bold** are the recommended adapter.
    +----------+---------------------+---------------------+--------------+
 
 
-mysqlclient, MySQL Connector/Python (without its C extension), pg8000
-and umysql are compatible (cooperative) with gevent without any extra effort.
+mysqlclient can be used with gevent by explicitly choosing a
+gevent-aware driver. PyMySQL, MySQL Connector/Python (without its C
+extension), pg8000 and umysql are compatible (cooperative) with gevent
+when the system is monkey-patched.
 
 For additional details and warnings, see the "driver" section for each database in
 :doc:`db-specific-options`.

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ tests_require = [
     'zc.zlibstorage',
     'zope.testrunner',
     'nti.testing',
+    'gevent >= 1.5a1',
 ] + memcache_require
 
 

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -23,6 +23,7 @@ from zope.interface import Interface
 class IRelStorageAdapter(Interface):
     """A database adapter for RelStorage"""
 
+    driver = Attribute("The IDBDriver being used")
     connmanager = Attribute("An IConnectionManager")
     dbiter = Attribute("An IDatabaseIterator")
     keep_history = Attribute("True if this adapter supports undo")

--- a/src/relstorage/adapters/mysql/adapter.py
+++ b/src/relstorage/adapters/mysql/adapter.py
@@ -93,7 +93,7 @@ class MySQLAdapter(object):
         self.keep_history = options.keep_history
         self._params = params
 
-        driver = select_driver(options)
+        self.driver = driver = select_driver(options)
         log.debug("Using driver %r", driver)
 
         self.connmanager = MySQLdbConnectionManager(

--- a/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
@@ -44,10 +44,8 @@ class PyMySQLConnectorDriver(AbstractMySQLDriver):
     USE_PURE = True
 
     _CONVERTER_CLASS = None
-
-    def __init__(self):
-        super(PyMySQLConnectorDriver, self).__init__()
-        del self.connect
+    _GEVENT_CAPABLE = True
+    _GEVENT_NEEDS_SOCKET_PATCH = True
 
     @classmethod
     def _get_converter_class(cls):
@@ -112,7 +110,7 @@ class PyMySQLConnectorDriver(AbstractMySQLDriver):
 
         return cls._CONVERTER_CLASS
 
-    def connect(self, *args, **kwargs): # pylint:disable=method-hidden
+    def connect(self, *args, **kwargs):
         # It defaults to the (slower) pure-python version prior to 8.0.11.
         # NOTE: The C implementation doesn't support the prepared
         # operations.
@@ -146,6 +144,7 @@ class CMySQLConnectorDriver(PyMySQLConnectorDriver):
     PRIORITY_PYPY = 4
 
     USE_PURE = False
+    _GEVENT_CAPABLE = False
 
     def get_driver_module(self):
         mod = super(CMySQLConnectorDriver, self).get_driver_module()

--- a/src/relstorage/adapters/mysql/drivers/mysqldb.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqldb.py
@@ -57,31 +57,39 @@ class GeventMySQLdbDriver(MySQLdbDriver):
     _wait_write = None
 
     def get_driver_module(self):
-        # pylint:disable=no-member
-        from gevent import socket
-        self._wait_read = socket.wait_read
-        self._wait_write = socket.wait_write
+        __import__('gevent')
         return super(GeventMySQLdbDriver, self).get_driver_module()
 
+    _Connection = None
+
+    @classmethod
+    def _get_connection_class(cls):
+        if cls._Connection is None:
+            # pylint:disable=import-error,no-name-in-module
+            from MySQLdb.connections import Connection as Base
+
+            from gevent import socket
+            wait_read = socket.wait_read # pylint:disable=no-member
+            wait_write = socket.wait_write # pylint:disable=no-member
+
+            class Connection(Base):
+                def query(self, query):
+                    # From the mysqlclient implementation:
+                    # "Since _mysql releases the GIL while querying, we need immutable buffer"
+                    if isinstance(query, bytearray):
+                        query = bytes(query)
+
+                    fileno = self.fileno()
+                    wait_write(fileno)
+                    self.send_query(query)
+                    wait_read(fileno)
+                    self.read_query_result()
+
+            cls._Connection = Connection
+        return cls._Connection
+
     def connect(self, *args, **kwargs):
-        # Prior to mysqlclient 1.4, there was a 'waiter' option
-        # that could be used to do this, but it was removed. So we
-        # implement it ourself.
-        conn = super(GeventMySQLdbDriver, self).connect(*args, **kwargs)
-
-        def query(query):
-            # From the mysqlclient implementation:
-            # "Since _mysql releases the GIL while querying, we need immutable buffer"
-            if isinstance(query, bytearray):
-                query = bytes(query)
-            __traceback_info__ = query
-
-            fileno = conn.fileno()
-            self._wait_write(fileno)
-            conn.send_query(query)
-            self._wait_read(fileno)
-            conn.read_query_result()
-
-        conn.query = query
-
-        return conn
+        # Prior to mysqlclient 1.4, there was a 'waiter' Connection
+        # argument that could be used to do this, but it was removed.
+        # So we implement it ourself.
+        return self._get_connection_class()(*args, **kwargs)

--- a/src/relstorage/adapters/mysql/drivers/mysqldb.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqldb.py
@@ -92,4 +92,5 @@ class GeventMySQLdbDriver(MySQLdbDriver):
         # Prior to mysqlclient 1.4, there was a 'waiter' Connection
         # argument that could be used to do this, but it was removed.
         # So we implement it ourself.
-        return self._get_connection_class()(*args, **kwargs)
+        klass = self._get_connection_class()
+        return klass(*args, **kwargs) # pylint:disable=not-callable

--- a/src/relstorage/adapters/mysql/drivers/pymysql.py
+++ b/src/relstorage/adapters/mysql/drivers/pymysql.py
@@ -34,7 +34,8 @@ class PyMySQLDriver(AbstractMySQLDriver):
     MODULE_NAME = 'pymysql'
     PRIORITY = 2
     PRIORITY_PYPY = 1
-
+    _GEVENT_CAPABLE = True
+    _GEVENT_NEEDS_SOCKET_PATCH = True
 
     def __init__(self):
         super(PyMySQLDriver, self).__init__()

--- a/src/relstorage/adapters/oracle/adapter.py
+++ b/src/relstorage/adapters/oracle/adapter.py
@@ -67,7 +67,7 @@ class OracleAdapter(object):
         self.options = options
         self.keep_history = options.keep_history
 
-        driver = select_driver(options)
+        self.driver = driver = select_driver(options)
         log.debug("Using driver %s", driver)
 
         self.connmanager = CXOracleConnectionManager(

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -59,7 +59,7 @@ class PostgreSQLAdapter(object):
         self.keep_history = options.keep_history
         self.version_detector = PostgreSQLVersionDetector()
 
-        driver = select_driver(options)
+        self.driver = driver = select_driver(options)
         log.debug("Using driver %r", driver)
 
         self.connmanager = Psycopg2ConnectionManager(

--- a/src/relstorage/adapters/postgresql/drivers/pg8000.py
+++ b/src/relstorage/adapters/postgresql/drivers/pg8000.py
@@ -126,9 +126,11 @@ def _make_lobject_method_for_connection(self, binary):
 class PG8000Driver(AbstractModuleDriver):
     __name__ = 'pg8000'
     MODULE_NAME = __name__
-
     PRIORITY = 3
     PRIORITY_PYPY = 2
+
+    _GEVENT_CAPABLE = True
+    _GEVENT_NEEDS_SOCKET_PATCH = True
 
     def __init__(self):
         super(PG8000Driver, self).__init__()
@@ -138,12 +140,11 @@ class PG8000Driver(AbstractModuleDriver):
         # XXX: Testing. Can we remove?
         self.disconnected_exceptions += (AttributeError,)
         self._connect = self.driver_module.connect
-        del self.connect
 
     # For debugging
     _wrap = False
 
-    def connect(self, dsn): # pylint:disable=method-hidden
+    def connect(self, dsn): # pylint:disable=arguments-differ
         # Parse the DSN into parts to pass as keywords.
         # We don't do this psycopg2 because a real DSN supports more options than
         # we do and we don't want to limit it.

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -965,6 +965,17 @@ class GenericRelStorageTests(
         finally:
             db.close()
 
+    def checkGeventSwitchesOnOpen(self):
+        # We make some queries when we open; if the driver is gevent
+        # capable, that should switch.
+        driver = self._storage._adapter.driver
+        if not driver.gevent_cooperative():
+            raise unittest.SkipTest("Driver %s not gevent capable" % (driver,))
+
+        from gevent.util import assert_switches
+        with assert_switches():
+            self.open()
+
 
 class AbstractRSZodbConvertTests(StorageCreatingMixin,
                                  FSZODBConvertTests):


### PR DESCRIPTION
This gets gevent support with the C extensions too, and it works on Python 3. This will be the suggested replacement for umysqldb.

Shootout results are generally encouraging:

```
** Python 2.7
** concurrency=6 **
"Transaction",               pymysql, mysqlclient_gevent, umysqldb, mysqlclient
"Add 150 Objects",              7154,              11273,    12119,       49754
"Update 150 Objects",           6482,               9879,    10047,       48315
"Read 150 Warm Objects",       39542,              39877,    42419,      192250
"Read 150 Cold Objects",        3050,               6848,     7138,       26968
"Read 150 Hot Objects",        59940,              39632,    50354,      201426
"Read 150 Steamin' Objects",  257150,             179630,   347721,     1321244
```

I can't currently explain why 'Hot' shows a dip, though. It's repeatable and shows up under Python 3 also:
```
** Python 3.7
** concurrency=6 **
"Transaction",                pymysql, mysqlclient_gevent, mysqlclient
"Add 1000 Objects",              6340,              12432,       67710
"Update 1000 Objects",          10178,              17264,       70837
"Read 1000 Warm Objects",       15763,              13594,       38805
"Read 1000 Cold Objects",        4563,               7225,       32632
"Read 1000 Hot Objects",        54510,              34812,      189015
"Read 1000 Steamin' Objects",  660171,             504369,     3218145
```

Here's a concurrency of 1; the difference between `mysqlclient` and `mysqlclient_gevent` should capture the overhead we added (and note that the 'Hot' dip isn't present):
```
** Python 3.7
** concurrency=1 **
"Transaction",                pymysql, mysqlclient_gevent, mysqlclient
"Add 1000 Objects",              9122,              10912,       11571
"Update 1000 Objects",          10049,              12176,       12488
"Read 1000 Warm Objects",      284795,             551375,      534986
"Read 1000 Cold Objects",        1683,               3989,        4527
"Read 1000 Hot Objects",        30939,              32328,       30538
"Read 1000 Steamin' Objects",  731613,             941814,      902774
```

```
** Python 2.7
** concurrency=1 **
"Transaction",                mysqlclient_gevent, umysqldb, pymysql, mysqlclient
"Add 1000 Objects",                         8806,    13458,   10150,       13139
"Update 1000 Objects",                      7176,    12561,    9853,       11279
"Read 1000 Warm Objects",                 766671,   750807,  554957,      880387
"Read 1000 Cold Objects",                   5254,     6441,    3064,        7036
"Read 1000 Hot Objects",                    5611,     6458,    3210,        7149
"Read 1000 Steamin' Objects",            1300537,  1374428,  964559,     1629113
```