### PR TITLE
Use proper DB-API parameters in current_object_tids instead of writing the string ourself.

### DIFF
--- a/src/relstorage/adapters/batch.py
+++ b/src/relstorage/adapters/batch.py
@@ -140,10 +140,15 @@ class RowBatcher(object):
                 params = rows
 
             if these_params_need_flattened:
-                params = sorted(params) if self.sorted_deletes else params
-                params = list(itertools.chain.from_iterable(params))
+                params = self._flatten_params(params)
+            __traceback_info__ = params
             self.cursor.execute(stmt, params)
         return count
+
+    def _flatten_params(self, params):
+        params = sorted(params) if self.sorted_deletes else params
+        params = list(itertools.chain.from_iterable(params))
+        return params
 
     def _make_single_column_query(self, command, table,
                                   filter_column, filter_value,

--- a/src/relstorage/adapters/batch.py
+++ b/src/relstorage/adapters/batch.py
@@ -79,6 +79,29 @@ class RowBatcher(object):
                 or self.size_added >= self.size_limit):
             self.flush()
 
+    def select_from(self, columns, table, **kw):
+        """
+        Handles a query of the ``WHERE col IN (?, ?,)`` type.
+
+        The keyword arguments should be of length 1, containing
+        an iterable of the values to check.
+
+        Returns a list of matching rows.
+        """
+        assert len(kw) == 1
+        filter_column, filter_values = kw.popitem()
+        filter_values = list(filter_values)
+        results = []
+        command = 'SELECT %s' % (','.join(columns),)
+        while filter_values:
+            filter_subset = filter_values[:self.row_limit]
+            del filter_values[:self.row_limit]
+            descriptor = [[(table, (filter_column,)), filter_subset]]
+            self._do_batch(command, descriptor, rows_need_flattened=False)
+            results.extend(self.cursor.fetchall())
+        return results
+
+
     def flush(self):
         if self.deletes:
             self.total_rows_deleted += self._do_deletes()
@@ -91,18 +114,19 @@ class RowBatcher(object):
         self.size_added = 0
 
     def _do_deletes(self):
+        return self._do_batch('DELETE', sorted(iteritems(self.deletes)))
+
+    def _do_batch(self, command, descriptors, rows_need_flattened=True):
         count = 0
-        for (table, columns), rows in sorted(iteritems(self.deletes)):
+        for (table, columns), rows in descriptors:
             count += len(rows)
             # Be careful not to use % formatting on a string already
             # containing `delete_placeholder`
+            these_params_need_flattened = rows_need_flattened
             if len(columns) == 1:
-                # TODO: Some databases, like Postgres, natively support
-                # array types, which can be much faster.
-                # We should do that.
-                placeholder_str = ','.join([self.delete_placeholder] * len(rows))
-                stmt = "DELETE FROM %s WHERE %s IN (%s)" % (
-                    table, columns[0], placeholder_str)
+                stmt, params, these_params_need_flattened = self._make_single_column_query(
+                    command, table,
+                    columns[0], rows, rows_need_flattened)
             else:
                 row_template = " AND ".join(
                     ("%s=" % (column,)) + self.delete_placeholder
@@ -110,13 +134,25 @@ class RowBatcher(object):
                 )
                 row_template = "(%s)" % (row_template,)
                 rows_template = [row_template] * len(rows)
-                stmt = "DELETE FROM %s WHERE %s" % (
+                stmt = "%s FROM %s WHERE %s" % (
+                    command,
                     table, " OR ".join(rows_template))
+                params = rows
 
-            rows = sorted(rows) if self.sorted_deletes else rows
-            rows = list(itertools.chain.from_iterable(rows))
-            self.cursor.execute(stmt, rows)
+            if these_params_need_flattened:
+                params = sorted(params) if self.sorted_deletes else params
+                params = list(itertools.chain.from_iterable(params))
+            self.cursor.execute(stmt, params)
         return count
+
+    def _make_single_column_query(self, command, table,
+                                  filter_column, filter_value,
+                                  rows_need_flattened):
+        placeholder_str = ','.join([self.delete_placeholder] * len(filter_value))
+        stmt = "%s FROM %s WHERE %s IN (%s)" % (
+            command, table, filter_column, placeholder_str
+        )
+        return stmt, filter_value, rows_need_flattened
 
     def _do_inserts(self):
         count = 0

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -31,6 +31,7 @@ from ..packundo import HistoryPreservingPackUndo
 from ..poller import Poller
 from ..scriptrunner import ScriptRunner
 from . import drivers
+from .batch import PostgreSQLRowBatcher
 from .connmanager import Psycopg2ConnectionManager
 from .locker import PostgreSQLLocker
 from .mover import PG8000ObjectMover
@@ -93,6 +94,7 @@ class PostgreSQLAdapter(object):
             options=options,
             runner=self.runner,
             version_detector=self.version_detector,
+            batcher_factory=PostgreSQLRowBatcher,
         )
         self.oidallocator = PostgreSQLOIDAllocator()
         self.txncontrol = txn_type(

--- a/src/relstorage/adapters/postgresql/batch.py
+++ b/src/relstorage/adapters/postgresql/batch.py
@@ -1,0 +1,38 @@
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""
+Batch table row insert/delete support.
+"""
+
+from __future__ import absolute_import
+
+
+from ..batch import RowBatcher
+
+class PostgreSQLRowBatcher(RowBatcher):
+    """
+    Applies array operations to DELETE and SELECT
+    for single column filters.
+    """
+
+    def _make_single_column_query(self, command, table,
+                                  filter_column, filter_value,
+                                  rows_need_flattened):
+        stmt = "%s FROM %s WHERE %s = ANY (%s)" % (
+            command, table, filter_column, self.delete_placeholder
+        )
+        # We only pass a single parameter, and it doesn't need flattened.
+        # It does have to be an actual list, though
+        params = filter_value if isinstance(filter_value, list) else list(filter_value)
+        return stmt, (params,), False

--- a/src/relstorage/adapters/postgresql/batch.py
+++ b/src/relstorage/adapters/postgresql/batch.py
@@ -32,7 +32,13 @@ class PostgreSQLRowBatcher(RowBatcher):
         stmt = "%s FROM %s WHERE %s = ANY (%s)" % (
             command, table, filter_column, self.delete_placeholder
         )
-        # We only pass a single parameter, and it doesn't need flattened.
+        # We only pass a single parameter, and it doesn't need further
+        # flattening.
         # It does have to be an actual list, though
-        params = filter_value if isinstance(filter_value, list) else list(filter_value)
+        params = filter_value
+        if rows_need_flattened:
+            # This is guaranteed to return a list
+            params = self._flatten_params(params)
+        elif not isinstance(params, list):
+            params = list(params)
         return stmt, (params,), False

--- a/src/relstorage/adapters/postgresql/mover.py
+++ b/src/relstorage/adapters/postgresql/mover.py
@@ -188,7 +188,6 @@ class PostgreSQLObjectMover(AbstractObjectMover):
         stmt = self._move_from_temp_hf_insert_query
         cursor.execute(stmt, (tid,))
 
-
     @metricmethod_sampled
     def store_temp(self, _cursor, batcher, oid, prev_tid, data):
         suffix = """

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -50,6 +50,7 @@ class MockCursor(object):
         self.executed = []
         self.inputsizes = {}
         self.results = []
+        self.many_results = None
 
     def setinputsizes(self, **kw):
         self.inputsizes.update(kw)
@@ -62,6 +63,8 @@ class MockCursor(object):
         return self.results.pop(0)
 
     def fetchall(self):
+        if self.many_results:
+            return self.many_results.pop(0)
         r = self.results
         self.results = None
         return r


### PR DESCRIPTION
Through a slight generalization of the existing RowBatcher.

Also use PostgreSQL array types for that query and for deletes during restores. Internally they get transformed to the same query plans (IN would have been rewnitten to use = ANY), but this should let us take advantage of statement plan caches, and perhaps be more efficient to write across the network (since we're working with integer objects that can be packed into something smaller than the typically quite long string representation of large ints), depending on the driver (psycopg2 appears to use text, but pg8000 seems to use binary).