### PR TITLE
Simplify cache tracing and storing multiple states.

### DIFF
--- a/src/relstorage/cache/_statecache_wrappers.py
+++ b/src/relstorage/cache/_statecache_wrappers.py
@@ -1,0 +1,166 @@
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""
+Wrappers for IStateCache.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from zope import interface
+
+from relstorage.cache.interfaces import IStateCache
+
+@interface.implementer(IStateCache)
+class MultiStateCache(object):
+    """
+    A proxy that encapsulates the handling of a local and a global
+    cache.
+
+    This lets us write loop-free code in all cases in StorageCache,
+    but still use both local and global caches.
+
+    For the case that there's just a local cache, which is common and
+    semi-recommended, we can just use that object directly.
+    """
+
+    __slots__ = ('l', 'g')
+
+    def __init__(self, lcache, gcache):
+        self.l = lcache
+        self.g = gcache
+
+    def close(self):
+        if self.l is not None:
+            self.l.close()
+            self.g.close()
+            self.l = None
+            self.g = None
+
+    def flush_all(self):
+        self.l.flush_all()
+        self.g.flush_all()
+
+    def __getitem__(self, key):
+        result = self.l[key]
+        if not result:
+            result = self.g[key]
+            if result:
+                self.l[key] = result
+        return result
+
+    def __setitem__(self, key, value):
+        self.l[key] = value
+        self.g[key] = value
+
+    def __call__(self, oid, tid1, tid2):
+        result = self.l(oid, tid1, tid2)
+        if not result:
+            result = self.g(oid, tid1, tid2)
+            if result:
+                self.l[(oid, tid1)] = result
+        return result
+
+    def set_all_for_tid(self, tid_int, state_oid_iter):
+        # If the transaction was very large, it may have spilled
+        # over to disk, in which case we will need to read it
+        # again (but the second time it's probably at least in the OS's
+        # cache). Unless it was very, very large, it probably all winds
+        # up in our local cache; we could avoid the second disk read by
+        # making a note of (oid, tid) pairs and then pulling them back out
+        # of the local cache. (Indeed, simply calling list() to materialize
+        # the iterator is probably usually sufficient, except for those very, very
+        # large cases.)
+        self.l.set_all_for_tid(tid_int, state_oid_iter)
+        self.g.set_all_for_tid(tid_int, state_oid_iter)
+
+    # Unlike everything else, checkpoints are on the global
+    # client first and then the local one.
+
+    def get_checkpoints(self):
+        return self.g.get_checkpoints() or self.l.get_checkpoints()
+
+    def store_checkpoints(self, c0, c1):
+        # TODO: Is there really much value in storing the checkpoints
+        # globally (as opposed to just on a single process)?
+        self.g.store_checkpoints(c0, c1)
+        return self.l.store_checkpoints(c0, c1)
+
+    def updating_delta_map(self, deltas):
+        return self.l.updating_delta_map(deltas)
+
+@interface.implementer(IStateCache)
+class TracingStateCache(object):
+    """
+    An ``IStateCache`` implementation that handles tracing.`
+    """
+    __slots__ = ('cache', 'tracer', '_trace', '_trace_store_current')
+
+    def __init__(self, cache, tracer):
+        self.cache = cache
+        self.tracer = tracer
+        self._trace = tracer.trace
+        self._trace_store_current = tracer.trace_store_current
+
+    def __getattr__(self, name):
+        return getattr(self.cache, name)
+
+    def __getitem__(self, key):
+        oid_int, tid_int = key
+        cache_data = self.cache[key]
+        if cache_data:
+            # Note that we trace all cache hits, not just the local cache hit.
+            # This makes the simulation less useful, but the stats might still have
+            # value to people trying different tuning options manually.
+            self._trace(0x22, oid_int, tid_int, dlen=len(cache_data[0]))
+        else:
+            self._trace(0x20, oid_int)
+        return cache_data
+
+    def __setitem__(self, key, value):
+        oid_int, _ = key
+        state, tid_int = value
+        # Record this as a store into the cache, ZEO does.
+        self._trace(0x52, oid_int, tid_int, dlen=len(state) if state else 0)
+        self.cache[key] = value
+
+    def __call__(self, oid_int, tid1, tid2):
+        response = self.cache(oid_int, tid1, tid2)
+        if response:
+            state, actual_tid = response
+            self._trace(0x22, oid_int, actual_tid, dlen=len(state))
+        else:
+            self._trace(0x20, oid_int)
+        return response
+
+    def set_all_for_tid(self, tid_int, state_oid_iter):
+        self._trace_store_current(tid_int, state_oid_iter)
+        self.cache.set_all_for_tid(tid_int, state_oid_iter)
+
+    def updating_delta_map(self, deltas):
+        return _MapWrapper(self.cache.updating_delta_map(deltas),
+                           self._trace)
+
+
+class _MapWrapper(object):
+    # Every setitem generates 0x1c invalidate (hit, saving non-current)
+    __slots__ = ('data', 'get', 'trace')
+    def __init__(self, data, trace):
+        self.get = data.get
+        self.trace = trace
+        self.data = data
+
+    def __setitem__(self, oid_int, tid_int):
+        self.trace(0x1C, oid_int, tid_int)
+        self.data[oid_int] = tid_int

--- a/src/relstorage/cache/interfaces.py
+++ b/src/relstorage/cache/interfaces.py
@@ -73,9 +73,17 @@ class IStateCache(Interface):
         matches the value tid.
         """
 
-    def set_multi(keys_and_values):
+    def set_all_for_tid(tid_int, state_oid_iter):
         """
-        Given a mapping from keys to values, set them all.
+        Store the states for the ``(state, oid_int)`` pairs under
+        ``(oid_int, tid_int)`` keys.
+
+        The *state_oid_iter* is an **iteable** of ``(state, oid_int)`` pairs;
+        this method may choose to buffer a limited amount of those pairs before
+        passing them on to the underlying storage in a bulk group.
+
+        As an **iterable**, *state_oid_iter* may be consumed multiple
+        times.
         """
 
     def store_checkpoints(cp0_tid, cp1_tid):
@@ -99,6 +107,16 @@ class IStateCache(Interface):
         """
         Clear cached data.
         """
+
+    ##
+    # Methods that are here to assist with tracing.
+    ##
+
+    def updating_delta_map(oid_tid_map):
+        """
+        Return a new map that can (temporarily) observe set actions.
+        """
+
 
 class IPersistentCache(Interface):
     """

--- a/src/relstorage/cache/local_client.py
+++ b/src/relstorage/cache/local_client.py
@@ -24,7 +24,6 @@ from contextlib import closing
 
 from zope import interface
 
-from relstorage._compat import iteritems
 from relstorage._util import get_memory_usage
 from relstorage._util import byte_display
 from relstorage._util import timer as _timer
@@ -237,9 +236,9 @@ class LocalClient(object):
             if tid > self._min_allowed_writeback.get(oid_tid[0], MAX_TID):
                 self._min_allowed_writeback[oid_tid[0]] = tid
 
-    def set_multi(self, keys_and_values):
-        for k, v in iteritems(keys_and_values):
-            self[k] = v
+    def set_all_for_tid(self, tid_int, state_oid_iter):
+        for state, oid_int in state_oid_iter:
+            self[(oid_int, tid_int)] = (state, tid_int)
 
     def store_checkpoints(self, cp0, cp1):
         # No lock, the assignment should be atomic
@@ -257,6 +256,9 @@ class LocalClient(object):
 
     def values(self):
         return self.__bucket.values()
+
+    def updating_delta_map(self, deltas):
+        return deltas
 
     @_log_timed
     def read_from_sqlite(self, connection, row_filter=None):

--- a/src/relstorage/cache/tests/cache_trace_analysis.rst
+++ b/src/relstorage/cache/tests/cache_trace_analysis.rst
@@ -48,14 +48,14 @@ Check to make sure the cache analysis scripts work.
     ...             cache.after_poll(None, cache.current_tid, serial, [(oid, serial)])
     ...             assert cache.current_tid == serial
     ...             cache.store_temp(oid, data)
-    ...             cache.send_queue(p64(serial))
+    ...             cache._send_queue(p64(serial))
     ...             cache.adapter.mover.data[oid] = (data, serial)
     ...         else:
     ...             new_cache.current_tid = serial
     ...             v = new_cache.load(None, oid)
     ...             if v[0] is None:
     ...                 new_cache.store_temp(oid, data)
-    ...                 new_cache.send_queue(p64(serial))
+    ...                 new_cache._send_queue(p64(serial))
     ...                 cache.adapter.mover.data[oid] = (data, serial)
     ...     cache.close(close_async=False)
 

--- a/src/relstorage/cache/tests/test__statecache_wrappers.py
+++ b/src/relstorage/cache/tests/test__statecache_wrappers.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from hamcrest import assert_that
+from nti.testing.matchers import verifiably_provides
+
+from relstorage.tests import TestCase
+
+from relstorage.cache import interfaces
+from relstorage.cache import _statecache_wrappers as wrappers
+
+class TestMultiStateCache(TestCase):
+
+    def _makeOne(self):
+        return wrappers.MultiStateCache(None, None)
+
+    def test_provides(self):
+        assert_that(self._makeOne(),
+                    verifiably_provides(interfaces.IStateCache))
+
+class MockTracer(object):
+    def __init__(self):
+        self.trace_events = []
+
+    def trace(self, code, oid_int=0, tid_int=0, end_tid_int=0, dlen=0):
+        self.trace_events.append((code, oid_int, tid_int, end_tid_int, dlen))
+
+    def trace_store_current(self, tid_int, state_oid_iter):
+        """Does nothing"""
+
+class TestTracingCacheWrapper(TestCase):
+
+    def _makeOne(self, kind=None):
+        kind = kind or wrappers.MultiStateCache
+
+        return wrappers.TracingStateCache(
+            kind(None, None),
+            MockTracer())
+
+    def test_provides(self):
+        assert_that(self._makeOne(),
+                    verifiably_provides(interfaces.IStateCache))
+
+    def test_get_miss(self):
+        from . import Cache
+        c = self._makeOne(lambda *args: Cache(100))
+
+        self.assertIsNone(c[(1, 0)])
+
+        self.assertEqual(
+            c.tracer.trace_events,
+            [(0x20, 1, 0, 0, 0,)]
+        )
+
+    def test_get_hit(self):
+        from . import Cache
+        c = self._makeOne(lambda *args: Cache(100))
+        # Deliberately mismatched tids in key and value;
+        # not the concern at this level.
+        c.cache[(1, 0)] = (b'abc', 1)
+        self.assertEqual(c[(1, 0)], (b'abc', 1))
+
+        self.assertEqual(
+            c.tracer.trace_events,
+            [(0x22, 1, 0, 0, 3,)]
+        )

--- a/src/relstorage/cache/tests/test_memcache_client.py
+++ b/src/relstorage/cache/tests/test_memcache_client.py
@@ -45,12 +45,17 @@ class AbstractStateCacheTests(TestCase):
     def test_provides(self):
         assert_that(self._makeOne(), verifiably_provides(IStateCache))
 
-    def test_set_multi_and_get_multi(self):
+    def test_set_all_for_tid(self):
         c = self._makeOne()
 
-        c.set_multi({(0, 0): (b'abc', 0),
-                     (0, 1): (b'def', 1),
-                     (1, 0): (b'ghi', 0)})
+        c.set_all_for_tid(
+            0,
+            [(b'abc', 0),
+             (b'ghi', 1),])
+        c.set_all_for_tid(
+            1,
+            [(b'def', 0)]
+        )
         # Hits on primary key
         self.assertEqual(c(0, 0),
                          (b'abc', 0))
@@ -68,6 +73,9 @@ class AbstractStateCacheTests(TestCase):
                          (b'def', 1))
         self.assertEqual(c(1, -1),
                          (b'ghi', 0))
+
+    def test_updating_delta_map(self):
+        self.assertIs(self._makeOne().updating_delta_map(self), self)
 
 class MemcacheClientTests(AbstractStateCacheTests):
 

--- a/src/relstorage/cache/trace.py
+++ b/src/relstorage/cache/trace.py
@@ -73,11 +73,13 @@ class ZEOTracer(object):
         with self._lock:
             self._trace(code, oid_int, tid_int, end_tid_int, dlen)
 
-    def trace_store_current(self, tid_int, items):
+    def trace_store_current(self, tid_int, state_oid_iter):
         # As a locking optimization, we accept this in bulk
+        # Theoretically this could be any iterable, but
+        # we only work with the one defined in storage_cache.
         with self._lock:
             now = time.time()
-            for startpos, endpos, oid_int in items:
+            for startpos, endpos, oid_int in state_oid_iter.items():
                 self._trace(0x52, oid_int, tid_int, dlen=endpos - startpos, now=now)
 
     def close(self):


### PR DESCRIPTION
Move that into a new IStateCache wrapper. This frees up the storage_cache implementation, and it removes any overhead when it's not in use.

Storing multiple states after a transaction into the cache is now also handled by its own separate logic we can test independently. This lets the IStateCache operate at a higher level, and local caches no longer pay the overhead of batching updates that we have to do for memcache.