### PR TITLE
On MySQL, move allocating a TID into the database.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,12 @@
   primarily intended to reduce the number of round-trips to the
   database. This is a step towards :issue:`281`.
 
+- Make ``RelStorage.pack()`` also accept a TID from the RelStorage
+  database to pack to. The usual Unix timestamp form for choosing a
+  pack time can be ambiguous in the event of multiple transactions
+  within a very short period of time. This is mostly a concern for
+  automated tests.
+
 3.0a5 (2019-07-11)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,9 @@
   within a very short period of time. This is mostly a concern for
   automated tests.
 
+  Similarly, it will accept a value less than 0 to mean the most
+  recent transaction.
+
 - Make PyMySQL use the same precision as mysqlclient when sending
   floating point parameters.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,11 @@
   This includes how (some) queries are written and managed, making it
   easier to prepare statements, but only those actually used.
 
+- On MySQL, move allocating a TID into the database. On benchmarks
+  of a local machine this can be a scant few percent faster, but it's
+  primarily intended to reduce the number of round-trips to the
+  database. This is a step towards :issue:`281`.
+
 3.0a5 (2019-07-11)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,11 +72,23 @@
   primarily intended to reduce the number of round-trips to the
   database. This is a step towards :issue:`281`.
 
+- On MySQL, set the connection timezone to be UTC. This is necessary
+  to get values consistent between ``UTC_TIMESTAMP``,
+  ``UNIX_TIMESTAMP``, ``FROM_UNIXTIME``, and Python's ``time.gmtime``,
+  as used for comparing TIDs.
+
 - Make ``RelStorage.pack()`` also accept a TID from the RelStorage
   database to pack to. The usual Unix timestamp form for choosing a
   pack time can be ambiguous in the event of multiple transactions
   within a very short period of time. This is mostly a concern for
   automated tests.
+
+- Make PyMySQL use the same precision as mysqlclient when sending
+  floating point parameters.
+
+- Automatically detect when MySQL stored procedures in the database
+  are out of date with the current source in this package and replace
+  them.
 
 3.0a5 (2019-07-11)
 ==================

--- a/src/relstorage/_util.py
+++ b/src/relstorage/_util.py
@@ -24,7 +24,17 @@ import sys
 import time
 import traceback
 
+from persistent.timestamp import TimeStamp
+
 logger = __import__('logging').getLogger(__name__)
+
+
+def timestamp_at_unixtime(now):
+    """
+    Return a :class:`persistent.timestamp.TimeStamp` for the moment
+    given by *now* (a float giving seconds since the epoch).
+    """
+    return TimeStamp(*(time.gmtime(now)[:5] + (now % 60,)))
 
 
 class timer(object):

--- a/src/relstorage/adapters/txncontrol.py
+++ b/src/relstorage/adapters/txncontrol.py
@@ -25,6 +25,7 @@ from ZODB.utils import u64 as bytes8_to_int64
 from zope.interface import implementer
 
 from .._compat import ABC
+from .._util import timestamp_at_unixtime
 from ._util import noop_when_history_free
 
 from .schema import Schema
@@ -79,7 +80,7 @@ class AbstractTransactionControl(ABC):
         # tid.
         last_tid = self.get_tid(cursor)
         now = time.time()
-        stamp = TimeStamp(*(time.gmtime(now)[:5] + (now % 60,)))
+        stamp = timestamp_at_unixtime(now)
         stamp = stamp.laterThan(TimeStamp(int64_to_8bytes(last_tid)))
         tid = stamp.raw()
 

--- a/src/relstorage/adapters/txncontrol.py
+++ b/src/relstorage/adapters/txncontrol.py
@@ -16,6 +16,11 @@
 from __future__ import absolute_import
 
 import abc
+import time
+
+from persistent.timestamp import TimeStamp
+from ZODB.utils import p64 as int64_to_8bytes
+from ZODB.utils import u64 as bytes8_to_int64
 
 from zope.interface import implementer
 
@@ -33,6 +38,7 @@ class AbstractTransactionControl(ABC):
 
     def __init__(self, connmanager):
         self.connmanager = connmanager
+        self.driver = self.connmanager.driver
 
     def commit_phase1(self, store_connection, tid):
         return '-'
@@ -59,6 +65,27 @@ class AbstractTransactionControl(ABC):
                         packed=False):
         """Add a transaction"""
         raise NotImplementedError()
+
+    def lock_database_and_choose_next_tid(self, cursor, locker,
+                                          username,
+                                          description,
+                                          extension):
+        locker.hold_commit_lock(cursor, ensure_current=True)
+
+        # Choose a transaction ID.
+        #
+        # Base the transaction ID on the current time, but ensure that
+        # the tid of this transaction is greater than any existing
+        # tid.
+        last_tid = self.get_tid(cursor)
+        now = time.time()
+        stamp = TimeStamp(*(time.gmtime(now)[:5] + (now % 60,)))
+        stamp = stamp.laterThan(TimeStamp(int64_to_8bytes(last_tid)))
+        tid = stamp.raw()
+
+        tid_int = bytes8_to_int64(tid)
+        self.add_transaction(cursor, tid_int, username, description, extension)
+        return tid_int
 
 @implementer(ITransactionControl)
 class GenericTransactionControl(AbstractTransactionControl):

--- a/src/relstorage/storage/__init__.py
+++ b/src/relstorage/storage/__init__.py
@@ -490,6 +490,9 @@ class RelStorage(LegacyMethodsMixin,
 
         return max(self._ltid, int64_to_8bytes(self._prev_polled_tid or 0))
 
+    def lastTransactionInt(self):
+        return bytes8_to_int64(self.lastTransaction())
+
     def new_oid(self):
         # If we're committing, we can't restart the connection.
         return self._oids.new_oid(bool(self._tpc_phase))

--- a/src/relstorage/storage/pack.py
+++ b/src/relstorage/storage/pack.py
@@ -56,18 +56,67 @@ class Pack(object):
     def __pre_pack(self, t, referencesf):
         logger.info("pack: beginning pre-pack")
 
-        # Find the latest commit before or at the pack time.
-        pack_point = TimeStamp(*time.gmtime(t)[:5] + (t % 60,)).raw()
-        tid_int = self.packundo.choose_pack_transaction(
-            bytes8_to_int64(pack_point))
+        # In 2019, Unix timestamps look like
+        #            1564006806.0
+        # While 64-bit integer TIDs for the same timestamp look like
+        #    275085010696509852
+        #
+        # Multiple TIDs can map to a single Unix timestamp.
+        # For example, the 9 integers between 275085010624927044 and
+        # 275085010624927035 all map to 1564006804.9999998.
+        #
+        # Therefore, Unix timestamps are ambiguous, especially if we're committing
+        # multiple transactions rapidly (within the resolution of the underlying TID
+        # clock).
+        # This ambiguity mostly matters for unit tests, where we do commit rapidly.
+        #
+        # To help them out, we accept 64-bit integer TIDs to specify an exact
+        # transaction to pack to.
+        if t > 275085010696509852:
+            # Must be a TID.
+
+            # Turn it back into a time.time() for later logging
+            ts = TimeStamp(int64_to_8bytes(t))
+            logger.debug(
+                "Treating requested pack time %s as TID meaning %s",
+                t, ts
+            )
+            best_pack_tid_int = t
+            t = ts.timeTime()
+        else:
+            # Find the latest commit before or at the pack time,
+            # starting with the largest 64-bit TID that will produce that same
+            # time.time() value (since several TIDs can fit in the resolution
+            # of a time.time() value).
+            requested_pack_ts = TimeStamp(*time.gmtime(t)[:5] + (t % 60,))
+            requested_pack_time = requested_pack_ts.timeTime()
+            requested_pack_tid = requested_pack_ts.raw()
+            requested_pack_tid_int = bytes8_to_int64(requested_pack_tid)
+
+            best_pack_tid_int = requested_pack_tid_int
+            best_pack_time = t
+
+            while 1:
+                best_pack_time = TimeStamp(int64_to_8bytes(best_pack_tid_int)).timeTime()
+                if best_pack_time > requested_pack_time:
+                    break
+                best_pack_tid_int += 1
+
+            logger.debug(
+                "Requested pack time of %s maps to TID %d; latest TID for same time is %d.",
+                requested_pack_time, requested_pack_tid_int, best_pack_tid_int
+            )
+
+        tid_int = self.packundo.choose_pack_transaction(best_pack_tid_int)
+
         if tid_int is None:
             logger.debug("all transactions before %s have already "
                          "been packed", time.ctime(t))
             return
 
         s = time.ctime(TimeStamp(int64_to_8bytes(tid_int)).timeTime())
-        logger.info("pack: analyzing transactions committed "
-                    "%s or before", s)
+        logger.info("Analyzing transactions committed %s or before (TID %d)",
+                    s, tid_int)
 
         # In pre_pack, the adapter fills tables with
         # information about what to pack.  The adapter

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -73,7 +73,11 @@ class TestCase(unittest.TestCase):
             connection.close = lambda *_, **__: None
 
     def __close(self, thing):
-        thing.close()
+        try:
+            thing.close()
+        except KeyError:
+            # As for Connection; a DB closes all its connections.
+            pass
 
     def _closing(self, o):
         """

--- a/src/relstorage/tests/blob/blob_packing.py
+++ b/src/relstorage/tests/blob/blob_packing.py
@@ -39,8 +39,6 @@ class TestBlobPackHistoryPreservingMixin(TestBlobMixin):
         filesystem.
         """
         from ZODB.utils import u64 as bytes8_to_int64
-        from ZODB.utils import p64 as int64_to_8bytes
-        from persistent.timestamp import TimeStamp
 
         connection1 = self.database.open()
         root = connection1.root()
@@ -61,18 +59,8 @@ class TestBlobPackHistoryPreservingMixin(TestBlobMixin):
             tid = blob._p_serial
             tids.append(tid)
             tid_int = bytes8_to_int64(tid)
-            tid_time = TimeStamp(tid).timeTime()
 
-            # Go backwards to deduce the next value *before* the tid
-            # we just committed.
-            before_time = tid_time
-            before_int = tid_int
-            while not before_time < tid_time:
-                before_int -= 1
-                before_time = TimeStamp(int64_to_8bytes(before_int)).timeTime()
-
-            times.append(before_time)
-
+            times.append(tid_int - 1)
 
         blob._p_activate()
 

--- a/src/relstorage/tests/blob/blob_packing.py
+++ b/src/relstorage/tests/blob/blob_packing.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
-import time
 
 from ZODB.serialize import referencesf
 from ZODB.blob import Blob

--- a/src/relstorage/tests/blob/blob_packing.py
+++ b/src/relstorage/tests/blob/blob_packing.py
@@ -82,7 +82,7 @@ class TestBlobPackHistoryPreservingMixin(TestBlobMixin):
     def _pack_at_time_index(self, time_index=0, count_not_exist=0):
         if time_index is None:
             # Use now
-            packtime = time.time()
+            packtime = -1
         else:
             packtime = self.times[time_index]
         self.blob_storage.pack(packtime, referencesf)

--- a/src/relstorage/tests/hftestbase.py
+++ b/src/relstorage/tests/hftestbase.py
@@ -68,12 +68,8 @@ class HistoryFreeRelStorageTests(GenericRelStorageTests, ZODBTestCase):
         pobj = loads(data)
         eq(pobj.getoid(), oid)
         eq(pobj.value, 3)
-        # Now pack all transactions; need to sleep a second to make
-        # sure that the pack time is greater than the last commit time.
-        now = packtime = time.time()
-        while packtime <= now:
-            packtime = time.time()
-        self._storage.pack(packtime, referencesf)
+
+        self._storage.pack(self._storage.lastTransactionInt() + 1, referencesf)
         self._storage.sync()
         # All revisions of the object should be gone, since there is no
         # reference from the root object to this object.

--- a/src/relstorage/tests/hptestbase.py
+++ b/src/relstorage/tests/hptestbase.py
@@ -12,7 +12,6 @@
 #
 ##############################################################################
 """A foundation for history-preserving RelStorage tests"""
-import time
 import unittest
 
 import transaction
@@ -242,9 +241,7 @@ class HistoryPreservingRelStorageTests(GenericRelStorageTests,
             transaction.get().note(u'add C to A')
             transaction.commit()
 
-            now = packtime = time.time()
-            while packtime <= now:
-                packtime = time.time()
+            packtime = c1._storage.lastTransactionInt()
             self._storage.pack(packtime, referencesf)
 
             # B should be gone, since nothing refers to it.
@@ -455,8 +452,11 @@ class HistoryPreservingRelStorageTests(GenericRelStorageTests,
             RevisionStorage.snooze = before_snooze
             PackableStorage.snooze = before_snooze
 
-    # def checkLoadBefore(self):
-    #     raise unittest.SkipTest("Assumes it can control timestamps")
+    def checkLoadBefore(self):
+        # Most of the time this works, but sometimes it fails an internal assertion,
+        # most commonly seen on AppVeyor.
+        # https://ci.appveyor.com/project/jamadden/relstorage/builds/26243441/job/p24ocr2ir6wpvg3v#L1087
+        raise unittest.SkipTest("Assumes it can control timestamps")
 
     def checkLoadBeforeOld(self):
         self.__maybe_ignore_monotonic(RevisionStorage.RevisionStorage,

--- a/src/relstorage/tests/persistentcache.py
+++ b/src/relstorage/tests/persistentcache.py
@@ -14,9 +14,6 @@
 """
 Test mixin for exercising persistent caching features.
 """
-import time
-
-
 import transaction
 
 from persistent.mapping import PersistentMapping
@@ -199,12 +196,12 @@ class PersistentCacheStorageTests(TestCase):
 
         checkpoints = self.assert_checkpoints(c1)
         self.__do_check_tids(root, old_tids)
-        tid = bytes8_to_int64(c1._storage.lastTransaction())
+        tid_int = bytes8_to_int64(c1._storage.lastTransaction())
         c1.close()
         if pack:
-            storage.pack(time.time(), referencesf)
+            storage.pack(tid_int, referencesf)
         db1.close()
-        return tid, checkpoints
+        return tid_int, checkpoints
 
     def __set_key_in_root_to(self,
                              storage,

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -860,6 +860,7 @@ class GenericRelStorageTests(
     def checkPackWhileReferringObjectChanges(self):
         # Packing should not remove objects referenced by an
         # object that changes during packing.
+        from persistent.timestamp import TimeStamp
         db = self._closing(DB(self._storage))
         try:
             # add some data to be packed
@@ -878,9 +879,14 @@ class GenericRelStorageTests(
                 transaction.commit()
                 expect_oids.append(child2._p_oid)
 
+
             adapter = self._storage._adapter
             adapter.packundo.on_filling_object_refs = inject_changes
-            packtime = time.time()
+
+            # Pack to the current time based on the TID in the database
+            last_tid = self._storage.lastTransaction()
+            last_tid_time = TimeStamp(last_tid).timeTime()
+            packtime = last_tid_time + 1
             self._storage.pack(packtime, referencesf)
 
             # "The on_filling_object_refs hook should have been called once")

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -831,18 +831,15 @@ class GenericRelStorageTests(
             c.add(extra2)
             transaction.commit()
 
-            # Choose the pack time
-            now = packtime = time.time()
-            while packtime <= now:
-                time.sleep(0.1)
-                packtime = time.time()
-            while packtime == time.time():
-                time.sleep(0.1)
+            # Choose the pack time to be that last committed transaction.
+            packtime = c._storage.lastTransactionInt()
 
             extra2.foo = 'bar'
             extra3 = PersistentMapping()
             c.add(extra3)
             transaction.commit()
+
+            self.assertGreater(c._storage.lastTransactionInt(), packtime)
 
             self._storage.pack(packtime, referencesf)
 


### PR DESCRIPTION
This can be a few percent faster, depending on the specifics (in a micro-benchmark of just the tpc phases, using 20 threads in a single process, it can be up to 20% faster, but, by Amdahl's law, that is unlikely to show up on real workloads).

The main point, though, is to reduce the number of round-trips to the database, and hence the amount that Python has to be involved to finish a commit. This is a first step towards #281, proving that it can work. We started with MySQL because it has the most limited stored procedure support.

A number of ZODB tests assumed that they can control exactly the TID allocation and even spacing by sleeping the current process or spinning, etc. That's no longer the case, so some workarounds were needed. For example, we're now more likely to produce TIDs that, although different and increasing, actually map back to the same Unix timestamp (time.time()) --- the TID format allows for more precision than can be represented in a floating point number, so about 9 different values can produce the same timestamp .

In many cases, no workarounds were needed. In others, when we were definitely committing fast enough to fall within `time.time()` resolution limits, we solved the problem by allowing `RelStorage.pack()` to accept specific TIDs in addition to `time.time()` values.

An interesting side-effect is that the TIDs should now be more consistent, by having them all based on a single clock (the database server clock) instead of the clocks of different machines.