### PR TITLE
Use prepared statements for get/add transaction and moving temp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 3.0a2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make MySQL and PostgreSQL use a prepared statement to get
+  transaction IDs during commit. This may be slightly faster.
+  See :issue:`246`.
 
 
 3.0a1 (2019-06-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,8 @@
 ==================
 
 - Make MySQL and PostgreSQL use a prepared statement to get
-  transaction IDs during commit. This may be slightly faster.
-  See :issue:`246`.
-
+  transaction IDs. PostgreSQL also uses a prepared statement to set
+  them. This may be slightly faster. See :issue:`246`.
 
 3.0a1 (2019-06-12)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,16 @@
 3.0a2 (unreleased)
 ==================
 
+- Drop support for PostgreSQL versions earlier than 9.6. See
+  :issue:`220`.
+
 - Make MySQL and PostgreSQL use a prepared statement to get
   transaction IDs. PostgreSQL also uses a prepared statement to set
   them. This may be slightly faster. See :issue:`246`.
+
+- Make PostgreSQL use a prepared statement to move objects to their
+  final destination during commit (history free only). See
+  :issue:`246`.
 
 3.0a1 (2019-06-12)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ memcache_require = [
 ]
 
 tests_require = [
-    'mock',
+    'mock', # XXX: This should probably be dependent on Python version
     # random2 is a forward port of python 2's random to
     # python 3. Our test_cache_stats (inherited from ZEO)
     # needs that. Without it, the tests can work on Py2 but

--- a/src/relstorage/adapters/_util.py
+++ b/src/relstorage/adapters/_util.py
@@ -48,29 +48,33 @@ def query_property(base_name,
 
     To use, define a property ending in `_queries` that is a
     two-tuple, where the preserving query comes first and the dropping
-    query comes second. This indirection lets subclasses override these
-    queries.
+    query comes second. This indirection lets subclasses override
+    these queries.
 
-    Then define a property, passing the base name (without _queries) to
-    this function.
+    Then define a property, passing the base name (without _queries)
+    to this function.
 
-    The correct query will be lazily picked at runtime. The instance must have the
-    ``keep_history`` attribute.
+    The correct query will be lazily picked at runtime. The instance
+    must have the ``keep_history`` attribute.
 
-    If the chosen query is an exception instance, it will be raised instead
-    of returned. This allows defining a query that is only supported in one of the
-    two modes.
+    If the chosen query is an exception instance or class, it will be raised
+    instead of returned. This allows defining a query that is only
+    supported in one of the two modes. Usually, this exception should be
+    :class:`ZODB.POSException.Unsupported`.
 
-    :keyword str extension: This string will be appended to whatever query
-      is chosen before it is formatted and before it is returned.
-    :keyword bool formatted: If True (*not* the default), then the chosen query
-      will be formatted using the ``self.runner.script_vars``.
+    :keyword str extension: This string will be appended to whatever
+        query is chosen before it is formatted and before it is returned.
+    :keyword bool formatted: If True (*not* the default), then the
+        chosen query will be formatted using the
+    ``self.runner.script_vars``.
     """
 
     def prop(inst):
         queries = getattr(inst, base_name + '_queries')
         query = queries[0] if inst.keep_history else queries[1]
-        if isinstance(query, Exception):
+        if isinstance(query, Exception) or (
+                isinstance(query, type)
+                and issubclass(query, Exception)):
             raise query
 
         if extension:

--- a/src/relstorage/adapters/connmanager.py
+++ b/src/relstorage/adapters/connmanager.py
@@ -63,6 +63,8 @@ class AbstractConnectionManager(object):
         Add a callable(cursor, restart=bool) for when a store connection
         is opened.
 
+        Hooks are called in the order added.
+
         .. versionadded:: 2.1a1
         """
         self._on_store_opened += (f,)
@@ -72,6 +74,8 @@ class AbstractConnectionManager(object):
     def add_on_load_opened(self, f):
         """
         Add a callable (cursor, restart=bool) for when a load connection is opened.
+
+        Hooks are called in the order added.
 
         .. versionadded:: 2.1a1
         """

--- a/src/relstorage/adapters/connmanager.py
+++ b/src/relstorage/adapters/connmanager.py
@@ -11,7 +11,7 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 from perfmetrics import metricmethod
 from zope.interface import implementer

--- a/src/relstorage/adapters/mysql/tests/test_txncontrol.py
+++ b/src/relstorage/adapters/mysql/tests/test_txncontrol.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
-# Copyright (c) 2009 Zope Foundation and Contributors.
+# Copyright (c) 2019 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,
@@ -11,18 +12,22 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""TransactionControl implementations"""
-
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-from ..txncontrol import GenericTransactionControl
+from relstorage.adapters.tests import test_txncontrol
 
+class MockDriver(object):
+    Binary = bytes
 
-class PostgreSQLTransactionControl(GenericTransactionControl):
+class TestMySQLTransactionControl(test_txncontrol.TestTransactionControl):
 
-    # See adapter.py for where this is prepared.
-    # Either history preserving or not, it's the same.
-    _get_tid_query = 'EXECUTE get_latest_tid'
+    def _getClass(self):
+        from ..txncontrol import MySQLTransactionControl
+        return MySQLTransactionControl
 
-    def __init__(self, keep_history, driver):
-        GenericTransactionControl.__init__(self, keep_history, driver.Binary)
+    def _get_hf_tid_query(self):
+        return 'EXECUTE get_latest_tid'
+
+    _get_hp_tid_query = _get_hf_tid_query

--- a/src/relstorage/adapters/mysql/txncontrol.py
+++ b/src/relstorage/adapters/mysql/txncontrol.py
@@ -19,4 +19,7 @@ from ..txncontrol import GenericTransactionControl
 
 
 class MySQLTransactionControl(GenericTransactionControl):
-    pass
+
+    # See adapter.py for where this is prepared.
+    # Either history preserving or not, it's the same.
+    _get_tid_query = 'EXECUTE get_latest_tid'

--- a/src/relstorage/adapters/poller.py
+++ b/src/relstorage/adapters/poller.py
@@ -11,7 +11,7 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import logging
 
@@ -100,7 +100,7 @@ class Poller(object):
         # pylint:disable=unused-argument
         # find out the tid of the most recent transaction.
         cursor.execute(self.poll_query)
-        rows = list(cursor)
+        rows = cursor.fetchall()
         if not rows or not rows[0][0]:
             # No data, must be fresh database, without even
             # the root object.
@@ -144,7 +144,6 @@ class Poller(object):
 
 
         # New transaction(s) have been added.
-
         if self.keep_history:
             # If the previously polled transaction no longer exists,
             # the cache is too old and needs to be cleared.
@@ -173,7 +172,6 @@ class Poller(object):
 
         cursor.execute(stmt, params)
         changes = cursor.fetchall()
-
         return changes, new_polled_tid
 
     def list_changes(self, cursor, after_tid, last_tid):

--- a/src/relstorage/adapters/postgresql/__init__.py
+++ b/src/relstorage/adapters/postgresql/__init__.py
@@ -19,3 +19,29 @@ from relstorage.adapters.postgresql.adapter import select_driver
 
 assert PostgreSQLAdapter
 assert select_driver
+
+
+def debug_my_locks(cursor): # pragma: no cover
+    conn = cursor.connection
+    pid = conn.info.backend_pid
+    cursor.execute("""
+    SELECT
+         a.datname,
+         l.relation::regclass,
+         l.locktype,
+         l.mode,
+         l.pid,
+         l.virtualxid, l.transactionid,
+         l.objid, l.objsubid,
+         l.virtualtransaction,
+         l.granted
+    FROM pg_stat_activity a
+    JOIN pg_locks l ON l.pid = a.pid
+    WHERE a.pid = %s and l.mode like '%%Exclu%%'
+    AND l.locktype <> 'virtualxid'
+    ORDER BY a.pid
+    """, (pid,))
+    rows = cursor.fetchall()
+    rows = '\n'.join('\t'.join((str(i) for i in r)) for r in rows)
+    header = '*Locks for %s isomode %s\n' % (pid, conn.isolation_level)
+    return header + rows

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -101,9 +101,10 @@ class PostgreSQLLocker(AbstractLocker):
         except self.lock_exceptions as e:
             if nowait:
                 return False
-            six.reraise(UnableToAcquireCommitLockError,
-                        'Acquiring a commit lock failed: %s' % (e,),
-                        sys.exc_info()[2])
+            six.reraise(
+                UnableToAcquireCommitLockError,
+                UnableToAcquireCommitLockError('Acquiring a commit lock failed: %s' % (e,)),
+                sys.exc_info()[2])
         return True
 
     def release_commit_lock(self, cursor):

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -17,7 +17,10 @@ Locker implementations.
 
 from __future__ import absolute_import
 
+import sys
+
 from perfmetrics import metricmethod
+import six
 from zope.interface import implementer
 
 from ..interfaces import ILocker
@@ -75,7 +78,8 @@ class PostgreSQLLocker(AbstractLocker):
                     stmt = """
                     %s
                     LOCK TABLE commit_lock IN EXCLUSIVE MODE%s;
-                    LOCK TABLE transaction, current_object IN SHARE MODE;
+                    LOCK TABLE transaction IN SHARE MODE;
+                    LOCK TABLE current_object IN SHARE MODE;
                     """ % (timeout_stmt, nowait and ' NOWAIT' or '',)
                 else:
                     stmt = """
@@ -83,24 +87,23 @@ class PostgreSQLLocker(AbstractLocker):
                     LOCK TABLE commit_lock IN EXCLUSIVE MODE%s;
                     LOCK TABLE object_state IN SHARE MODE
                     """ % (timeout_stmt, nowait and ' NOWAIT' or '',)
-                for s in stmt.splitlines():
-                    if not s.strip():
-                        continue
-                    cursor.execute(s)
             else:
                 stmt = """
                 %s
                 LOCK TABLE commit_lock IN EXCLUSIVE MODE%s
                 """ % (timeout_stmt, ' NOWAIT' if nowait else '')
-                for s in stmt.splitlines():
-                    if not s.strip():
-                        continue
-                    cursor.execute(s)
 
-        except self.lock_exceptions:
+            for s in stmt.splitlines():
+                if not s.strip():
+                    continue
+                cursor.execute(s)
+
+        except self.lock_exceptions as e:
             if nowait:
                 return False
-            raise UnableToAcquireCommitLockError('Acquiring a commit lock failed')
+            six.reraise(UnableToAcquireCommitLockError,
+                        'Acquiring a commit lock failed: %s' % (e,),
+                        sys.exc_info()[2])
         return True
 
     def release_commit_lock(self, cursor):

--- a/src/relstorage/adapters/postgresql/mover.py
+++ b/src/relstorage/adapters/postgresql/mover.py
@@ -19,6 +19,7 @@ import functools
 import os
 
 from zope.interface import implementer
+from ZODB.POSException import Unsupported
 
 from ..._compat import xrange
 from .._util import query_property
@@ -71,8 +72,6 @@ def to_prepared_queries(name, queries, datatypes=()):
 @implementer(IObjectMover)
 class PostgreSQLObjectMover(AbstractObjectMover):
 
-    __need_version_check = True
-
     _prepare_load_current_queries = to_prepared_queries(
         'load_current',
         AbstractObjectMover._load_current_queries,
@@ -90,26 +89,44 @@ class PostgreSQLObjectMover(AbstractObjectMover):
 
     _detect_conflict_query = 'EXECUTE detect_conflicts'
 
-    on_load_opened_statement_names = ('_prepare_load_current_query',)
-    on_store_opened_statement_names = on_load_opened_statement_names + (
-        '_prepare_detect_conflict_query',)
-
-    # Sadly we can't PREPARE this statement; apparently it holds a
-    # lock on OBJECT_STATE that interferes with taking the commit lock.
-    # XXX: Now that we've figured out to COMMIT right after the prepare,
-    # this should be fine and we should be able to prepare it.
-    _move_from_temp_object_state_95_query = """
+    _move_from_temp_hf_insert_query_raw = """
         INSERT INTO object_state (zoid, tid, state_size, state)
         SELECT zoid, %s, COALESCE(LENGTH(state), 0), state
         FROM temp_store
-        ON CONFLICT (zoid) DO UPDATE SET state_size = COALESCE(LENGTH(excluded.state), 0),
-                              tid = %s,
-                              STATE = excluded.state
+        ON CONFLICT (zoid)
+        DO UPDATE
+        SET state_size = COALESCE(LENGTH(excluded.state), 0),
+            tid = excluded.tid,
+            state = excluded.state
     """
 
-    def _move_from_temp_object_state_95(self, cursor, tid):
-        stmt = self._move_from_temp_object_state_95_query
-        cursor.execute(stmt, (tid, tid))
+    _move_from_temp_hf_insert_raw_queries = (
+        Unsupported("States accumulate in history-preserving mode"),
+        _move_from_temp_hf_insert_query_raw,
+    )
+
+    _prepare_move_from_temp_hf_insert_queries = to_prepared_queries(
+        'move_from_temp',
+        _move_from_temp_hf_insert_raw_queries,
+        ('BIGINT',)
+    )
+
+    _prepare_move_from_temp_hf_insert_query = query_property(
+        '_prepare_move_from_temp_hf_insert')
+
+    _move_from_temp_hf_insert_queries = (
+        Unsupported("States accumulate in history-preserving mode"),
+        'EXECUTE move_from_temp(%s)'
+    )
+
+    _move_from_temp_hf_insert_query = query_property('_move_from_temp_hf_insert')
+
+    on_load_opened_statement_names = ('_prepare_load_current_query',)
+    on_store_opened_statement_names = on_load_opened_statement_names + (
+        '_prepare_detect_conflict_query',
+        '_prepare_move_from_temp_hf_insert_query',
+    )
+
 
     @metricmethod_sampled
     def on_store_opened(self, cursor, restart=False):
@@ -147,31 +164,37 @@ class PostgreSQLObjectMover(AbstractObjectMover):
                     EXECUTE PROCEDURE temp_blob_chunk_delete_trigger();
                 """,
             ]
+            # For some reason, preparing the INSERT statement also wants
+            # to acquire a lock. If we're committing is another
+            # transaction, this can block indefinitely (if that other transaction
+            # happens to be in this same thread!)
+            # checkIterationIntraTransaction (PostgreSQLHistoryPreservingRelStorageTests)
+            # easily triggers this. Fortunately, I don't think this
+            # is a common case, and we can workaround the test failure by
+            # only prepping this in the store connection.
+            # TODO: Is there a more general solution?
+            cursor.execute('SET lock_timeout = 100')
 
         for stmt in ddl_stmts:
             cursor.execute(stmt)
 
-        if self.__need_version_check:
-            self.__need_version_check = False
-            supports_conflict = self.version_detector.get_version(cursor) >= (9, 5)
-            if supports_conflict:
-                self._move_from_temp_object_state = self._move_from_temp_object_state_95
-                self.store_temp = self._store_temp_95
-
         AbstractObjectMover.on_store_opened(self, cursor, restart)
 
-    def _store_temp_95(self, _cursor, batcher, oid, prev_tid, data):
+    def _move_from_temp_object_state(self, cursor, tid):
+        # Override the history-free version of moving from
+        # temp_store to do it in one step.
+        stmt = self._move_from_temp_hf_insert_query
+        cursor.execute(stmt, (tid,))
 
+
+    @metricmethod_sampled
+    def store_temp(self, _cursor, batcher, oid, prev_tid, data):
         suffix = """
         ON CONFLICT (zoid) DO UPDATE SET state = excluded.state,
                               prev_tid = excluded.prev_tid,
                               md5 = excluded.md5
         """
         self._generic_store_temp(batcher, oid, prev_tid, data, suffix=suffix)
-
-    @metricmethod_sampled
-    def store_temp(self, cursor, batcher, oid, prev_tid, data): # pylint:disable=method-hidden
-        self._generic_store_temp(batcher, oid, prev_tid, data)
 
     @metricmethod_sampled
     def restore(self, cursor, batcher, oid, tid, data):
@@ -308,8 +331,13 @@ class PostgreSQLObjectMover(AbstractObjectMover):
 
 
 class PG8000ObjectMover(PostgreSQLObjectMover):
-
+    # Delete the statements that need paramaters.
     on_load_opened_statement_names = ()
     on_store_opened_statement_names = ('_prepare_detect_conflict_query',)
 
     _load_current_query = AbstractObjectMover._load_current_query
+
+    _move_from_temp_hf_insert_queries = (
+        Unsupported("States accumulate in history-preserving mode"),
+        PostgreSQLObjectMover._move_from_temp_hf_insert_query_raw
+    )

--- a/src/relstorage/adapters/postgresql/mover.py
+++ b/src/relstorage/adapters/postgresql/mover.py
@@ -13,7 +13,7 @@
 ##############################################################################
 """IObjectMover implementation.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import functools
 import os
@@ -26,13 +26,47 @@ from ..interfaces import IObjectMover
 from ..mover import AbstractObjectMover
 from ..mover import metricmethod_sampled
 
+# Important: pg8000 1.10 - 1.13, at least, can't handle prepared
+# statements that take parameters but it doesn't need to because it
+# prepares every statement anyway. So you must have a backup that you use
+# for that driver.
+# https://github.com/mfenniak/pg8000/issues/132
 
-def to_prepared_queries(name, queries, datatypes=''):
-    # Only handles one param
-    return [
-        'PREPARE ' + name + ' ' + datatypes + ' AS ' + x.replace('%s', '$1')
-        for x in queries
-    ]
+
+def to_prepared_queries(name, queries, datatypes=()):
+    # Give correct datatypes for the queries, wherever possible.
+    # The number of parameters should be the same or more than the
+    # number of datatypes.
+    # datatypes is a sequence of strings.
+
+    # Maybe instead of having the adapter have to know about all the
+    # statements that need prepared, we could keep a registry?
+    if datatypes:
+        assert isinstance(datatypes, (list, tuple))
+        datatypes = ', '.join(datatypes)
+        datatypes = ' (%s)' % (datatypes,)
+    else:
+        datatypes = ''
+
+    result = []
+    for q in queries:
+        if not isinstance(q, str):
+            # Unsupported marker
+            result.append(q)
+            continue
+
+        q = q.strip()
+        param_count = q.count('%s')
+        rep_count = 0
+        while rep_count < param_count:
+            rep_count += 1
+            q = q.replace('%s', '$' + str(rep_count), 1)
+        stmt = 'PREPARE {name}{datatypes} AS {query}'.format(
+            name=name, datatypes=datatypes, query=q
+        )
+        result.append(stmt)
+    return result
+
 
 @implementer(IObjectMover)
 class PostgreSQLObjectMover(AbstractObjectMover):
@@ -42,7 +76,7 @@ class PostgreSQLObjectMover(AbstractObjectMover):
     _prepare_load_current_queries = to_prepared_queries(
         'load_current',
         AbstractObjectMover._load_current_queries,
-        '(BIGINT)')
+        ['BIGINT'])
 
     _prepare_load_current_query = query_property('_prepare_load_current')
 
@@ -62,6 +96,8 @@ class PostgreSQLObjectMover(AbstractObjectMover):
 
     # Sadly we can't PREPARE this statement; apparently it holds a
     # lock on OBJECT_STATE that interferes with taking the commit lock.
+    # XXX: Now that we've figured out to COMMIT right after the prepare,
+    # this should be fine and we should be able to prepare it.
     _move_from_temp_object_state_95_query = """
         INSERT INTO object_state (zoid, tid, state_size, state)
         SELECT zoid, %s, COALESCE(LENGTH(state), 0), state
@@ -79,40 +115,40 @@ class PostgreSQLObjectMover(AbstractObjectMover):
     def on_store_opened(self, cursor, restart=False):
         """Create the temporary tables for storing objects"""
         # note that the md5 column is not used if self.keep_history == False.
-        stmts = [
+        # Ideally we wouldn't execute any of these on a restart, but
+        # I've seen an issue with temp_stare apparently going missing on pg8000
+        ddl_stmts = [
             """
-            CREATE TEMPORARY TABLE temp_store (
-                zoid        BIGINT NOT NULL,
+            CREATE TEMPORARY TABLE IF NOT EXISTS temp_store (
+                zoid        BIGINT NOT NULL PRIMARY KEY,
                 prev_tid    BIGINT NOT NULL,
                 md5         CHAR(32),
                 state       BYTEA
-            ) ON COMMIT DROP;
+            ) ON COMMIT DELETE ROWS;
             """,
             """
-            CREATE UNIQUE INDEX temp_store_zoid ON temp_store (zoid);
-            """,
-            """
-            CREATE TEMPORARY TABLE temp_blob_chunk (
+            CREATE TEMPORARY TABLE IF NOT EXISTS temp_blob_chunk (
                 zoid        BIGINT NOT NULL,
                 chunk_num   BIGINT NOT NULL,
-                chunk       OID
-            ) ON COMMIT DROP;
-            """,
-            """
-            CREATE UNIQUE INDEX temp_blob_chunk_key
-            ON temp_blob_chunk (zoid, chunk_num);
-            """,
-            """
-            -- This trigger removes blobs that get replaced before being
-            -- moved to blob_chunk.  Note that it is never called when
-            -- the temp_blob_chunk table is being dropped or truncated.
-            CREATE TRIGGER temp_blob_chunk_delete
-                BEFORE DELETE ON temp_blob_chunk
-                FOR EACH ROW
-                EXECUTE PROCEDURE temp_blob_chunk_delete_trigger();
+                chunk       OID,
+                PRIMARY KEY (zoid, chunk_num)
+            ) ON COMMIT DELETE ROWS;
             """,
         ]
-        for stmt in stmts:
+        if not restart:
+            ddl_stmts += [
+                """
+                -- This trigger removes blobs that get replaced before being
+                -- moved to blob_chunk.  Note that it is never called when
+                -- the temp_blob_chunk table is being dropped or truncated.
+                CREATE TRIGGER temp_blob_chunk_delete
+                    BEFORE DELETE ON temp_blob_chunk
+                    FOR EACH ROW
+                    EXECUTE PROCEDURE temp_blob_chunk_delete_trigger();
+                """,
+            ]
+
+        for stmt in ddl_stmts:
             cursor.execute(stmt)
 
         if self.__need_version_check:
@@ -272,9 +308,6 @@ class PostgreSQLObjectMover(AbstractObjectMover):
 
 
 class PG8000ObjectMover(PostgreSQLObjectMover):
-    # pg8000 1.10 can't handle prepared statements that take parameters
-    # but it doesn't need to because it prepares every statement
-    # anyway. https://github.com/mfenniak/pg8000/issues/132
 
     on_load_opened_statement_names = ()
     on_store_opened_statement_names = ('_prepare_detect_conflict_query',)

--- a/src/relstorage/adapters/postgresql/tests/test_txncontrol.py
+++ b/src/relstorage/adapters/postgresql/tests/test_txncontrol.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from relstorage.adapters.tests import test_txncontrol
+
+class MockDriver(object):
+    Binary = bytes
+
+class TestPostgreSQLTransactionControl(test_txncontrol.TestTransactionControl):
+
+    def setUp(self):
+        super(TestPostgreSQLTransactionControl, self).setUp()
+
+        driver = MockDriver()
+        driver.Binary = super(TestPostgreSQLTransactionControl, self).Binary
+        self.Binary = driver
+
+    def tearDown(self):
+        del self.Binary
+        super(TestPostgreSQLTransactionControl, self).tearDown()
+
+    def _getClass(self):
+        from ..txncontrol import PostgreSQLTransactionControl
+        return PostgreSQLTransactionControl
+
+    def _get_hf_tid_query(self):
+        return 'EXECUTE get_latest_tid'
+
+    _get_hp_tid_query = _get_hf_tid_query

--- a/src/relstorage/adapters/postgresql/txncontrol.py
+++ b/src/relstorage/adapters/postgresql/txncontrol.py
@@ -15,14 +15,39 @@
 
 from __future__ import absolute_import
 
+from ZODB.POSException import Unsupported
 from ..txncontrol import GenericTransactionControl
+from .._util import query_property
+from .mover import to_prepared_queries
 
-
-class PostgreSQLTransactionControl(GenericTransactionControl):
+class _PostgreSQLTransactionControl(GenericTransactionControl):
 
     # See adapter.py for where this is prepared.
     # Either history preserving or not, it's the same.
     _get_tid_query = 'EXECUTE get_latest_tid'
 
+
     def __init__(self, keep_history, driver):
         GenericTransactionControl.__init__(self, keep_history, driver.Binary)
+
+
+class PostgreSQLTransactionControl(_PostgreSQLTransactionControl):
+
+    # (tid, packed, username, description, extension)
+    _add_transaction_query = 'EXECUTE add_transaction(%s, %s, %s, %s, %s)'
+
+    _prepare_add_transaction_queries = to_prepared_queries(
+        'add_transaction',
+        [
+            GenericTransactionControl._add_transaction_query,
+            Unsupported("No transactions in HF mode"),
+        ],
+        ('BIGINT', 'BOOLEAN', 'BYTEA', 'BYTEA', 'BYTEA')
+    )
+
+    _prepare_add_transaction_query = query_property('_prepare_add_transaction')
+
+
+class PG8000TransactionControl(_PostgreSQLTransactionControl):
+    # We can't handle the parameterized prepared statements.
+    pass

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -128,10 +128,12 @@ class AbstractSchemaInstaller(ABC):
         """
         raise NotImplementedError()
 
-    #: The type of the column used to hold binary strings
+    #: The type of the column used to hold binary strings.
+    #: Our default is appropriate for PostgreSQL.
     COLTYPE_BINARY_STRING = 'BYTEA'
     #: The suffix needed (after the closing ')') to make sure a
     #: table behaves in a transactional manner.
+    #: Our default is appropriate for PostgreSQL.
     TRANSACTIONAL_TABLE_SUFFIX = ''
 
     CREATE_TRANSACTION_STMT_TMPL = """

--- a/src/relstorage/adapters/tests/test_batch.py
+++ b/src/relstorage/adapters/tests/test_batch.py
@@ -12,10 +12,11 @@
 #
 ##############################################################################
 
-import unittest
+from relstorage.tests import TestCase
+from relstorage.tests import MockCursor
 
 
-class RowBatcherTests(unittest.TestCase):
+class RowBatcherTests(TestCase):
 
     def getClass(self):
         from relstorage.adapters.batch import RowBatcher
@@ -244,7 +245,7 @@ class RowBatcherTests(unittest.TestCase):
         ])
 
 
-class OracleRowBatcherTests(unittest.TestCase):
+class OracleRowBatcherTests(TestCase):
 
     def getClass(self):
         from relstorage.adapters.oracle.batch import OracleRowBatcher
@@ -347,14 +348,3 @@ class OracleRowBatcherTests(unittest.TestCase):
             'rawdata_0': MockRawType,
             'rawdata_1': MockRawType,
         })
-
-
-class MockCursor(object):
-    def __init__(self):
-        self.executed = []
-        self.inputsizes = {}
-    def setinputsizes(self, **kw):
-        self.inputsizes.update(kw)
-    def execute(self, stmt, params=None):
-        params = tuple(params) if isinstance(params, list) else params
-        self.executed.append((stmt, params))

--- a/src/relstorage/adapters/tests/test_connmanager.py
+++ b/src/relstorage/adapters/tests/test_connmanager.py
@@ -12,10 +12,12 @@
 #
 ##############################################################################
 
-import unittest
+from relstorage.tests import TestCase
+from relstorage.tests import MockCursor
+from relstorage.tests import MockConnection
 
 
-class AbstractConnectionManagerTests(unittest.TestCase):
+class AbstractConnectionManagerTests(TestCase):
 
     def test_without_replica_conf(self):
         from relstorage.adapters.connmanager import AbstractConnectionManager
@@ -86,29 +88,3 @@ class MockOptions(object):
         self.replica_conf = fn
         self.ro_replica_conf = ro_fn
         self.replica_timeout = 600.0
-
-class MockConnection(object):
-    rolled_back = False
-    closed = False
-    replica = None
-
-    def rollback(self):
-        self.rolled_back = True
-
-    def close(self):
-        self.closed = True
-
-class MockCursor(object):
-    closed = False
-
-    def close(self):
-        self.closed = True
-
-
-def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(AbstractConnectionManagerTests))
-    return suite
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')

--- a/src/relstorage/adapters/tests/test_txncontrol.py
+++ b/src/relstorage/adapters/tests/test_txncontrol.py
@@ -60,7 +60,7 @@ class TestTransactionControl(TestCase):
     def test_get_tid_empty_db(self):
         inst = self._makeOne()
         cur = MockCursor()
-        cur.results = [None]
+        cur.results = None
 
         self.assertEqual(inst.get_tid(cur), 0)
 

--- a/src/relstorage/adapters/tests/test_txncontrol.py
+++ b/src/relstorage/adapters/tests/test_txncontrol.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2009 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from relstorage.tests import TestCase
+from relstorage.tests import MockConnection
+from relstorage.tests import MockCursor
+
+
+class TestTransactionControl(TestCase):
+
+    def _getClass(self):
+        from ..txncontrol import GenericTransactionControl
+        return GenericTransactionControl
+
+    def Binary(self, arg):
+        if not isinstance(arg, bytes):
+            arg = arg.encode('ascii')
+        return arg
+
+    def _makeOne(self, keep_history=True, binary=None):
+        return self._getClass()(keep_history, binary or self.Binary)
+
+    def _get_hf_tid_query(self):
+        return self._getClass()._get_tid_queries[1]
+
+    def _get_hp_tid_query(self):
+        return self._getClass()._get_tid_queries[0]
+
+    def _check_get_tid_query(self, keep_history, expected_query):
+        inst = self._makeOne(keep_history)
+        cur = MockCursor()
+        cur.results = [(1,)]
+
+        inst.get_tid(cur)
+
+        self.assertEqual(cur.executed.pop(),
+                         (expected_query, None))
+
+    def test_get_tid_hf(self):
+        self._check_get_tid_query(False, self._get_hf_tid_query())
+
+    def test_get_tid_hp(self):
+        self._check_get_tid_query(True, self._get_hp_tid_query())
+
+    def test_get_tid_empty_db(self):
+        inst = self._makeOne()
+        cur = MockCursor()
+        cur.results = [None]
+
+        self.assertEqual(inst.get_tid(cur), 0)
+
+    def test_add_transaction_hp(self):
+        inst = self._makeOne()
+        cur = MockCursor()
+
+        inst.add_transaction(cur, 1, u'user', u'desc', u'ext')
+
+        self.assertEqual(
+            cur.executed.pop(),
+            (inst._add_transaction_query,
+             (1, False, b'user', b'desc', b'ext'))
+        )
+
+        inst.add_transaction(cur, 1, u'user', u'desc', u'ext', packed=True)
+
+        self.assertEqual(
+            cur.executed.pop(),
+            (inst._add_transaction_query,
+             (1, True, b'user', b'desc', b'ext'))
+        )
+
+    def test_commit_phase1(self):
+        inst = self._makeOne()
+        result = inst.commit_phase1(None, None, None)
+        self.assertEqual(result, '-')
+
+    def test_commit_phase2(self):
+        inst = self._makeOne()
+        conn = MockConnection()
+        inst.commit_phase2(conn, None, None)
+        self.assertTrue(conn.committed)
+
+    def test_abort(self):
+        inst = self._makeOne()
+        conn = MockConnection()
+        inst.abort(conn, None, None)
+        self.assertTrue(conn.rolled_back)

--- a/src/relstorage/adapters/txncontrol.py
+++ b/src/relstorage/adapters/txncontrol.py
@@ -82,27 +82,23 @@ class GenericTransactionControl(AbstractTransactionControl):
 
     def get_tid(self, cursor):
         cursor.execute(self._get_tid_query)
-        row = cursor.fetchone()
+        row = cursor.fetchall()
         if not row:
             # nothing has been stored yet
             return 0
 
-        tid = row[0]
+        tid = row[0][0]
         return tid if tid is not None else 0
 
     _add_transaction_query = """
-    INSERT INTO transaction
-           (tid, packed, username, description, extension)
+    INSERT INTO transaction (tid, packed, username, description, extension)
     VALUES (%s, %s, %s, %s, %s)
     """
 
     @noop_when_history_free
     def add_transaction(self, cursor, tid, username, description, extension,
-                        packed=False,
-                        # We don't expect subclasses to override, so we
-                        # bind early for speed. TODO: Benchmark.
-                        _stmt=_add_transaction_query):
+                        packed=False):
         binary = self.Binary
-        cursor.execute(_stmt, (
+        cursor.execute(self._add_transaction_query, (
             tid, packed, binary(username),
             binary(description), binary(extension)))

--- a/src/relstorage/adapters/txncontrol.py
+++ b/src/relstorage/adapters/txncontrol.py
@@ -90,15 +90,19 @@ class GenericTransactionControl(AbstractTransactionControl):
         tid = row[0]
         return tid if tid is not None else 0
 
+    _add_transaction_query = """
+    INSERT INTO transaction
+           (tid, packed, username, description, extension)
+    VALUES (%s, %s, %s, %s, %s)
+    """
+
     @noop_when_history_free
     def add_transaction(self, cursor, tid, username, description, extension,
-                        packed=False):
-        stmt = """
-        INSERT INTO transaction
-            (tid, packed, username, description, extension)
-        VALUES (%s, %s, %s, %s, %s)
-        """
+                        packed=False,
+                        # We don't expect subclasses to override, so we
+                        # bind early for speed. TODO: Benchmark.
+                        _stmt=_add_transaction_query):
         binary = self.Binary
-        cursor.execute(stmt, (
+        cursor.execute(_stmt, (
             tid, packed, binary(username),
             binary(description), binary(extension)))

--- a/src/relstorage/cache/local_database.py
+++ b/src/relstorage/cache/local_database.py
@@ -55,8 +55,8 @@ class SimpleQueryProperty(object):
         cur.close()
         return result
 
-SUPPORTS_UPSERT = sqlite3.sqlite_version_info >= (3, 28) # 2019-04-16
 SUPPORTS_WINDOW = sqlite3.sqlite_version_info >= (3, 25) # 2018-09-15
+SUPPORTS_UPSERT = sqlite3.sqlite_version_info >= (3, 24) # 2018-06-04
 SUPPORTS_PAREN_UPDATE = sqlite3.sqlite_version_info >= (3, 15) # 2016-10-14
 SUPPORTS_CTE = sqlite3.sqlite_version_info >= (3, 8, 3) # 2014-02-03
 

--- a/src/relstorage/cache/tests/__init__.py
+++ b/src/relstorage/cache/tests/__init__.py
@@ -7,29 +7,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
-from relstorage.options import Options
 from relstorage.cache.lru_cffiring import CFFICache as _BaseCache
 from relstorage.cache.mapping import SizedLRUMapping as _BaseSizedLRUMapping
 from relstorage.cache.local_client import LocalClient as _BaseLocalClient
 
-class MockOptions(Options):
-    cache_module_name = '' # disable
-    cache_servers = ''
-    cache_local_mb = 1
-    cache_local_dir_count = 1 # shrink
-
-    @classmethod
-    def from_args(cls, **kwargs):
-        inst = cls()
-        for k, v in kwargs.items():
-            setattr(inst, k, v)
-        return inst
-
-    def __setattr__(self, name, value):
-        if name not in Options.valid_option_names():
-            raise AttributeError("Invalid option", name) # pragma: no cover
-        object.__setattr__(self, name, value)
+from relstorage.tests import MockOptions
 
 class MockOptionsWithFakeMemcache(MockOptions):
     cache_module_name = 'relstorage.tests.fakecache'

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -52,5 +52,10 @@ class MockCursor(object):
     def fetchone(self):
         return self.results.pop(0)
 
+    def fetchall(self):
+        r = self.results
+        self.results = None
+        return r
+
     def close(self):
         self.closed = True

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -15,3 +15,42 @@ class TestCase(unittest.TestCase):
         self.assertEqual(len(container), 0)
 
     assertEmpty = assertIsEmpty
+
+class MockConnection(object):
+    rolled_back = False
+    closed = False
+    replica = None
+    committed = False
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        self.closed = True
+
+    def cursor(self):
+        return MockCursor()
+
+class MockCursor(object):
+    closed = False
+
+    def __init__(self):
+        self.executed = []
+        self.inputsizes = {}
+        self.results = []
+
+    def setinputsizes(self, **kw):
+        self.inputsizes.update(kw)
+
+    def execute(self, stmt, params=None):
+        params = tuple(params) if isinstance(params, list) else params
+        self.executed.append((stmt, params))
+
+    def fetchone(self):
+        return self.results.pop(0)
+
+    def close(self):
+        self.closed = True

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -2,6 +2,8 @@
 
 import unittest
 
+from relstorage.options import Options
+
 class TestCase(unittest.TestCase):
     # Avoid deprecation warnings; 2.7 doesn't have
     # assertRaisesRegex
@@ -59,3 +61,21 @@ class MockCursor(object):
 
     def close(self):
         self.closed = True
+
+class MockOptions(Options):
+    cache_module_name = '' # disable
+    cache_servers = ''
+    cache_local_mb = 1
+    cache_local_dir_count = 1 # shrink
+
+    @classmethod
+    def from_args(cls, **kwargs):
+        inst = cls()
+        for k, v in kwargs.items():
+            setattr(inst, k, v)
+        return inst
+
+    def __setattr__(self, name, value):
+        if name not in Options.valid_option_names():
+            raise AttributeError("Invalid option", name) # pragma: no cover
+        object.__setattr__(self, name, value)


### PR DESCRIPTION
These are typically called once per transaction. For larger transactions, no difference shows up in benchmarks. But for small ones, it's there:

| Benchmark                        | Master | This branch              |
|----------------------------------|-----------------|------------------------------|
| psycopg2_0: add 10 objects       | 9.42 ms                | 6.64 ms: 1.42x faster (-30%) |
| psycopg2_0: update 10 objects    | 10.6 ms                | 7.58 ms: 1.40x faster (-29%) |
| psycopg2_0_hf: add 10 objects    | 9.75 ms                | 5.17 ms: 1.89x faster (-47%) |
| psycopg2_0_hf: update 10 objects | 11.2 ms                | 6.47 ms: 1.73x faster (-42%) |


I'd like to continue moving towards using prepared statements where it makes sense, but this PR shows that the infrastructure to make that happen could use some work. Currently it's pretty ugly.

Fixes #246 