### PR TITLE
Start on #159: Make opening and closing transactions faster

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,11 @@
      multi-database and that only ``multi-zodb-gc`` be used to perform
      garbage collection.
 
+- Eliminate a few extra round trips to the database on transaction
+  completion: One extra ``ROLLBACK`` in all databases, and one query
+  against the ``transaction`` table in history-preserving databases.
+  See :issue:`159`.
+
 3.0a5 (2019-07-11)
 ==================
 

--- a/src/relstorage/adapters/_util.py
+++ b/src/relstorage/adapters/_util.py
@@ -50,7 +50,8 @@ def query_property(base_name,
         query is chosen before it is formatted and before it is returned.
     :keyword bool formatted: If True (*not* the default), then the
         chosen query will be formatted using the
-        ``self.runner.script_vars``.
+        ``self.runner.script_vars``. This should produce a new
+        query that uses the correct parameter binding for the database.
     """
 
     def prop(inst):

--- a/src/relstorage/adapters/poller.py
+++ b/src/relstorage/adapters/poller.py
@@ -15,12 +15,11 @@ from __future__ import absolute_import, print_function
 
 import logging
 
-from ZODB.POSException import ReadConflictError
-from ZODB.POSException import Unsupported
 from zope.interface import implementer
 
 from ._util import formatted_query_property
 from .interfaces import IPoller
+from .interfaces import StaleConnectionError
 
 log = logging.getLogger(__name__)
 
@@ -67,13 +66,6 @@ class Poller(object):
     _poll_inv_exc_query = formatted_query_property('_poll_inv',
                                                    extension=' AND tid != %(self_tid)s')
 
-    _tran_exists_queries = (
-        "SELECT 1 FROM transaction WHERE tid = %(tid)s",
-        Unsupported("Transaction data not available without history")
-    )
-
-    _tran_exists_query = formatted_query_property('_tran_exists')
-
 
     def __init__(self, poll_query, keep_history, runner, revert_when_stale):
         self.poll_query = poll_query
@@ -85,17 +77,18 @@ class Poller(object):
         """
         Polls for new transactions.
 
-        conn and cursor must have been created previously by
-        open_for_load(). prev_polled_tid is the tid returned at the
-        last poll, or None if this is the first poll. If ignore_tid is
-        not None, changes committed in that transaction will not be
-        included in the list of changed OIDs.
+        *conn* and *cursor* must have been created previously by
+        ``open_for_load()`` (a snapshot connection). prev_polled_tid
+        is the tid returned at the last poll, or None if this is the
+        first poll. If ignore_tid is not None, changes committed in
+        that transaction will not be included in the list of changed
+        OIDs.
 
-        Returns (changes, new_polled_tid), where changes is either a
-        list of (oid, tid) that have changed, or None to indicate that
-        the changes are too complex to list --- this must cause local
-        storage caches to be invalidated.. new_polled_tid can be 0 if
-        there is no data in the database.
+        Returns ``(changes, new_polled_tid)``, where *changes* is
+        either a list of ``(oid_int, tid_int)`` that have changed, or
+        ``None`` to indicate that the changes are too complex to li
+        --- this must cause local storage caches to be invalidated..
+        *new_polled_tid* can be 0 if there is no data in the database.
         """
         # pylint:disable=unused-argument
         # find out the tid of the most recent transaction.
@@ -106,6 +99,7 @@ class Poller(object):
             # the root object.
             # Anything we had cached is now definitely invalid.
             return None, 0
+
         new_polled_tid = rows[0][0]
         if prev_polled_tid is None:
             # This is the first time the connection has polled.
@@ -138,30 +132,24 @@ class Poller(object):
             # raise ReadConflictError to trigger a retry.
             # We're probably just waiting for async replication
             # to catch up, so retrying could do the trick.
-            raise ReadConflictError(
-                "The database connection is stale: new_polled_tid=%d, "
-                "prev_polled_tid=%d." % (new_polled_tid, prev_polled_tid))
-
+            raise StaleConnectionError.from_prev_and_new_tid(
+                prev_polled_tid, new_polled_tid)
 
         # New transaction(s) have been added.
-        if self.keep_history:
-            # If the previously polled transaction no longer exists,
-            # the cache is too old and needs to be cleared.
-            # XXX Do we actually need to detect this condition? I think
-            # if we delete this block of code, all the unreachable
-            # objects will be garbage collected anyway. So, as a test,
-            # there is no equivalent of this block of code for
-            # history-free storage. If something goes wrong, then we'll
-            # know there's some other edge condition we have to account
-            # for.
-            cursor.execute(
-                self._tran_exists_query,
-                {'tid': prev_polled_tid})
-            rows = cursor.fetchall()
-            if not rows:
-                # Transaction not found; perhaps it has been packed.
-                # The connection cache should be cleared.
-                return None, new_polled_tid
+
+        # In the past, but only for history-preserving databases, we
+        # would check to see if the previously polled transaction no
+        # longer exists in the transaction table. If it didn't, we
+        # would return ``(None, new_polled_tid)``, in order to clear
+        # the Connection cache.
+        #
+        # However, we ran for yers without an analogous case for
+        # history-free databases without problems, on the theory that
+        # all the unreachable objects will be garbage collected
+        # anyway.
+        #
+        # Thus we became convinced it was safe to remove the check in history-preserving
+        # databases.
 
         # Get the list of changed OIDs and return it.
         stmt = self._poll_inv_query

--- a/src/relstorage/storage/interfaces.py
+++ b/src/relstorage/storage/interfaces.py
@@ -25,6 +25,7 @@ from __future__ import division
 from __future__ import print_function
 
 from zope.interface import Interface
+from zope.interface import Attribute
 
 # pylint:disable=inherit-non-class,no-self-argument,no-method-argument
 
@@ -49,4 +50,76 @@ class IStaleAware(Interface):
         and return it.
 
         :return: Another `IStaleAware`.
+        """
+
+class IManagedDBConnection(Interface):
+    """
+    A managed DB connection consists of a DB-API ``connection`` object
+    and a single DB-API ``cursor`` from that connection.
+
+    This encapsulates proper use of ``IConnectionManager``, including
+    handling disconnections and re-connecting at appropriate times.
+
+    It is not allowed to use multiple cursors from a connection at the
+    same time; not all drivers properly support that.
+
+    If the DB-API connection is not open and presumed to be good, this
+    object has a false value.
+
+    "Restarting" a connection means to bring it to a current view of
+    the database. Typically this means a rollback so that a new
+    transaction can begin with a new MVCC snapshot.
+    """
+
+    cursor = Attribute("The DB-API cursor to use. Read-only.")
+    connection = Attribute("The DB-API connection to use. Read-only.")
+
+    def __bool__():
+        """
+        Return true if the database connection is believed to be ready to use.
+        """
+
+    def __nonzero__():
+        """
+        Same as __bool__ for Python 2.
+        """
+
+    def drop():
+        """
+        Unconditionally drop (close) the database connection.
+        """
+
+    def rollback():
+        """
+        Rollback the connection.
+
+        When this completes, the connection will be in a neutral state,
+        not idle in a transaction.
+
+        If an error occurs during rollback, the connection is dropped
+        and the exception is raised.
+        """
+
+    def isolated_connection():
+        """
+        Context manager that opens a new, distinct connection and
+        returns its cursor.
+
+        No matter what happens in the ``with`` block, the connection will be
+        dropped afterwards.
+        """
+
+    def restart_and_call(f, *args, **kw):
+        """
+        Restart the connection (roll it back) and call a function
+        after doing this.
+
+        This may drop and re-connect the connection if necessary.
+
+        :param callable f:
+            The function to call: ``f(conn, cursor, *args, **kwargs)``.
+            May be called up to twice if it raises a disconnected exception
+            on the first try.
+
+        :return: The return value of ``f``.
         """

--- a/src/relstorage/storage/tests/test_connections.py
+++ b/src/relstorage/storage/tests/test_connections.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for connections.py
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from hamcrest import assert_that
+from nti.testing.matchers import verifiably_provides
+
+from relstorage.tests import TestCase
+from relstorage.tests import MockConnectionManager
+
+from ..interfaces import IManagedDBConnection
+from ..connections import StoreConnection
+from ..connections import LoadConnection
+from ..connections import ClosedConnection
+
+class TestConnectionCommon(TestCase):
+
+    klass = StoreConnection
+
+    def _makeArgument(self):
+        return MockConnectionManager()
+
+    def _makeOne(self):
+        return self.klass(self._makeArgument())
+
+    def test_provides(self):
+        assert_that(self._makeOne(), verifiably_provides(IManagedDBConnection))
+
+class TestConnection(TestConnectionCommon):
+
+    def test_restart_and_call_does_not_activate(self):
+        manager = self._makeOne()
+        self.assertFalse(manager.active)
+        self.assertFalse(manager)
+
+        def on_first_use(_conn, _cursor):
+            self.fail('Should not call')
+
+        cc = []
+
+        def on_opened(conn, cursor):
+            self.assertIsNotNone(conn)
+            self.assertIsNotNone(cursor)
+            cc.append(conn)
+            cc.append(cursor)
+
+        manager.on_first_use = on_first_use
+        manager.on_opened = on_opened
+
+        manager.restart_and_call(lambda _conn, _cursor: None)
+
+        # If we try to access the cursor, it gets called, though.
+        with self.assertRaises(AssertionError):
+            getattr(manager, 'cursor')
+
+        del manager.on_opened
+        self.assertEqual(cc, [manager.connection, manager.cursor])
+
+    def test_restart_and_call_opens(self):
+        manager = self._makeOne()
+        opened = [0]
+        def on_opened(_conn, _cursor):
+            opened[0] += 1
+        manager.on_opened = on_opened
+        manager.restart_and_call(lambda _conn, _cursor: None)
+
+        self.assertEqual(opened, [1])
+
+    def test_restart_and_call_rollback(self):
+        manager = self._makeOne()
+        opened = [0]
+        def on_rolledback(_conn, _cursor):
+            opened[0] += 1
+        manager.on_rolledback = on_rolledback
+
+        manager.restart_and_call(lambda _conn, _cursor: None)
+        # That was just an open, so no rollback
+        self.assertEqual(opened, [0])
+
+        # But second time is the charm
+        manager.restart_and_call(lambda _conn, _cursor: None)
+        self.assertEqual(opened, [1])
+
+    def test_drop_activates(self, meth='drop'):
+        count = [0]
+
+        def on_first_use(_conn, _cursor):
+            count[0] += 1
+
+        manager = self._makeOne()
+        manager.on_first_use = on_first_use
+
+        getattr(manager, 'cursor')
+        self.assertEqual(count, [1])
+
+        getattr(manager, meth)()
+        self.assertEqual(count, [1])
+
+        getattr(manager, 'cursor')
+        self.assertEqual(count, [2])
+
+    def test_rollback_activates(self):
+        self.test_drop_activates('rollback')
+
+class TestLoadConnection(TestConnection):
+    klass = LoadConnection
+
+class TestClosedConnection(TestConnectionCommon):
+    klass = ClosedConnection

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -247,7 +247,29 @@ class MockOptions(Options):
         object.__setattr__(self, name, value)
 
 class MockConnectionManager(object):
-    pass
+
+    disconnected_exceptions = ()
+
+
+    def rollback(self, conn, cursor):
+        "Does nothing"
+
+    def rollback_and_close(self, conn, cursor):
+        if conn:
+            conn.close()
+        if cursor:
+            cursor.close()
+
+    def open_for_load(self):
+        conn = MockConnection()
+        return conn, conn.cursor()
+
+    open_for_store = open_for_load
+
+    def restart_load(self, conn, cursor):
+        pass
+
+    restart_store = restart_load
 
 class MockPackUndo(object):
     pass


### PR DESCRIPTION
This is the beginning of some work on #159. We start here by eliminating some unnecessary database traffic that we can control.

`zodbshootout --loops 32 --values 4   -c 5 -p 10`

| Benchmark                             | master | This branch               |
|---------------------------------------|-------------|-----------------------------|
| MappingStorage: empty implicit commit | 40.9 us     | 44.0 us: 1.08x slower (+8%) |
| psycopg2_hp: empty implicit commit    | 435 us      | 424 us: 1.03x faster (-3%)  |
| mysqlclient_hp: empty explicit commit | 771 us      | 752 us: 1.03x faster (-3%)  |
| mysqlclient_hp: empty implicit commit | 828 us      | 624 us: 1.33x faster (-25%) |
| psycopg2_hf: empty explicit commit    | 538 us      | 449 us: 1.20x faster (-17%) |
| psycopg2_hf: empty implicit commit    | 553 us      | 425 us: 1.30x faster (-23%) |
| mysqlclient_hf: empty explicit commit | 912 us      | 764 us: 1.19x faster (-16%) |
| mysqlclient_hf: empty implicit commit | 891 us      | 644 us: 1.38x faster (-28%) |

Not significant (2): MappingStorage: empty explicit commit; psycopg2_hp: empty explicit commit
