### PR TITLE
Add more aggressive validation and, when possible, corrections for some cache consistency errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,7 +84,7 @@
   happen we now reset the cache and raise a type of ``TransientError``
   allowing the application to retry. A few instances where previously
   incorrect data could be cached may now raise such a
-  ``TransientError``.
+  ``TransientError``. See :pr:`245`.
 
 2.1.1 (2019-01-07)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,17 @@
   1-2% before). It is currently slower to read and write, however.
   This is a work in progress. See :pr:`243`.
 
+- Add more aggressive validation and, when possible, corrections for
+  certain types of cache consistency errors. Previously an
+  ``AssertionError`` would be raised with the message "Detected an
+  inconsistency between RelStorage and the database...". We now
+  proactively try harder to avoid that situation based on some
+  educated guesses about when it could happen, and should it still
+  happen we now reset the cache and raise a type of ``TransientError``
+  allowing the application to retry. A few instances where previously
+  incorrect data could be cached may now raise such a
+  ``TransientError``.
+
 2.1.1 (2019-01-07)
 ==================
 

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -542,10 +542,16 @@ class IPoller(Interface):
         """
 
     def list_changes(cursor, after_tid, last_tid):
-        """Return the (oid, tid) values changed in a range of transactions.
+        """
+        Return the ``(oid, tid)`` values changed in a range of
+        transactions.
 
-        The returned iterable must include all changes in the range
-        after_tid < tid <= last_tid.
+        The returned sequence (which has a defined ``len``) must
+        include the latest changes in the range *after_tid* < ``tid``
+        <= *last_tid*.
+
+        The ``oid`` values returned will be distinct: each ``oid``
+        will have been changed in exactly one ``tid``.
         """
 
 

--- a/src/relstorage/adapters/poller.py
+++ b/src/relstorage/adapters/poller.py
@@ -29,6 +29,9 @@ log = logging.getLogger(__name__)
 class Poller(object):
     """Database change notification poller"""
 
+    # The zoid is the primary key on both ``current_object`` (history
+    # preserving) and ``object_state`` (history free), so these
+    # queries are guaranteed to only produce an OID once.
     _list_changes_range_queries = (
         """
         SELECT zoid, tid
@@ -174,10 +177,8 @@ class Poller(object):
         return changes, new_polled_tid
 
     def list_changes(self, cursor, after_tid, last_tid):
-        """Return the (oid, tid) values changed in a range of transactions.
-
-        The returned iterable must include the latest changes in the range
-        after_tid < tid <= last_tid.
+        """
+        See ``IPoller``.
         """
         params = {'min_tid': after_tid, 'max_tid': last_tid}
         cursor.execute(self._list_changes_range_query, params)

--- a/src/relstorage/cache/interfaces.py
+++ b/src/relstorage/cache/interfaces.py
@@ -19,6 +19,8 @@ from zope.interface import Attribute
 from zope.interface import Interface
 
 import BTrees
+from transaction.interfaces import TransientError
+from ZODB.POSException import StorageError
 
 from relstorage._compat import PYPY
 
@@ -319,9 +321,19 @@ class IGenerationalLRUCache(ILRUCache):
     generations = Attribute("Ordered list of generations, with 0 being NoSuchGeneration.")
 
 
-class CacheCorruptedError(AssertionError):
+class CacheCorruptedError(StorageError):
     """
-    Raised when we detect cache corruption.
+    Raised when we detect internal cache corruption,
+    outside of any particular transaction.
+    """
+
+class CacheConsistencyError(StorageError, TransientError):
+    """
+    Raised when we detect internal cache corruption, having to do with
+    transactional consistency.
+
+    This is probably a transient error. By the time it is raised, the
+    faulty cache will have been cleared, and we can try again.
     """
 
 class NoSuchGeneration(object):

--- a/src/relstorage/cache/local_client.py
+++ b/src/relstorage/cache/local_client.py
@@ -242,6 +242,9 @@ class LocalClient(object):
 
     def store_checkpoints(self, cp0, cp1):
         # No lock, the assignment should be atomic
+        # Both checkpoints should be None, or the same integer,
+        # or cp0 should be ahead of cp1. Anything else is a bug.
+        assert cp0 == cp1 or cp0 > cp1
         cp = self.checkpoints = cp0, cp1
         return cp
 

--- a/src/relstorage/cache/tests/__init__.py
+++ b/src/relstorage/cache/tests/__init__.py
@@ -50,13 +50,15 @@ class MockPoller(object):
     def __init__(self):
         self.changes = []  # [(oid, tid)]
     def list_changes(self, _cursor, after_tid, last_tid):
-        # Return a generator, because the caller shouldn't assume
-        # a length. Return exactly the item in the list because
+        # Return a list, because the caller is allowed
+        # to assume a length. Return exactly the item in the list because
         # it may be a type other than a tuple
-        for change in self.changes:
-            _, tid = change
-            if tid > after_tid and tid <= last_tid:
-                yield change
+        return [
+            item
+            for item in self.changes
+            if item[1] > after_tid and item[1] <= last_tid
+        ]
+
 
 class Cache(_BaseCache):
     # Tweak the generation sizes to match what we developed the tests with

--- a/src/relstorage/storage.py
+++ b/src/relstorage/storage.py
@@ -1217,6 +1217,14 @@ class RelStorage(UndoLogCompatible,
         the transaction.
         """
 
+        # This is called directly from code in DB.py on a new instance
+        # (created either by new_instance() or a special
+        # undo_instance()). That new instance is never asked to load
+        # anything, or poll invalidations, so our storage cache is ineffective
+        # (unless we had loaded persistent state files)
+        #
+        # TODO: Implement 'undo_instance' to make this clear.
+
         if self._stale_error is not None:
             raise self._stale_error
         if self._is_read_only:


### PR DESCRIPTION
Previously an ``AssertionError`` would be raised with the message "Detected an inconsistency between RelStorage and the database...". We've seen a number of those recently that are thus far undiagnosed; they *could* be due to a flaky database driver (umysql), it's given us wrong results in the past.

We now proactively try harder to avoid that situation based on some educated guesses about when it could happen, and should it still happen we now reset the cache and raise a type of ``TransientError`` allowing the application to retry. A few instances where previously incorrect data could be cached may now raise such a ``TransientError``.

I also noticed that the poller's "list_changes" method does make certain guarantees, and so we started to rely on them. This helps us detect any issues initially building up the local delta maps (and it's probably faster, though I didn't check, because it avoids at least one data copy and one trip through a BTree; the extra validation probably makes up for that though.)

Fixes #226

This is the last thing I'm hoping to land before cutting 3.0a1.