### PR TITLE
Remove more outdated code for old PostgreSQL versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,20 @@
   already chunking the blobs for storage, so our layer of extra chunking was
   unnecessary.
 
+  .. important::
+
+     The first time a storage is opened with this version,
+     blobs that have multiple chunks will be collapsed into a single
+     chunk. If there are many blobs larger than 2GB, this could take
+     some time.
+
+     It is recommended you have a backup before installing this
+     version.
+
+     To verify that the blobs were correctly migrated, you should
+     clean or remove your configured blob-cache directory, forcing new
+     blobs to be downloaded.
+
 - Fix a bug that left large objects behind if a PostgreSQL database
   containing any blobs was ever zapped (with ``storage.zap_all()``).
   The ``zodbconvert`` command, the ``zodbshootout`` command, and the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,7 +143,8 @@
 
 - Add ``gevent MySQLdb``, a new driver that cooperates with gevent
   while still using the C extensions of ``mysqlclient`` to communicate
-  with MySQL. This is now recommended over ``umysqldb``.
+  with MySQL. This is now recommended over ``umysqldb``, which is
+  deprecated and will be removed.
 
 - Rewrite the persistent cache implementation. It now is likely to
   produce much higher hit rates (100% on some benchmarks, compared to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,18 @@
   cache and so may be useful for more than one thread. This can be
   3x or more faster than loading objects on-demand. See :issue:`239`.
 
+- Stop chunking blob uploads on PostgreSQL. All supported versions
+  natively handle blobs greater than 2GB in size, and the server was
+  already chunking the blobs for storage, so our layer of extra chunking was
+  unnecessary.
+
+- Fix a bug that left large objects behind if a PostgreSQL database
+  containing any blobs was ever zapped (with ``storage.zap_all()``).
+  The ``zodbconvert`` command, the ``zodbshootout`` command, and the
+  RelStorage test suite could all zap databases. Running the
+  ``vacuumlo`` command included with PostgreSQL will free such
+  orphaned large objects, after which a regular ``vacuumdb`` command
+  can be used to reclaim space. See :issue:`260`.
 
 3.0a3 (2019-06-26)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 
 RelStorage is a storage implementation for ZODB that stores pickles in
-a relational database. PostgreSQL 9.0 and above (performance is best
-with 9.5 and above), MySQL 5.7 / 8.0, and Oracle 10g and 11g
-are currently supported. RelStorage replaced the PGStorage project.
+a relational database. PostgreSQL 9.6 and above, MySQL 5.7 / 8.0, and
+Oracle 10g and 11g are currently supported. RelStorage replaced the
+PGStorage project.
 
 
 ==========

--- a/docs/db-specific-options.rst
+++ b/docs/db-specific-options.rst
@@ -27,16 +27,21 @@ driver
 PostgreSQL Adapter Options
 ==========================
 
-RelStorage 2.1 performs best with PostgreSQL 9.5 or above.
+RelStorage 3.0 requires PostgreSQL 9.6 or above.
 
 The PostgreSQL adapter accepts:
 
 driver
-    The possible options are:
+    All of these drivers use the name of the corresponding PyPI
+    package. The possible options are:
 
     psycopg2
       A C-based driver that requires the PostgreSQL development
       libraries. Optimal on CPython, but not compatible with gevent.
+      Non-production, experimental usage, can install the
+      ``psycopg2-binary`` package to be able to use this driver
+      without `needing a C compiler
+      <http://initd.org/psycopg/docs/install.html#binary-packages>`_.
 
     psycopg2cffi
       A C-based driver that requires the PostgreSQL development
@@ -46,8 +51,6 @@ driver
     pg8000
      A pure-Python driver suitable for use with gevent. Works on all
      supported platforms.
-
-     .. note:: pg8000 requires PostgreSQL 9.4 or above for BLOB support.
 
 dsn
     Specifies the data source name for connecting to PostgreSQL.

--- a/docs/db-specific-options.rst
+++ b/docs/db-specific-options.rst
@@ -29,6 +29,20 @@ PostgreSQL Adapter Options
 
 RelStorage 3.0 requires PostgreSQL 9.6 or above.
 
+.. tip::
+
+   Persistent object state data (pickles) will default to being stored
+   on disk in a compressed format if they are longer than roughly
+   2,000 bytes. Thus wrapper storages like ``zc.zlibstorage`` are
+   unlikely to save much disk space. They may still reduce network
+   traffic, however, at the cost of CPU usage in the Python process.
+
+   If you used a compressing wrapper, `you can disable this disk
+   compression
+   <https://www.postgresql.org/docs/current/storage-toast.html#STORAGE-TOAST-ONDISK>`_
+   with the SQL command ``ALTER TABLE object_state ALTER COLUMN STATE
+   SET storage EXTERNAL``.
+
 The PostgreSQL adapter accepts:
 
 driver

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -28,6 +28,22 @@ Database Adapter
 You also need the Python database adapter that corresponds with your
 database.
 
+On CPython2, install psycopg2 2.8+, mysqlclient 1.4+, or cx_Oracle
+5.2+ (but use caution with 5.2.1+); PyMySQL 0.7, MySQL
+Connector/Python 8.0.16 and umysql are also tested to work as is
+pg8000.
+
+.. note:: umysql support is deprecated and will be removed.
+
+For CPython3, install psycopg2, mysqlclient 1.4+, or cx_Oracle;
+PyMySQL, MySQL Connector/Python  and pg8000 are also known to work.
+
+On PyPy, install psycopg2cffi 2.8+ or PyMySQL 0.6.6+ (PyPy will
+generally work with psycopg2 and mysqlclient, but it will be *much*
+slower; in contrast, pg8000 performs nearly as well. cx_Oracle is
+untested on PyPy). MySQL Connector/Python is tested to work on PyPy
+7.1.
+
 .. tip::
    The easiest way to get the recommended and tested database adapter for
    your platform and database is to install the corresponding RelStorage
@@ -38,25 +54,17 @@ database.
     pip install "RelStorage[postgresql]"
     pip install "RelStorage[oracle]"
 
+   Installing those packages may require you to have database client
+   software and development libraries already installed. Some packages
+   may provide binary wheels on PyPI for some platforms. In the case
+   of psycopg2, that binary package (which is not recommended for
+   production use) can be installed with the name ``psycopg2-binary``.
+   Note that the ``postgresql`` extra in RelStorage does **not**
+   install the binary but attempts to install from source.
 
-On CPython2, install psycopg2 2.6.1+, mysqlclient 1.4+, or cx_Oracle
-5.2+ (but use caution with 5.2.1+); PyMySQL 0.7, MySQL
-Connector/Python 8.0.16 and umysql are also tested to work as is
-pg8000.
-
-.. note:: umysql support is deprecated and will be removed.
-
-For CPython3, install psycopg2, mysqlclient 1.4+, or cx_Oracle;
-PyMySQL, MySQL Connector/Python  and pg8000 are also known to work.
-
-On PyPy, install psycopg2cffi 2.7.4+ or PyMySQL 0.6.6+ (PyPy will
-generally work with psycopg2 and mysqlclient, but it will be *much*
-slower; in contrast, pg8000 performs nearly as well. cx_Oracle is
-untested on PyPy). MySQL Connector/Python is tested to work on PyPy
-7.1.
 
 Here's a table of known (tested) working adapters; adapters **in
-bold** are the recommended adapter.
+bold** are the recommended adapter installed with the extra.
 
 .. table:: Tested Adapters
    :widths: auto

--- a/setup.py
+++ b/setup.py
@@ -132,12 +132,24 @@ setup(
         'mysql:platform_python_implementation=="PyPy" or sys_platform == "win32"': [
             'PyMySQL>=0.6.6',
         ],
+        # Notes on psycopg2: In 2.8, they stopped distributing full
+        # binary wheels under that name. For that, you have to use
+        # psycopg2-binary (which in 2.8.3 appears to be compiled with
+        # the libpq from postgres 11). But that's not recommended for
+        # production usage because it can have conflicts with other libraries,
+        # and the authors specifically request that other modules not depend on
+        # psycopg2-binary.
+        # See http://initd.org/psycopg/docs/install.html#binary-packages
         'postgresql: platform_python_implementation == "CPython"': [
-            # 2.4.1+ is required for proper bytea handling
-            'psycopg2>=2.6.1',
+            # 2.4.1+ is required for proper bytea handling;
+            # 2.6+ is needed for 64-bit lobject support.
+            # 2.7+ is needed for Python 3.7 support and PostgreSQL 10+.
+            # 2.7.6+ is needed for PostgreSQL 11
+            'psycopg2 >= 2.8.3',
         ],
         'postgresql: platform_python_implementation == "PyPy"': [
-            'psycopg2cffi>=2.7.4',
+            # 2.8.0+ is needed for Python 3.7
+            'psycopg2cffi >= 2.8.1',
         ],
         'oracle': [
             'cx_Oracle>=5.0.0'

--- a/src/relstorage/_util.py
+++ b/src/relstorage/_util.py
@@ -109,7 +109,6 @@ def get_memory_usage():
 def byte_display(size):
     """
     Returns a size with the correct unit (KB, MB), given the size in bytes.
-    The output should be given to zope.i18n.translate()
     """
     if size == 0:
         return '0 KB'

--- a/src/relstorage/adapters/postgresql/__init__.py
+++ b/src/relstorage/adapters/postgresql/__init__.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """PostgreSQL adapter for RelStorage."""
 from __future__ import absolute_import
+from __future__ import print_function
 
 from relstorage.adapters.postgresql.adapter import PostgreSQLAdapter
 from relstorage.adapters.postgresql.adapter import select_driver
@@ -45,3 +46,44 @@ def debug_my_locks(cursor): # pragma: no cover
     rows = '\n'.join('\t'.join((str(i) for i in r)) for r in rows)
     header = '*Locks for %s isomode %s\n' % (pid, conn.isolation_level)
     return header + rows
+
+
+def print_size_report(cursor): # pragma: no cover
+    extra_query = ''
+    query = """
+    SELECT table_name,
+        pg_size_pretty(total_bytes) AS total,
+        pg_size_pretty(index_bytes) AS INDEX,
+        pg_size_pretty(toast_bytes) AS toast,
+        pg_size_pretty(table_bytes) AS TABLE
+    FROM (
+    SELECT *, total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes FROM (
+    SELECT c.oid,nspname AS table_schema, relname AS TABLE_NAME
+          , c.reltuples AS row_estimate
+          , pg_total_relation_size(c.oid) AS total_bytes
+          , pg_indexes_size(c.oid) AS index_bytes
+          , pg_total_relation_size(reltoastrelid) AS toast_bytes
+      FROM pg_class c
+      LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE relkind = 'r'
+        ) a
+    ) a
+    WHERE (table_name NOT LIKE 'pg_%' and table_name not like 'abstract_%'
+    )
+    AND table_schema <> 'pg_catalog' and table_schema <> 'information_schema'
+    ORDER BY total_bytes DESC
+    """
+
+    cursor.execute(query)
+    keys = ['table_name', 'total', 'index', 'toast', 'table']
+    rows = [dict(zip(keys, row)) for row in cursor]
+
+    rows.insert(0, {k: k for k in keys})
+    print()
+    fmt = "| {table_name:35s} | {total:10s} | {index:10s} | {toast:10s} | {table:10s}"
+    for row in rows:
+        if not extra_query and row['total'] in ('72 kB', '32 kB', '24 kB', '16 kB', '8192 bytes'):
+            continue
+        print(fmt.format(
+            **{k: v if v else '<null>' for k, v in row.items()}
+        ))

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -72,9 +72,8 @@ class PostgreSQLAdapter(object):
         )
         self.runner = ScriptRunner()
         self.locker = PostgreSQLLocker(
-            options=options,
-            lock_exceptions=driver.lock_exceptions,
-            version_detector=self.version_detector,
+            options,
+            driver.lock_exceptions,
         )
         self.schema = PostgreSQLSchemaInstaller(
             connmanager=self.connmanager,
@@ -208,7 +207,6 @@ class PostgreSQLAdapter(object):
 
     def new_instance(self):
         inst = type(self)(dsn=self._dsn, options=self.options)
-        inst.version_detector.version = self.version_detector.version
         return inst
 
     def __str__(self):

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -76,10 +76,10 @@ class PostgreSQLAdapter(object):
             driver.lock_exceptions,
         )
         self.schema = PostgreSQLSchemaInstaller(
+            options=options,
             connmanager=self.connmanager,
             runner=self.runner,
             locker=self.locker,
-            keep_history=self.keep_history,
         )
 
         mover_type = PostgreSQLObjectMover

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -384,6 +384,7 @@ class AbstractSchemaInstaller(ABC):
     # Subclasses can redefine these.
     _slow_zap_all_tbl_stmt = _zap_all_tbl_stmt = 'DELETE FROM %s'
 
+
     def zap_all(self, reset_oid=True, slow=False):
         """
         Clear all data out of the database.
@@ -400,6 +401,7 @@ class AbstractSchemaInstaller(ABC):
             todo = list(self.all_tables)
             todo.reverse() # using reversed()  doesn't print nicely
             log.debug("Checking tables: %r", todo)
+            self._before_zap_all_tables(cursor, existent, slow)
             for table in todo:
                 log.debug("Considering table %s", table)
                 if table.startswith('temp_'):
@@ -418,6 +420,12 @@ class AbstractSchemaInstaller(ABC):
                 log.debug("Done running OID reset script.")
 
         self.connmanager.open_and_call(callback)
+
+    # Hooks for subclasses
+
+    def _before_zap_all_tables(self, cursor, tables, slow=False):
+        log.debug("Before zapping existing tables (%s) with %s; slow: %s",
+                  tables, cursor, slow)
 
     def _after_zap_all_tables(self, cursor, slow=False):
         log.debug("Running init script. Slow: %s", slow)

--- a/src/relstorage/tests/testpostgresql.py
+++ b/src/relstorage/tests/testpostgresql.py
@@ -17,10 +17,13 @@ from __future__ import absolute_import
 import logging
 import unittest
 
+from ZODB.tests import StorageTestBase
+
 from relstorage.adapters.postgresql import PostgreSQLAdapter
 
 from .util import AbstractTestSuiteBuilder
-
+from . import StorageCreatingMixin
+from . import TestCase
 
 class PostgreSQLAdapterMixin(object):
 
@@ -63,6 +66,72 @@ class PostgreSQLAdapterMixin(object):
     def verify_adapter_from_zconfig(self, adapter):
         self.assertEqual(adapter._dsn, self.__get_adapter_zconfig_dsn())
 
+class TestBlobMerge(PostgreSQLAdapterMixin,
+                    StorageCreatingMixin,
+                    TestCase,
+                    StorageTestBase.StorageTestBase):
+    # pylint:disable=too-many-ancestors
+
+    def test_merge_blobs_on_open(self):
+        from ZODB.DB import DB
+        from ZODB.blob import Blob
+        import transaction
+        storage = self._closing(self.make_storage(
+            blob_dir='blobs', shared_blob_dir=False))
+        db = self._closing(DB(storage))
+        conn = db.open()
+
+        blob = Blob()
+        base_chunk = b"This is my base blob."
+        with blob.open('w') as f:
+            f.write(base_chunk)
+
+        conn.root().blob = blob
+        transaction.commit()
+
+        # Insert some extra chunks. Get them big to be sure we loop
+        # properly
+        second_chunk = b'second chunk' * 800
+        cursor = conn._storage._store_cursor
+        cursor.execute("""
+        INSERT INTO blob_chunk (zoid, chunk_num, tid, chunk)
+        SELECT zoid, 1, tid, lo_from_bytea(0, %s)
+        FROM blob_chunk WHERE chunk_num = 0;
+        """, (second_chunk,))
+        third_chunk = b'third chunk' * 900
+        cursor.execute("""
+        INSERT INTO blob_chunk (zoid, chunk_num, tid, chunk)
+        SELECT zoid, 2, tid, lo_from_bytea(0, %s)
+        FROM blob_chunk WHERE chunk_num = 0;
+        """, (third_chunk,))
+
+        cursor.execute('SELECT COUNT(*) FROM blob_chunk')
+        self.assertEqual(3, cursor.fetchone()[0])
+        cursor.connection.commit()
+        # Now open again and find everything put together.
+        # But we need to use a new blob dir, because
+        # we changed data behind its back.
+        conn.close()
+        db.close()
+
+        storage = self._closing(self.make_storage(blob_dir='blobs2',
+                                                  shared_blob_dir=False,
+                                                  zap=False))
+        db = self._closing(DB(storage))
+        conn = db.open()
+
+        blob = conn.root().blob
+        with blob.open('r') as f:
+            data = f.read()
+
+        cursor = conn._storage._load_cursor
+        cursor.execute('SELECT COUNT(*) FROM blob_chunk')
+        self.assertEqual(1, cursor.fetchone()[0])
+
+        self.assertEqual(data, base_chunk + second_chunk + third_chunk)
+        conn.close()
+        db.close()
+
 # Timing shows that we spend 6.9s opening database connections to a
 # local PostgreSQL 11 server when using Python 3.7 and psycopg2 2.8
 # during a total test run of 2:27. I had thought that maybe connection
@@ -78,6 +147,7 @@ class PostgreSQLTestSuiteBuilder(AbstractTestSuiteBuilder):
         super(PostgreSQLTestSuiteBuilder, self).__init__(
             drivers,
             PostgreSQLAdapterMixin,
+            extra_test_classes=(TestBlobMerge,)
         )
 
     def _compute_large_blob_size(self, use_small_blobs):
@@ -95,6 +165,7 @@ class PostgreSQLTestSuiteBuilder(AbstractTestSuiteBuilder):
 
 def test_suite():
     return PostgreSQLTestSuiteBuilder().test_suite()
+
 
 if __name__ == '__main__':
     logging.basicConfig()

--- a/src/relstorage/tests/testpostgresql.py
+++ b/src/relstorage/tests/testpostgresql.py
@@ -84,14 +84,12 @@ class PostgreSQLTestSuiteBuilder(AbstractTestSuiteBuilder):
         if use_small_blobs:
             # Avoid creating 2GB blobs to be friendly to neighbors
             # and to run fast (2GB blobs take about 4 minutes on Travis
-            # CI as-of June 2016)
-            # XXX: This is dirty.
-            from relstorage.adapters.postgresql.mover import PostgreSQLObjectMover as ObjectMover
-            assert hasattr(ObjectMover, 'postgresql_blob_chunk_maxsize')
-            ObjectMover.postgresql_blob_chunk_maxsize = 1024 * 1024 * 10
-            large_blob_size = ObjectMover.postgresql_blob_chunk_maxsize * 2
+            # CI as-of June 2016).
+            # RS 3.0 no longer needs to chunk.
+            large_blob_size = 20 * 1024 * 1024
         else:
-            large_blob_size = 1 << 31
+            # Something bigger than 2GB (signed 32 bit int)
+            large_blob_size = (1 << 31) + 200 * 1024 * 1024
         return large_blob_size
 
 

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -256,6 +256,9 @@ class AbstractTestSuiteBuilder(ABC):
 
         for shared_blob_dir in shared_blob_dir_choices:
             for keep_history in (False, True):
+                # TODO: Make any of the tests that are needing this
+                # subclass StorageCreatingMixin so we unify where
+                # that's handled.
                 def create_storage(name, blob_dir,
                                    shared_blob_dir=shared_blob_dir,
                                    keep_history=keep_history, **kw):

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -95,7 +95,7 @@ class AbstractTestSuiteBuilder(ABC):
 
     __name__ = None # PostgreSQL, MySQL, Oracle
 
-    def __init__(self, driver_options, use_adapter):
+    def __init__(self, driver_options, use_adapter, extra_test_classes=()):
         """
         :param driver_options: The ``IDBDriverOptions``
         :param use_adapter: A mixin class implementing the abstract methods
@@ -103,6 +103,7 @@ class AbstractTestSuiteBuilder(ABC):
         """
 
         self.drivers = driver_options
+        self.extra_test_classes = extra_test_classes
         self.base_dbname = os.environ.get('RELSTORAGETEST_DBNAME', 'relstoragetest')
         self.db_names = {
             'data': self.base_dbname,
@@ -245,6 +246,12 @@ class AbstractTestSuiteBuilder(ABC):
             suite.addTest(unittest.makeSuite(klass, "check"))
 
         for klass in self._make_zodbconvert_classes():
+            suite.addTest(unittest.makeSuite(
+                self._new_class_for_driver(driver_name,
+                                           klass,
+                                           is_available)))
+
+        for klass in self.extra_test_classes:
             suite.addTest(unittest.makeSuite(
                 self._new_class_for_driver(driver_name,
                                            klass,


### PR DESCRIPTION
In particular, it's no longer necessary to split blobs into multiple chunks. Postgres has supported > 2GB blobs since 9.3, and the drivers and libpq don't even need to know about that given our limited use of the `lobject` class. For psycopg2/psycopg2cffi, this could make large blobs much more pleasant to work with, as the entirety of the upload/download is now done with the GIL released.

I think this largely finishes fixing #220 

As part of updating the documentation for version requirements, this fixes #208.  

Working with blobs led to the discovery and fix of #260 