### PR TITLE
Make zapping MySQL much faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --rcfile=.pylintrc relstorage -f parseable -r n; fi
   # Disable inlining right now. See https://github.com/zodb/relstorage/issues/228#issuecomment-492423284
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then python --jit inlining=0 -m zope.testrunner --test-path=src --auto-color --auto-progress; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -m  zope.testrunner --test-path=src --auto-color --auto-progress; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -m zope.testrunner --test-path=src --auto-color --auto-progress; fi
 after_success:
   - coveralls
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 - Zapping a storage now also removes any persistent cache files. See
   :issue:`241`.
 
+- Zapping a MySQL storage now issues ``DROP TABLE`` statements instead
+  of ``DELETE FROM`` statements. This is much faster on large
+  databases. See :issue:`242`.
+
 3.0a2 (2019-06-19)
 ==================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,7 +96,7 @@ build_script:
 test_script:
   - if not "%GWHEEL_ONLY%"=="true" cmd /c .travis\mysql.cmd
   - if not "%GWHEEL_ONLY%"=="true" cmd /c .travis\postgres.cmd
-  - if not "%GWHEEL_ONLY%"=="true" %PYEXE% -m zope.testrunner --test-path=src --auto-color
+  - if not "%GWHEEL_ONLY%"=="true" %PYEXE% -m zope.testrunner --test-path=src -vvv --color --slow-test 3
 
 after_test:
   - "%CMD_IN_ENV% %PYEXE% setup.py bdist_wheel -d dist"

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -210,7 +210,7 @@ class PostgreSQLAdapter(object):
         return inst
 
     def __str__(self):
-        parts = [self.__class__.__name__]
+        parts = []
         if self.keep_history:
             parts.append('history preserving')
         else:
@@ -218,7 +218,11 @@ class PostgreSQLAdapter(object):
         dsnparts = self._dsn.split()
         s = ' '.join(p for p in dsnparts if not p.startswith('password'))
         parts.append('dsn=%r' % s)
-        return ", ".join(parts)
+        return "<%s at %x %s>" % (
+            self.__class__.__name__, id(self), ",".join(parts)
+        )
+
+    __repr__ = __str__
 
 
 

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -122,7 +122,10 @@ class StorageCreatingMixin(ABC):
             # with them? This leads to connections remaining open with
             # locks on PyPy, so on PostgreSQL we can't TRUNCATE tables
             # and have to go the slow route.
-            storage.zap_all(slow=True)
+            #
+            # As of 2019-06-20 with PyPy 7.1.1, I'm no longer able to replicate
+            # a problem like that locally, so we go back to the fast way.
+            storage.zap_all()
         return self._wrap_storage(storage)
 
 

--- a/src/relstorage/tests/testpostgresql.py
+++ b/src/relstorage/tests/testpostgresql.py
@@ -40,9 +40,13 @@ class PostgreSQLAdapterMixin(object):
             else:
                 dbname = self.base_dbname + '_hf'
         dsn = (
-            "dbname='%s' user='relstoragetest' host='127.0.0.1' password='relstoragetest'"
+            "dbname='%s' user='relstoragetest' password='relstoragetest'"
             % dbname
         )
+        # psycopg2cffi can have a unix socket path hardcoded in it,
+        # and that path may not be right
+        if 'cffi' in self.driver_name.lower():
+            dsn += " host='127.0.0.1'"
         return dsn
 
     def get_adapter_zconfig(self):

--- a/src/relstorage/tests/testpostgresql.py
+++ b/src/relstorage/tests/testpostgresql.py
@@ -25,26 +25,22 @@ from .util import AbstractTestSuiteBuilder
 class PostgreSQLAdapterMixin(object):
 
     def make_adapter(self, options, db=None):
-        if db is None:
-            if self.keep_history:
-                db = self.base_dbname
-            else:
-                db = self.base_dbname + '_hf'
         return PostgreSQLAdapter(
-            dsn='dbname=%s user=relstoragetest password=relstoragetest' % db,
+            dsn=self.__get_adapter_zconfig_dsn(db),
             options=options,
         )
 
     def get_adapter_class(self):
         return PostgreSQLAdapter
 
-    def __get_adapter_zconfig_dsn(self):
-        if self.keep_history:
-            dbname = self.base_dbname
-        else:
-            dbname = self.base_dbname + '_hf'
+    def __get_adapter_zconfig_dsn(self, dbname=None):
+        if dbname is None:
+            if self.keep_history:
+                dbname = self.base_dbname
+            else:
+                dbname = self.base_dbname + '_hf'
         dsn = (
-            "dbname='%s' user='relstoragetest' password='relstoragetest'"
+            "dbname='%s' user='relstoragetest' host='127.0.0.1' password='relstoragetest'"
             % dbname
         )
         return dsn

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -276,8 +276,9 @@ class AbstractTestSuiteBuilder(ABC):
 
                     adapter_maker = self.use_adapter()
                     adapter = adapter_maker.make_adapter(options, db)
+                    __traceback_info__ = adapter, options
                     storage = RelStorage(adapter, name=name, options=options)
-                    storage.zap_all(slow=True)
+                    storage.zap_all()
                     return storage
 
                 prefix = '%s_%s%s' % (

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -275,6 +275,7 @@ class AbstractTestSuiteBuilder(ABC):
                         **kw)
 
                     adapter_maker = self.use_adapter()
+                    adapter_maker.driver_name = driver_name
                     adapter = adapter_maker.make_adapter(options, db)
                     __traceback_info__ = adapter, options
                     storage = RelStorage(adapter, name=name, options=options)


### PR DESCRIPTION
By dropping the tables instead of deleting from them. This isn't fully transactional, but that shouldn't matter here.