### PR TITLE
Fix #270, fix #271 and fix #272

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,22 @@
 3.0a5 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Reduce the time that MySQL will wait to perform OID garbage
+  collection on startup. See :issue:`271`.
 
+- Fix several instances where RelStorage could attempt to perform
+  operations on a database connection with outstanding results on a
+  cursor. Some database drivers can react badly to this, depending on
+  the exact circumstances. For example, mysqlclient can raise
+  ``ProgrammingError: (2014, "Commands out of sync; you can't run this
+  command now")``. See :issue:`270`.
+
+- Fix the "gevent MySQLdb" driver to be cooperative during ``commit``
+  and ``rollback`` operations. Previously, it would block the event
+  loop for the entire time it took to send the commit or rollback
+  request, the server to perform the request, and the result to be
+  returned. Now, it frees the event loop after sending the request.
+  See :issue:`272`.
 
 3.0a4 (2019-07-10)
 ==================

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -205,8 +205,24 @@ class IConnectionManager(Interface):
     def open():
         """Open a database connection and return (conn, cursor)."""
 
-    def close(conn, cursor):
-        """Close a connection and cursor, ignoring certain errors.
+    def close(conn=None, cursor=None):
+        """
+        Close a connection and cursor, ignoring certain errors.
+        """
+
+    def rollback_and_close(conn, cursor):
+        """
+        Rollback the connection and close it.
+
+        Certain database drivers, such as MySQLdb using the SSCursor, require
+        all cursors to be closed before rolling back (otherwise it generates a
+        ProgrammingError: 2014 "Commands out of sync").
+        This method abstracts that.
+        """
+
+    def rollback(conn, cursor):
+        """
+        Like `rollback_and_close`, but without the close.
         """
 
     def open_and_call(callback):

--- a/src/relstorage/adapters/mysql/adapter.py
+++ b/src/relstorage/adapters/mysql/adapter.py
@@ -122,6 +122,7 @@ class MySQLAdapter(object):
         self.connmanager.add_on_load_opened(self.mover.on_load_opened)
         self.oidallocator = MySQLOIDAllocator()
         self.txncontrol = MySQLTransactionControl(
+            connmanager=self.connmanager,
             keep_history=self.keep_history,
             Binary=driver.Binary,
         )

--- a/src/relstorage/adapters/mysql/connmanager.py
+++ b/src/relstorage/adapters/mysql/connmanager.py
@@ -43,6 +43,7 @@ class MySQLdbConnectionManager(AbstractConnectionManager):
         self.use_replica_exceptions = driver.use_replica_exceptions
         self._db_connect = driver.connect
         self._db_driver = driver
+        self._fetchall_on_rollback = driver.fetchall_on_rollback
         super(MySQLdbConnectionManager, self).__init__(options)
 
     def _alter_params(self, replica):

--- a/src/relstorage/adapters/mysql/drivers/__init__.py
+++ b/src/relstorage/adapters/mysql/drivers/__init__.py
@@ -35,6 +35,9 @@ class AbstractMySQLDriver(AbstractModuleDriver):
     # https://github.com/zodb/relstorage/issues/213)
     MY_CHARSET_STMT = 'SET names binary'
 
+    # Does this driver need cursor.fetchall() called before a rollback?
+    fetchall_on_rollback = False
+
     def cursor(self, conn):
         cursor = AbstractModuleDriver.cursor(self, conn)
         cursor.execute(self.MY_CHARSET_STMT)

--- a/src/relstorage/adapters/mysql/drivers/mysqldb.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqldb.py
@@ -22,6 +22,7 @@ from zope.interface import implementer
 
 from relstorage.adapters.interfaces import IDBDriver
 
+from relstorage._util import Lazy
 from relstorage._compat import PY3
 from . import AbstractMySQLDriver
 
@@ -46,6 +47,38 @@ class MySQLdbDriver(AbstractMySQLDriver):
         # values.
         MY_CHARSET_STMT = 'SET character_set_results = binary'
 
+    fetchall_on_rollback = True
+
+    @Lazy
+    def _strict_cursor(self):
+        from MySQLdb.cursors import SSCursor # pylint:disable=no-name-in-module,import-error
+        # Using MySQLdb.cursors.SSCursor can get us some legitimate
+        # errors (ProgrammingError: (2014, "Commands out of sync; you
+        # can't run this command now")), although it adds some overhead
+        # because of more database communication. And the docstring says you have to
+        # call `close()` before making another query, but in practice that
+        # doesn't seem to be the case.
+        #
+        # For extra strictness/debugging, we can wrap this with our
+        # custom debugging cursor.
+        if 0: # pylint:disable=using-constant-test
+            # TODO: Make this configurable, and add this to
+            # all drivers.
+            from relstorage._util import NeedsFetchallBeforeCloseCursor
+
+            def cursor_factory(conn):
+                cur = SSCursor(conn)
+                cur = NeedsFetchallBeforeCloseCursor(cur)
+                return cur
+        else:
+            cursor_factory = SSCursor
+
+        return cursor_factory
+
+    def connect(self, *args, **kwargs):
+        if self.STRICT and 'cursorclass' not in kwargs:
+            kwargs['cursorclass'] = self._strict_cursor
+        return AbstractMySQLDriver.connect(self, *args, **kwargs)
 
 class GeventMySQLdbDriver(MySQLdbDriver):
     __name__ = 'gevent MySQLdb'
@@ -53,10 +86,15 @@ class GeventMySQLdbDriver(MySQLdbDriver):
     _GEVENT_CAPABLE = True
     _GEVENT_NEEDS_SOCKET_PATCH = False
 
-    _wait_read = None
-    _wait_write = None
+    def __init__(self):
+        super(GeventMySQLdbDriver, self).__init__()
+        # Replace self._connect (which was MySQLdb.connect) with
+        # direct call to our desired class.
+        self._connect = self._get_connection_class()
 
     def get_driver_module(self):
+        # Make sure we can use gevent; if we can't the ImportError
+        # will prevent this driver from being used.
         __import__('gevent')
         return super(GeventMySQLdbDriver, self).get_driver_module()
 
@@ -72,6 +110,9 @@ class GeventMySQLdbDriver(MySQLdbDriver):
             wait_read = socket.wait_read # pylint:disable=no-member
             wait_write = socket.wait_write # pylint:disable=no-member
 
+            # Prior to mysqlclient 1.4, there was a 'waiter' Connection
+            # argument that could be used to do this, but it was removed.
+            # So we implement it ourself.
             class Connection(Base):
                 def query(self, query):
                     # From the mysqlclient implementation:
@@ -85,12 +126,21 @@ class GeventMySQLdbDriver(MySQLdbDriver):
                     wait_read(fileno)
                     self.read_query_result()
 
+                # The default implementations of 'rollback' and
+                # 'commit' use only C API functions `mysql_rollback`
+                # and `mysql_commit`; it doesn't touch any internal
+                # state. Those in turn simply call
+                # `mysql_real_query("rollback")` and
+                # `mysql_real_query("commit")`. That's a synchronous
+                # function that waits for the result to be ready. We
+                # don't want to block like that (commit could
+                # potentially take some time.)
+
+                def rollback(self):
+                    self.query('rollback')
+
+                def commit(self):
+                    self.query('commit')
+
             cls._Connection = Connection
         return cls._Connection
-
-    def connect(self, *args, **kwargs):
-        # Prior to mysqlclient 1.4, there was a 'waiter' Connection
-        # argument that could be used to do this, but it was removed.
-        # So we implement it ourself.
-        klass = self._get_connection_class()
-        return klass(*args, **kwargs) # pylint:disable=not-callable

--- a/src/relstorage/adapters/oracle/adapter.py
+++ b/src/relstorage/adapters/oracle/adapter.py
@@ -111,6 +111,7 @@ class OracleAdapter(object):
             connmanager=self.connmanager,
         )
         self.txncontrol = OracleTransactionControl(
+            connmanager=self.connmanager,
             keep_history=self.keep_history,
             Binary=driver.Binary,
             twophase=twophase,

--- a/src/relstorage/adapters/oracle/txncontrol.py
+++ b/src/relstorage/adapters/oracle/txncontrol.py
@@ -25,8 +25,8 @@ log = logging.getLogger(__name__)
 
 class OracleTransactionControl(GenericTransactionControl):
 
-    def __init__(self, keep_history, Binary, twophase):
-        GenericTransactionControl.__init__(self, keep_history, Binary)
+    def __init__(self, connmanager, keep_history, Binary, twophase):
+        GenericTransactionControl.__init__(self, connmanager, keep_history, Binary)
         self.twophase = twophase
 
     def commit_phase1(self, conn, cursor, tid):

--- a/src/relstorage/adapters/packundo.py
+++ b/src/relstorage/adapters/packundo.py
@@ -566,7 +566,7 @@ class HistoryPreservingPackUndo(PackUndo):
             log.info("pre_pack: finished successfully")
             conn.commit()
         except:
-            conn.rollback()
+            self.connmanager.rollback(conn, cursor)
             raise
         finally:
             self.connmanager.close(conn, cursor)
@@ -768,7 +768,7 @@ class HistoryPreservingPackUndo(PackUndo):
 
             except:
                 log.exception("pack: failed")
-                conn.rollback()
+                self.connmanager.rollback(conn, cursor)
                 raise
 
             else:
@@ -1051,7 +1051,7 @@ class HistoryFreePackUndo(PackUndo):
                 self._pre_pack_main(conn, cursor, pack_tid, get_references)
             except:
                 log.exception("pre_pack: failed")
-                conn.rollback()
+                self.connmanager.rollback(conn, cursor)
                 raise
             else:
                 conn.commit()
@@ -1169,13 +1169,12 @@ class HistoryFreePackUndo(PackUndo):
 
             except:
                 log.exception("pack: failed")
-                conn.rollback()
+                self.connmanager.rollback(conn, cursor)
                 raise
 
             else:
                 log.info("pack: finished successfully")
                 conn.commit()
-
         finally:
             self.connmanager.close(conn, cursor)
 

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -98,6 +98,7 @@ class PostgreSQLAdapter(object):
         )
         self.oidallocator = PostgreSQLOIDAllocator()
         self.txncontrol = txn_type(
+            connmanager=self.connmanager,
             keep_history=self.keep_history,
             driver=driver,
         )

--- a/src/relstorage/adapters/postgresql/connmanager.py
+++ b/src/relstorage/adapters/postgresql/connmanager.py
@@ -49,6 +49,8 @@ class Psycopg2ConnectionManager(AbstractConnectionManager):
             dsn = '%s host=%s' % (self._dsn, replica)
         return dsn
 
+    _fetchall_on_rollback = False
+
     @metricmethod
     def open(self, isolation=None, deferrable=False, read_only=False,
              replica_selector=None, **kwargs):

--- a/src/relstorage/adapters/postgresql/drivers/pg8000.py
+++ b/src/relstorage/adapters/postgresql/drivers/pg8000.py
@@ -24,7 +24,6 @@ from collections import deque
 from zope.interface import implementer
 
 from ..._abstract_drivers import AbstractModuleDriver
-from ..._abstract_drivers import _ConnWrapper
 from ...interfaces import IDBDriver
 
 __all__ = [
@@ -190,9 +189,6 @@ class PG8000Driver(AbstractModuleDriver):
 
         self._connect = Connection
 
-    # For debugging
-    _wrap = False
-
     def connect(self, dsn): # pylint:disable=arguments-differ
         # Parse the DSN into parts to pass as keywords.
         # We don't do this psycopg2 because a real DSN supports more options than
@@ -206,8 +202,7 @@ class PG8000Driver(AbstractModuleDriver):
                 key = 'database'
             kwds[key] = value
         conn = self._connect(**kwds)
-
-        return _ConnWrapper(conn) if self._wrap else conn
+        return conn
 
     # Extensions
 

--- a/src/relstorage/adapters/postgresql/txncontrol.py
+++ b/src/relstorage/adapters/postgresql/txncontrol.py
@@ -27,8 +27,12 @@ class _PostgreSQLTransactionControl(GenericTransactionControl):
     _get_tid_query = 'EXECUTE get_latest_tid'
 
 
-    def __init__(self, keep_history, driver):
-        GenericTransactionControl.__init__(self, keep_history, driver.Binary)
+    def __init__(self, connmanager, keep_history, driver):
+        super(_PostgreSQLTransactionControl, self).__init__(
+            connmanager,
+            keep_history,
+            driver.Binary
+        )
 
 
 class PostgreSQLTransactionControl(_PostgreSQLTransactionControl):

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -523,7 +523,6 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
             return False
 
         cursor.execute('SELECT * FROM transaction WHERE tid < 0')
-
         columns = self._column_descriptions(cursor)
         # Make sure to read the (empty) result, some drivers (CMySQLConnector)
         # are picky about that and won't let you close a cursor without reading

--- a/src/relstorage/adapters/tests/test_txncontrol.py
+++ b/src/relstorage/adapters/tests/test_txncontrol.py
@@ -20,6 +20,10 @@ from relstorage.tests import TestCase
 from relstorage.tests import MockConnection
 from relstorage.tests import MockCursor
 
+class MockConnmanager(object):
+
+    def rollback(self, conn, _cursor):
+        conn.rollback()
 
 class TestTransactionControl(TestCase):
 
@@ -33,7 +37,7 @@ class TestTransactionControl(TestCase):
         return arg
 
     def _makeOne(self, keep_history=True, binary=None):
-        return self._getClass()(keep_history, binary or self.Binary)
+        return self._getClass()(MockConnmanager(), keep_history, binary or self.Binary)
 
     def _get_hf_tid_query(self):
         return self._getClass()._get_tid_queries[1]

--- a/src/relstorage/adapters/txncontrol.py
+++ b/src/relstorage/adapters/txncontrol.py
@@ -30,6 +30,9 @@ class AbstractTransactionControl(ABC):
 
     # pylint:disable=unused-argument
 
+    def __init__(self, connmanager):
+        self.connmanager = connmanager
+
     def commit_phase1(self, conn, cursor, tid):
         """Begin a commit.  Returns the transaction name.
 
@@ -50,7 +53,7 @@ class AbstractTransactionControl(ABC):
 
     def abort(self, conn, cursor, txn=None):
         """Abort the commit.  If txn is not None, phase 1 is also aborted."""
-        conn.rollback()
+        self.connmanager.rollback(conn, cursor)
 
     @abc.abstractmethod
     def get_tid(self, cursor):
@@ -76,7 +79,8 @@ class GenericTransactionControl(AbstractTransactionControl):
     )
     _get_tid_query = query_property('_get_tid')
 
-    def __init__(self, keep_history, Binary): # noqa
+    def __init__(self, connmanager, keep_history, Binary):
+        super(GenericTransactionControl, self).__init__(connmanager)
         self.keep_history = keep_history
         self.Binary = Binary
 

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -98,6 +98,9 @@ class AbstractTestSuiteBuilder(ABC):
     # test run even if installed.
     MAX_PRIORITY = int(os.environ.get('RS_MAX_TEST_PRIORITY', '100'))
 
+    # Ask the drivers to be in their strictest possible mode.
+    STRICT_DRIVER = True
+
     def __init__(self, driver_options, use_adapter, extra_test_classes=()):
         """
         :param driver_options: The ``IDBDriverOptions``
@@ -145,6 +148,8 @@ class AbstractTestSuiteBuilder(ABC):
             # list of tests; this makes the output much shorter and easier to read,
             # but it does make zope-testrunner's discovery options less useful.
             if available or TEST_UNAVAILABLE_DRIVERS:
+                if driver is not None:
+                    type(driver).STRICT = True
                 # Checking the driver is just a unit test, it doesn't connect or
                 # need a layer
                 suite.addTest(unittest.makeSuite(


### PR DESCRIPTION
(Yes, all in one commit. I'm sorry.)

Introduce a strict mode for testing, and use the server-side cursor in MySQLdb when that's the case. It raises the ProgrammingError we were seeing in #270 consistently, so find and fix all of those. Some refactoring to be able to do this testing in other databases, but that's not fully hooked up yet.

At the same time, make the gevent MySQLdb driver more cooperative, and make OID GC block for less time.

/cc @jzuech3