### PR TITLE
Validate older cache entries when loading from a persistent cache.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,18 @@
   store objects into the database. This can be 20-40% faster. See
   :issue:`247`.
 
+- Use more efficient mechanisms to poll the database for current TIDs
+  when verifying serials in transactions.
+
 - Silence a warning about ``cursor.connection`` from pg8000. See
   :issue:`238`.
+
+- Poll the database for the correct TIDs of older transactions when
+  loading from a persistent cache, and only use the entries if they
+  are current. This restores the functionality lost in the fix for
+  :issue:`249`.
+
+- Increase the default cache delta limit sizes.
 
 3.0a2 (2019-06-19)
 ==================

--- a/docs/relstorage-options.rst
+++ b/docs/relstorage-options.rst
@@ -345,12 +345,16 @@ cache-delta-size-limit
         beneficial. The cost is about 300K of memory for every 10000
         on CPython.
 
-        The default is 20000 on CPython, 10000 on PyPy.
+        The default is 100,000 on CPython, 50,000 on PyPy.
 
         .. versionchanged:: 2.0b7
            Double the default size from 10000 to 20000 on CPython. The
            use of LLBTree for the internal data structure means we use
            much less memory than we did before.
+
+        .. versionchanged:: 3.0a3
+           Increase the sizes again. With better persistent caching,
+           these become increasingly important.
 
 Persistent Local Caching
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -47,6 +47,10 @@ else:
 OID_TID_MAP_TYPE = BTrees.family64.II.BTree if not PYPY else dict
 OID_OBJECT_MAP_TYPE = BTrees.family64.IO.BTree if not PYPY else dict
 
+def iteroiditems(d):
+    # Could be either a BTree, which always has 'iteritems',
+    # or a plain dict, which may or may not have iteritems.
+    return d.iteritems() if hasattr(d, 'iteritems') else d.items()
 
 # Types
 

--- a/src/relstorage/cache/tests/test_storage_cache.py
+++ b/src/relstorage/cache/tests/test_storage_cache.py
@@ -597,7 +597,8 @@ class PersistentRowFilterTests(TestCase):
 
     def _makeOne(self):
         from relstorage.cache.storage_cache import _PersistentRowFilter
-        return _PersistentRowFilter(dict)
+        adapter = MockAdapter()
+        return _PersistentRowFilter(adapter, dict)
 
     def test_no_checkpoints(self):
         f = self._makeOne()

--- a/src/relstorage/options.py
+++ b/src/relstorage/options.py
@@ -89,7 +89,7 @@ class Options(object):
     #: Directory holding persistent cache files
     cache_local_dir = None
     #: Switch checkpoints after this many writes
-    cache_delta_size_limit = 20000 if not PYPY else 10000
+    cache_delta_size_limit = 100000 if not PYPY else 50000
     #: Implementation of ILRUCache to use for local cache
     #: storage.
     cache_local_storage = None


### PR DESCRIPTION
This makes the cache useful again for objects that rarely change in write-heavy databases. The cost appears to be less than 1s per 100K cached objects.

This does mean that we should more carefully track frequency of hits and evict old objects that are never actually used, though. (That isn't done here.)

Also, we should propagate invalidations down to the persistent cache layer, but this also isn't done here.