### PR TITLE
Store objects using COPY FROM BINARY on pg8000 and psycopg2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@
   binary ``COPY FROM`` to initially store objects into the database.
   This can be 20-25% faster. See :issue:`247`.
 
+- Silence a warning about ``cursor.connection`` from pg8000. See
+  :issue:`238`.
+
 3.0a2 (2019-06-19)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@
 
 - Make the psycopg2 and pg8000 drivers use PostgreSQL's efficient
   binary ``COPY FROM`` to initially store objects into the database.
-  This can be 20-25% faster. See :issue:`247`.
+  This can be 20-40% faster. See :issue:`247`.
 
 - Silence a warning about ``cursor.connection`` from pg8000. See
   :issue:`238`.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@
 - Workaround the PyPy 7.1 JIT bug using MySQL Connector/Python. It is no
   longer necessary to disable the JIT in PyPy 7.1.
 
+- Make the psycopg2 and pg8000 drivers use PostgreSQL's efficient
+  binary ``COPY FROM`` to initially store objects into the database.
+  This can be 20-25% faster. See :issue:`247`.
+
 3.0a2 (2019-06-19)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,9 +15,9 @@
 - Workaround the PyPy 7.1 JIT bug using MySQL Connector/Python. It is no
   longer necessary to disable the JIT in PyPy 7.1.
 
-- Make the psycopg2 and pg8000 drivers use PostgreSQL's efficient
-  binary ``COPY FROM`` to initially store objects into the database.
-  This can be 20-40% faster. See :issue:`247`.
+- On PostgreSQL, use PostgreSQL's efficient binary ``COPY FROM`` to
+  store objects into the database. This can be 20-40% faster. See
+  :issue:`247`.
 
 - Silence a warning about ``cursor.connection`` from pg8000. See
   :issue:`238`.

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 import platform
 import sys
 
+import BTrees
 # XXX: This is a private module in ZODB, but it has a lot
 # of knowledge about how to choose the right implementation
 # based on Python version and implementation. We at least
@@ -42,6 +43,10 @@ else:
     iteritems = dict.iteritems
     iterkeys = dict.iterkeys
     itervalues = dict.itervalues
+
+OID_TID_MAP_TYPE = BTrees.family64.II.BTree if not PYPY else dict
+OID_OBJECT_MAP_TYPE = BTrees.family64.IO.BTree if not PYPY else dict
+
 
 # Types
 

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -380,7 +380,11 @@ class IObjectMover(Interface):
         """
 
     def current_object_tids(cursor, oids):
-        """Returns the current {oid: tid} for specified object ids."""
+        """
+        Returns the current {oid_int: tid_int} for specified object ids.
+
+        Note that this may be a BTree mapping, not a dictionary.
+        """
 
     def on_store_opened(cursor, restart=False):
         """Create the temporary table for storing objects.
@@ -392,14 +396,22 @@ class IObjectMover(Interface):
     def make_batcher(cursor, row_limit):
         """Return an object to be used for batch store operations.
 
-        row_limit is the maximum number of rows to queue before
+        *row_limit* is the maximum number of rows to queue before
         calling the database.
         """
 
-    def store_temp(cursor, batcher, oid, prev_tid, data):
-        """Store an object in the temporary table.
+    def store_temps(cursor, state_oid_tid_iter):
+        """
+        Store many objects in the temporary table.
 
-        batcher is an object returned by self.make_batcher().
+        *batcher* is an object returned by :meth:`make_batcher`.
+
+        *state_oid_tid_iter* is an iterable providing tuples
+        ``(data, oid_int, prev_tid_int)``. It is guaranteed that the
+        ``oid_int`` values will be distinct. It is further guaranteed that
+        this method will not be called more than once in a given transaction;
+        further updates to the temporary table will be made using
+        ``replace_temp``, one at a time.
         """
 
     def restore(cursor, batcher, oid, tid, data, stmt_buf):

--- a/src/relstorage/adapters/mover.py
+++ b/src/relstorage/adapters/mover.py
@@ -182,10 +182,12 @@ class AbstractObjectMover(ABC):
 
     _current_object_tids_query = _query_property('_current_object_tids')
 
+    _current_object_tids_map_type = OID_TID_MAP_TYPE
+
     @metricmethod_sampled
     def current_object_tids(self, cursor, oids):
         """Returns the current {oid: tid} for specified object ids."""
-        res = OID_TID_MAP_TYPE()
+        res = self._current_object_tids_map_type()
         _stmt = self._current_object_tids_query
         oids = list(oids)
         while oids:

--- a/src/relstorage/adapters/mover.py
+++ b/src/relstorage/adapters/mover.py
@@ -22,6 +22,7 @@ from perfmetrics import Metric
 from zope.interface import implementer
 from ZODB.POSException import Unsupported
 
+from .._compat import OID_TID_MAP_TYPE
 from ..iter import fetchmany
 from ._util import noop_when_history_free
 from ._util import query_property as _query_property
@@ -184,17 +185,19 @@ class AbstractObjectMover(ABC):
     @metricmethod_sampled
     def current_object_tids(self, cursor, oids):
         """Returns the current {oid: tid} for specified object ids."""
-        res = {}
+        res = OID_TID_MAP_TYPE()
         _stmt = self._current_object_tids_query
         oids = list(oids)
         while oids:
-            # XXX: Dangerous (SQL injection)! And probably slow. Can we do better?
+            # XXX: Dangerous (SQL injection)! And probably slow. Can
+            # we do better? Under PostgreSQL with psycopg2, we should
+            # be able to pass a list and have it automatically turned into
+            # an array and use an IN/ANY operator.
             oid_list = ','.join(str(oid) for oid in oids[:1000])
             del oids[:1000]
             stmt = _stmt % (oid_list,)
             cursor.execute(stmt)
-            for oid, tid in fetchmany(cursor):
-                res[oid] = tid
+            res.update(cursor.fetchall())
         return res
 
     #: A sequence of *names* of attributes on this object that are statements to be
@@ -228,7 +231,8 @@ class AbstractObjectMover(ABC):
     def _generic_store_temp(self, batcher, oid, prev_tid, data,
                             command='INSERT', suffix=''):
         md5sum = self._compute_md5sum(data)
-
+        # TODO: Now that we guarantee not to feed duplicates here, drop
+        # the conflict handling.
         if command == 'INSERT' and not suffix:
             # MySQL uses command=REPLACE for an UPSERT
             # PostgreSQL 9.5+ uses a suffix='ON CONFLICT UPDATE...' for an UPSERT
@@ -246,6 +250,14 @@ class AbstractObjectMover(ABC):
     @abstractmethod
     def store_temp(self, cursor, batcher, oid, prev_tid, data):
         raise NotImplementedError()
+
+    @metricmethod_sampled
+    def store_temps(self, cursor, state_oid_tid_iter):
+        batcher = self.make_batcher(cursor) # Default row limit
+        store_temp = self.store_temp
+        for data, oid_int, tid_int in state_oid_tid_iter:
+            store_temp(cursor, batcher, oid_int, tid_int, data)
+        batcher.flush()
 
     @metricmethod_sampled
     def _generic_restore(self, batcher, oid, tid, data, command='INSERT'):

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -34,6 +34,7 @@ from . import drivers
 from .connmanager import Psycopg2ConnectionManager
 from .locker import PostgreSQLLocker
 from .mover import PG8000ObjectMover
+from .mover import Psycopg2ObjectMover
 from .mover import PostgreSQLObjectMover
 from .mover import to_prepared_queries
 from .oidallocator import PostgreSQLOIDAllocator
@@ -87,6 +88,12 @@ class PostgreSQLAdapter(object):
         if driver.__name__ == 'pg8000':
             mover_type = PG8000ObjectMover
             txn_type = PG8000TransactionControl
+        elif driver.__name__ == 'psycopg2':
+            # Sadly, psycopg2cffi 2.8.2 fails to correctly
+            # handle 'COPY FROM STDIN' in copy_expert().
+            # It's not immediately obvious why that is.
+            # XXX: Figure out what the difference is.
+            mover_type = Psycopg2ObjectMover
 
         self.mover = mover_type(
             driver,

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -34,7 +34,6 @@ from . import drivers
 from .connmanager import Psycopg2ConnectionManager
 from .locker import PostgreSQLLocker
 from .mover import PG8000ObjectMover
-from .mover import Psycopg2ObjectMover
 from .mover import PostgreSQLObjectMover
 from .mover import to_prepared_queries
 from .oidallocator import PostgreSQLOIDAllocator
@@ -88,12 +87,6 @@ class PostgreSQLAdapter(object):
         if driver.__name__ == 'pg8000':
             mover_type = PG8000ObjectMover
             txn_type = PG8000TransactionControl
-        elif driver.__name__ == 'psycopg2':
-            # Sadly, psycopg2cffi 2.8.2 fails to correctly
-            # handle 'COPY FROM STDIN' in copy_expert().
-            # It's not immediately obvious why that is.
-            # XXX: Figure out what the difference is.
-            mover_type = Psycopg2ObjectMover
 
         self.mover = mover_type(
             driver,

--- a/src/relstorage/adapters/postgresql/drivers/pg8000.py
+++ b/src/relstorage/adapters/postgresql/drivers/pg8000.py
@@ -168,6 +168,7 @@ class PG8000Driver(AbstractModuleDriver):
     def connect_with_isolation(self, isolation, dsn):
         conn = self.connect(dsn)
         cursor = conn.cursor()
+        cursor.copy_expert = lambda sql, stream: cursor.execute(sql, stream=stream)
         # For the current transaction
         cursor.execute('SET TRANSACTION %s' % isolation)
         # For future transactions on this same connection.

--- a/src/relstorage/adapters/postgresql/drivers/pg8000.py
+++ b/src/relstorage/adapters/postgresql/drivers/pg8000.py
@@ -19,12 +19,10 @@ pg8000 IDBDriver implementations.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import io
 from collections import deque
 
 from zope.interface import implementer
 
-from relstorage._compat import PY3
 from ..._abstract_drivers import AbstractModuleDriver
 from ..._abstract_drivers import _ConnWrapper
 from ...interfaces import IDBDriver
@@ -153,23 +151,8 @@ class PG8000Driver(AbstractModuleDriver):
                 # "UserWarning: DB-API extension cursor.connection used"
                 return self._c
 
-            # pg8000 on Python 3 wants to call `stream.readinto`,
-            # unlike psycopg2, which just uses `stream.read`. We don't implement
-            # that natively, so wrap it up.
-            # XXX: Do better than buffering the whole thing.
-            if PY3:
-                def copy_expert(self, sql, stream):
-                    bio = io.BytesIO()
-                    s = stream.read()
-                    while s:
-                        bio.write(s)
-                        s = stream.read()
-
-                    bio.seek(0)
-                    return self.execute(sql, stream=bio)
-            else:
-                def copy_expert(self, sql, stream):
-                    return self.execute(sql, stream=stream)
+            def copy_expert(self, sql, stream):
+                return self.execute(sql, stream=stream)
 
         class Connection(self.driver_module.Connection):
             def __init__(self,

--- a/src/relstorage/adapters/postgresql/drivers/psycopg2.py
+++ b/src/relstorage/adapters/postgresql/drivers/psycopg2.py
@@ -30,14 +30,6 @@ __all__ = [
     'Psycopg2Driver',
 ]
 
-def _create_connection(mod):
-    class Psycopg2Connection(mod.extensions.connection):
-        # The replica attribute holds the name of the replica this
-        # connection is bound to.
-        __slots__ = ('replica',)
-
-    return Psycopg2Connection
-
 
 @implementer(IDBDriver)
 class Psycopg2Driver(AbstractModuleDriver):
@@ -55,11 +47,19 @@ class Psycopg2Driver(AbstractModuleDriver):
         # pylint:disable=no-member
 
         self.Binary = psycopg2.Binary
-        self.connect = _create_connection(psycopg2)
+        self.connect = self._create_connection(psycopg2)
 
         # extensions
         self.ISOLATION_LEVEL_READ_COMMITTED = psycopg2.extensions.ISOLATION_LEVEL_READ_COMMITTED
         self.ISOLATION_LEVEL_SERIALIZABLE = psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE
+
+    def _create_connection(self, mod):
+        class Psycopg2Connection(mod.extensions.connection):
+            # The replica attribute holds the name of the replica this
+            # connection is bound to.
+            __slots__ = ('replica',)
+
+        return Psycopg2Connection
 
     def connect_with_isolation(self, isolation, *args, **kwargs):
         conn = self.connect(*args, **kwargs)

--- a/src/relstorage/adapters/postgresql/mover.py
+++ b/src/relstorage/adapters/postgresql/mover.py
@@ -407,7 +407,7 @@ class TempStoreCopyBuffer(object):
     # Finally, the trailer is a tuple size of -1
     TRAILER = struct.pack("!h", -1)
 
-    def read(self, size=0):
+    def read(self, size=8192):
         header = b''
         if self.HEADER:
             header = self.HEADER
@@ -433,7 +433,8 @@ class TempStoreCopyBuffer(object):
                 len_data = len(data)
                 md5 = digester(data) if digester is not None else None
                 # TODO: Maybe we should be using a bytearray and
-                # pack_into?
+                # pack_into? Or if we implement readinto() we can wrap a
+                # io.BufferedReader around us
                 if md5:
                     header = _pack_md5(
                         4,
@@ -452,7 +453,6 @@ class TempStoreCopyBuffer(object):
                     )
 
                 result += header + data
-
         return result
 
     def _read_done(self, _header, _size):

--- a/src/relstorage/cache/interfaces.py
+++ b/src/relstorage/cache/interfaces.py
@@ -22,16 +22,12 @@ import BTrees
 from transaction.interfaces import TransientError
 from ZODB.POSException import StorageError
 
-from relstorage._compat import PYPY
-
 # pylint: disable=inherit-non-class,no-method-argument,no-self-argument
 # pylint:disable=unexpected-special-method-signature
 # pylint:disable=signature-differs
 
 # An LLBTree uses much less memory than a dict, and is still plenty fast on CPython;
 # it's just as big and slower on PyPy, though.
-OID_TID_MAP_TYPE = BTrees.family64.II.BTree if not PYPY else dict
-OID_OBJECT_MAP_TYPE = BTrees.family64.IO.BTree if not PYPY else dict
 MAX_TID = BTrees.family64.maxint
 
 class IStateCache(Interface):
@@ -80,9 +76,10 @@ class IStateCache(Interface):
         Store the states for the ``(state, oid_int)`` pairs under
         ``(oid_int, tid_int)`` keys.
 
-        The *state_oid_iter* is an **iteable** of ``(state, oid_int)`` pairs;
-        this method may choose to buffer a limited amount of those pairs before
-        passing them on to the underlying storage in a bulk group.
+        The *state_oid_iter* is an **iteable** of ``(state, oid_int,
+        prev_tid_int)`` pairs; this method may choose to buffer a
+        limited amount of those pairs before passing them on to the
+        underlying storage in a bulk group.
 
         As an **iterable**, *state_oid_iter* may be consumed multiple
         times.

--- a/src/relstorage/cache/local_client.py
+++ b/src/relstorage/cache/local_client.py
@@ -28,11 +28,11 @@ from relstorage._util import get_memory_usage
 from relstorage._util import byte_display
 from relstorage._util import timer as _timer
 from relstorage._util import log_timed as _log_timed
+from relstorage._compat import OID_OBJECT_MAP_TYPE
+from relstorage._compat import OID_TID_MAP_TYPE
 
 from relstorage.cache.interfaces import IStateCache
 from relstorage.cache.interfaces import IPersistentCache
-from relstorage.cache.interfaces import OID_OBJECT_MAP_TYPE
-from relstorage.cache.interfaces import OID_TID_MAP_TYPE
 from relstorage.cache.interfaces import MAX_TID
 from relstorage.cache.interfaces import CacheCorruptedError
 
@@ -242,7 +242,7 @@ class LocalClient(object):
                 self._min_allowed_writeback[oid_tid[0]] = tid
 
     def set_all_for_tid(self, tid_int, state_oid_iter):
-        for state, oid_int in state_oid_iter:
+        for state, oid_int, _ in state_oid_iter:
             self[(oid_int, tid_int)] = (state, tid_int)
 
     def store_checkpoints(self, cp0, cp1):

--- a/src/relstorage/cache/local_database.py
+++ b/src/relstorage/cache/local_database.py
@@ -28,9 +28,10 @@ from contextlib import closing
 import sqlite3
 
 from relstorage._compat import ABC
+from relstorage._compat import OID_TID_MAP_TYPE
 from relstorage._util import log_timed
 from relstorage.adapters.batch import RowBatcher
-from relstorage.cache.interfaces import OID_TID_MAP_TYPE
+
 
 logger = __import__('logging').getLogger(__name__)
 

--- a/src/relstorage/cache/memcache_client.py
+++ b/src/relstorage/cache/memcache_client.py
@@ -107,7 +107,7 @@ class MemcacheStateCache(object):
     def set_all_for_tid(self, tid_int, state_oid_iter):
         send_size = 0
         to_send = {}
-        for state, oid_int in state_oid_iter:
+        for state, oid_int, _ in state_oid_iter:
             length = len(state)
             cachekey = (oid_int, tid_int)
             item_size = length + len(cachekey)

--- a/src/relstorage/cache/storage_cache.py
+++ b/src/relstorage/cache/storage_cache.py
@@ -810,6 +810,9 @@ class _PersistentRowFilter(object):
                     # we later wind up constructing that key (how could we do that?)
                     # or drop it; since we don't know what key it was actively being
                     # found under before, dropping it is our best option. Sadly.
+                    #
+                    # TODO: Use adapter.mover.current_object_tids() to check for currency
+                    # and store it if it's current.
                     continue
                 yield key, value
 

--- a/src/relstorage/cache/tests/test_memcache_client.py
+++ b/src/relstorage/cache/tests/test_memcache_client.py
@@ -50,11 +50,11 @@ class AbstractStateCacheTests(TestCase):
 
         c.set_all_for_tid(
             0,
-            [(b'abc', 0),
-             (b'ghi', 1),])
+            [(b'abc', 0, -1),
+             (b'ghi', 1, -1),])
         c.set_all_for_tid(
             1,
-            [(b'def', 0)]
+            [(b'def', 0, -1)]
         )
         # Hits on primary key
         self.assertEqual(c(0, 0),

--- a/src/relstorage/cache/tests/test_storage_cache.py
+++ b/src/relstorage/cache/tests/test_storage_cache.py
@@ -327,8 +327,9 @@ class StorageCacheTests(TestCase):
         c.store_temp(1, b'def')
         c.store_temp(2, b'ghi')
         self.assertEqual(b'ghi', c.read_temp(2))
-        self.assertEqual(dict(c.queue.stored_oids), {1: (3, 6), 2: (6, 9)})
-        f = c.queue._queue
+        self.assertEqual(dict(c.temp_objects.stored_oids),
+                         {1: (3, 6, 0), 2: (6, 9, 0)})
+        f = c.temp_objects._queue
         f.seek(0)
         self.assertEqual(f.read(), b'abcdefghi')
         c.checkpoints = (1, 0)
@@ -384,7 +385,7 @@ class StorageCacheTests(TestCase):
         c = self._makeOne()
         c.tpc_begin()
         c.clear_temp()
-        self.assertIsNone(c.queue)
+        self.assertIsNone(c.temp_objects)
 
     def test_after_poll_init_checkpoints(self):
         from relstorage.tests.fakecache import data

--- a/src/relstorage/cache/trace.py
+++ b/src/relstorage/cache/trace.py
@@ -79,7 +79,7 @@ class ZEOTracer(object):
         # we only work with the one defined in storage_cache.
         with self._lock:
             now = time.time()
-            for startpos, endpos, oid_int in state_oid_iter.items():
+            for startpos, endpos, oid_int, _prev_tid_int in state_oid_iter.items():
                 self._trace(0x52, oid_int, tid_int, dlen=endpos - startpos, now=now)
 
     def close(self):

--- a/src/relstorage/tests/blob/blob_connection.txt
+++ b/src/relstorage/tests/blob/blob_connection.txt
@@ -32,6 +32,9 @@ calling the blob's open method:
 
     >>> nothing = transaction.begin()
     >>> anotherblob = Blob()
+    >>> try:
+    ...    root._p_activate()
+    ... except: pass
     >>> root['anotherblob'] = anotherblob
     >>> nothing = transaction.commit()
 


### PR DESCRIPTION
This can be 20% or more faster.

Addresses #247 but there are still some cleanups that would be nice to do.