### PR TITLE
Move the components of tpc_finish into the database for MySQL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,14 @@
   ``UNIX_TIMESTAMP``, ``FROM_UNIXTIME``, and Python's ``time.gmtime``,
   as used for comparing TIDs.
 
+- On MySQL, move most steps of finishing a transaction into a stored
+  procedure. Together with the TID allocation changes, this reduces
+  the number of database queries from 1 to lock + 1 to get TID + 1 to
+  store transaction + 1 to move states + 2 for blobs + 1 to set
+  current = 7 down to 1. This is expected to be especially helpful for
+  gevent deployments, as only one greenlet switch needs to occur once
+  the database lock is held. See :issue:`281`.
+
 - Make ``RelStorage.pack()`` also accept a TID from the RelStorage
   database to pack to. The usual Unix timestamp form for choosing a
   pack time can be ambiguous in the event of multiple transactions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,7 +70,7 @@
 - On MySQL, move allocating a TID into the database. On benchmarks
   of a local machine this can be a scant few percent faster, but it's
   primarily intended to reduce the number of round-trips to the
-  database. This is a step towards :issue:`281`.
+  database. This is a step towards :issue:`281`. See :pr:`286`.
 
 - On MySQL, set the connection timezone to be UTC. This is necessary
   to get values consistent between ``UTC_TIMESTAMP``,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,12 @@
   gevent deployments, as only one greenlet switch needs to occur once
   the database lock is held. See :issue:`281`.
 
+  .. caution::
+
+     This is known to crash MySQL 5.7.12 as installed on AppVeyor. The
+     cause is unknown. A temporary workaround is present, but may be
+     removed.
+
 - Make ``RelStorage.pack()`` also accept a TID from the RelStorage
   database to pack to. The usual Unix timestamp form for choosing a
   pack time can be ambiguous in the event of multiple transactions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,52 @@
 3.0a6 (unreleased)
 ==================
 
+Enhancements
+------------
+
+- Eliminate a few extra round trips to the database on transaction
+  completion: One extra ``ROLLBACK`` in all databases, and one query
+  against the ``transaction`` table in history-preserving databases.
+  See :issue:`159`.
+
+- Prepare more statements used during regular polling.
+
+- Gracefully handle certain disconnected exceptions when rolling back
+  connections in between transactions. See :issue:`280`.
+
+- Fix a cache error ("TypeError: NoneType object is not
+  subscriptable") when an object had been deleted (such as through
+  undoing its creation transaction, or with ``multi-zodb-gc``).
+
+- Implement ``IExternalGC`` for history-preserving databases. This
+  lets them be used with `zc.zodbdgc
+  <https://pypi.org/project/zc.zodbdgc/>`_, allowing for
+  multi-database garbage collection (see :issue:`76`). Note that you
+  must pack the database after running ``multi-zodb-gc`` in order to
+  reclaim space.
+
+  .. caution::
+
+     It is critical that ``pack-gc`` be turned off (set to false) in a
+     multi-database and that only ``multi-zodb-gc`` be used to perform
+     garbage collection.
+
+Packing
+~~~~~~~
+
+- Make ``RelStorage.pack()`` also accept a TID from the RelStorage
+  database to pack to. The usual Unix timestamp form for choosing a
+  pack time can be ambiguous in the event of multiple transactions
+  within a very short period of time. This is mostly a concern for
+  automated tests.
+
+  Similarly, it will accept a value less than 0 to mean the most
+  recent transaction in the database. This is useful when machine
+  clocks may not be well synchronized, or from automated tests.
+
+Implementation
+--------------
+
 - Remove vestigial top-level thread locks. No instance of RelStorage
   is thread safe.
 
@@ -36,36 +82,13 @@
   ``IBlobStorage``, and if ``keep-history`` is false, it won't
   implement ``IStorageUndoable``.
 
-- Fix a cache error ("TypeError: NoneType object is not
-  subscriptable") when an object had been deleted (such as through
-  undoing its creation transaction, or with ``multi-zodb-gc``).
-
-- Implement ``IExternalGC`` for history-preserving databases. This
-  lets them be used with `zc.zodbdgc
-  <https://pypi.org/project/zc.zodbdgc/>`_, allowing for
-  multi-database garbage collection (see :issue:`76`). Note that you
-  must pack the database after running ``multi-zodb-gc`` in order to
-  reclaim space.
-
-  .. caution::
-
-     It is critical that ``pack-gc`` be turned off (set to false) in a
-     multi-database and that only ``multi-zodb-gc`` be used to perform
-     garbage collection.
-
-- Eliminate a few extra round trips to the database on transaction
-  completion: One extra ``ROLLBACK`` in all databases, and one query
-  against the ``transaction`` table in history-preserving databases.
-  See :issue:`159`.
-
-- Prepare more statements used during regular polling.
-
-- Gracefully handle certain disconnected exceptions when rolling back
-  connections in between transactions. See :issue:`280`.
-
 - Refactor RelStorage internals for a cleaner separation of concerns.
   This includes how (some) queries are written and managed, making it
   easier to prepare statements, but only those actually used.
+
+
+MySQL
+-----
 
 - On MySQL, move allocating a TID into the database. On benchmarks
   of a local machine this can be a scant few percent faster, but it's
@@ -79,26 +102,28 @@
 
 - On MySQL, move most steps of finishing a transaction into a stored
   procedure. Together with the TID allocation changes, this reduces
-  the number of database queries from 1 to lock + 1 to get TID + 1 to
-  store transaction + 1 to move states + 2 for blobs + 1 to set
-  current = 7 down to 1. This is expected to be especially helpful for
-  gevent deployments, as only one greenlet switch needs to occur once
-  the database lock is held. See :issue:`281`.
+  the number of database queries from::
+
+    1 to lock
+     + 1 to get TID
+     + 1 to store transaction (0 in history free)
+     + 1 to move states
+     + 1 for blobs (2 in history free)
+     + 1 to set current (0 in history free)
+     + 1 to commit
+    = 7 or 6 (in history free)
+
+  down to 1. This is expected to be especially helpful for gevent
+  deployments, as the database lock is held, the transaction finalized
+  and committed, and the database lock released, all without involving
+  greenlets or greenlet switches. By allowing the GIL to be released
+  longer it may also be helpful for threaded environments. See :issue:`281`.
 
   .. caution::
 
-     This is known to crash MySQL 5.7.12 as installed on AppVeyor. The
-     cause is unknown. A temporary workaround is present, but may be
-     removed.
-
-- Make ``RelStorage.pack()`` also accept a TID from the RelStorage
-  database to pack to. The usual Unix timestamp form for choosing a
-  pack time can be ambiguous in the event of multiple transactions
-  within a very short period of time. This is mostly a concern for
-  automated tests.
-
-  Similarly, it will accept a value less than 0 to mean the most
-  recent transaction.
+     Calling the stored procedure is known to crash MySQL 5.7.12 as
+     installed on AppVeyor. The cause is unknown. A temporary
+     workaround is present, but is likely to be removed.
 
 - Make PyMySQL use the same precision as mysqlclient when sending
   floating point parameters.
@@ -106,6 +131,7 @@
 - Automatically detect when MySQL stored procedures in the database
   are out of date with the current source in this package and replace
   them.
+
 
 3.0a5 (2019-07-11)
 ==================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,7 +92,7 @@ build_script:
   # --no-use-pep517
   # Here, we only want to install one driver; we only support the best
   # driver on Windows.
-  - "%CMD_IN_ENV% %PYEXE% -m pip install -U -e .[test,postgresql,mysql]"
+  - if not "%GWHEEL_ONLY%"=="true" "%CMD_IN_ENV% %PYEXE% -m pip install -U -e .[test,postgresql,mysql]"
 
 test_script:
   - if not "%GWHEEL_ONLY%"=="true" cmd /c .travis\mysql.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,7 +92,7 @@ build_script:
   # --no-use-pep517
   # Here, we only want to install one driver; we only support the best
   # driver on Windows.
-  - if not "%GWHEEL_ONLY%"=="true" "%CMD_IN_ENV% %PYEXE% -m pip install -U -e .[test,postgresql,mysql]"
+  - if not "%GWHEEL_ONLY%"=="true" %CMD_IN_ENV% %PYEXE% -m pip install -U -e .[test,postgresql,mysql]
 
 test_script:
   - if not "%GWHEEL_ONLY%"=="true" cmd /c .travis\mysql.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,10 +65,10 @@ environment:
 
 services:
   - mysql
-  - postgresql
+  - postgresql101
 
 install:
-  - "SET PATH=C:\\Program Files\\PostgreSQL\\9.4\\bin;C:\\Program Files\\MySql\\MySQL Server 5.7\\bin;%PATH%"
+  - "SET PATH=C:\\Program Files\\PostgreSQL\\10\\bin;C:\\Program Files\\MySql\\MySQL Server 5.7\\bin;%PATH%"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\bin;%PATH%"
   - "SET PYEXE=%PYTHON%\\%PYTHON_EXE%.exe"
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,6 +35,9 @@ Connector/Python 8.0.16 is also tested to work as is pg8000.
 .. note:: umysql support was removed in RelStorage 3.0. Use 'gevent
           MySQLdb' instead.
 
+.. note:: mysqlclient 1.4 is not available on Windows for Python 2.
+          PyMySQL is tested instead.
+
 For CPython3, install psycopg2, mysqlclient 1.4+, or cx_Oracle;
 PyMySQL, MySQL Connector/Python  and pg8000 are also known to work.
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ tests_require = [
     'zc.zlibstorage',
     'zope.testrunner',
     'nti.testing',
-    'gevent >= 1.5a1',
+    'gevent >= 1.5a1; sys_platform != "win32"',
     'pyperf',
     'psutil',
 ] + memcache_require

--- a/setup.py
+++ b/setup.py
@@ -123,13 +123,16 @@ setup(
         # PyMySQL and mysqlclient support Python 3, use mysqlclient on
         # Python 3 because it's a binary driver and *probably* faster
         # for CPython; it requires some minor code changes to support,
-        # so be sure to test this configuration. mysqlclient doesn't compile on
-        # windows, though, so only install the pure-python version.
+        # so be sure to test this configuration. mysqlclient doesn't
+        # compile on windows for Python 2.7 and only has wheels for
+        # 3.6 and 3.7, though, so only install the pure-python
+        # version.
+
         # pylint:disable=line-too-long
-        'mysql:platform_python_implementation=="CPython" and sys_platform != "win32"': [
+        'mysql:platform_python_implementation=="CPython" and (sys_platform != "win32" or python_version > "3.5")': [
             'mysqlclient >= 1.4',
         ],
-        'mysql:platform_python_implementation=="PyPy" or sys_platform == "win32"': [
+        'mysql:platform_python_implementation=="PyPy" or (sys_platform == "win32" and python_version < "3.6")': [
             'PyMySQL>=0.6.6',
         ],
         # Notes on psycopg2: In 2.8, they stopped distributing full
@@ -169,10 +172,10 @@ setup(
             # First, mysql
             # pymysql on 3.6 on all platforms. We get coverage data from Travis,
             # and we get 2.7 from PyPy and Windows.
-            'PyMySQL >= 0.6.6; python_version == "3.6" or platform_python_implementation == "PyPy" or sys_platform == "win32"',
+            'PyMySQL >= 0.6.6; python_version == "3.6" or platform_python_implementation == "PyPy" or (sys_platform == "win32" and python_version < "3.6")',
             # mysqlclient (binary) on all CPythons. It's the default,
-            # except on Windows. We get coverage from Travis.
-            'mysqlclient >= 1.4;platform_python_implementation=="CPython" and sys_platform != "win32"',
+            # except on old Windows. We get coverage from Travis.
+            'mysqlclient >= 1.4;platform_python_implementation=="CPython" and (sys_platform != "win32" or python_version > "3.5")',
             # mysql-connector-python on Python 3.7 for coverage on Travis and ensuring it works
             # on Windows, and PyPy for testing there, since it's one of two pure-python versions.
             'mysql-connector-python >= 8.0.16; python_version == "3.7" or platform_python_implementation == "PyPy"',

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -99,7 +99,6 @@ class AbstractAdapter(object):
 
         self.mover.move_from_temp(cursor, committing_tid_int, txn_has_blobs)
 
-
         after_selecting_tid(committing_tid_int)
 
         self.mover.update_current(cursor, committing_tid_int)

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -71,6 +71,7 @@ class AbstractAdapter(object):
                            store_connection,
                            blobhelper,
                            ude,
+                           commit=True, # pylint:disable=unused-argument
                            committing_tid_int=None,
                            after_selecting_tid=lambda tid: None):
         # Here's where we take the global commit lock, and

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+"""
+Base class for ``IRelStorageAdapter``.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import time
+
+from persistent.timestamp import TimeStamp
+from ZODB.utils import p64 as int64_to_8bytes
+from ZODB.utils import u64 as bytes8_to_int64
+
+from .._util import timestamp_at_unixtime
+from ..options import Options
+
+from ._abstract_drivers import _select_driver
+
+class AbstractAdapter(object):
+
+    options = None # type: Options
+    driver_options = None # type: IDBDriverOptions
+    locker = None # type: ILocker
+    txncontrol = None # type: ITransactionControl
+    mover = None # type: IObjectMover
+
+    def _select_driver(self, options=None):
+        return _select_driver(
+            options or self.options or Options(),
+            self.driver_options
+        )
+
+    def lock_database_and_choose_next_tid(self, cursor,
+                                          username,
+                                          description,
+                                          extension):
+        self.locker.hold_commit_lock(cursor, ensure_current=True)
+
+        # Choose a transaction ID.
+        #
+        # Base the transaction ID on the current time, but ensure that
+        # the tid of this transaction is greater than any existing
+        # tid.
+        last_tid = self.txncontrol.get_tid(cursor)
+        now = time.time()
+        stamp = timestamp_at_unixtime(now)
+        stamp = stamp.laterThan(TimeStamp(int64_to_8bytes(last_tid)))
+        tid = stamp.raw()
+
+        tid_int = bytes8_to_int64(tid)
+        self.txncontrol.add_transaction(cursor, tid_int, username, description, extension)
+        return tid_int
+
+    def tpc_prepare_phase1(self,
+                           store_connection,
+                           blobhelper,
+                           ude,
+                           committing_tid_int=None,
+                           after_selecting_tid=lambda tid: None):
+        # Here's where we take the global commit lock, and
+        # allocate the next available transaction id, storing it
+        # into history-preserving DBs. But if someone passed us
+        # a TID (``restore``), then it must already be in the DB, and the lock must
+        # already be held.
+        #
+        # If we've prepared the transaction, then the TID must be in the
+        # db, the lock must be held, and we must have finished all of our
+        # storage actions. This is only expected to be the case when we have
+        # a shared blob dir.
+
+        cursor = store_connection.cursor
+        if committing_tid_int is None:
+            committing_tid_int = self.lock_database_and_choose_next_tid(
+                cursor,
+                *ude
+            )
+
+        # Move the new states into the permanent table
+        # TODO: Figure out how to do as much as possible of this before holding
+        # the commit lock. For example, use a dummy TID that we later replace.
+        # (This has FK issues in HP dbs).
+        txn_has_blobs = blobhelper.txn_has_blobs
+
+        self.mover.move_from_temp(cursor, committing_tid_int, txn_has_blobs)
+
+
+        after_selecting_tid(committing_tid_int)
+
+        self.mover.update_current(cursor, committing_tid_int)
+        return committing_tid_int, self.txncontrol.commit_phase1(
+            store_connection, committing_tid_int)

--- a/src/relstorage/adapters/mover.py
+++ b/src/relstorage/adapters/mover.py
@@ -447,7 +447,9 @@ class AbstractObjectMover(ABC):
 
             if txn_has_blobs:
                 # If we can require storages to have an UPSERT (mysql and
-                # postgres do), then we can remove the DELETE.
+                # postgres do), then can we remove the DELETE?
+                # Answer: probably not. What if the blob shrunk and we
+                # have fewer chunks than we used to?
                 stmt = self._move_from_temp_hf_delete_blob_chunk_query
                 cursor.execute(stmt)
 

--- a/src/relstorage/adapters/mover.py
+++ b/src/relstorage/adapters/mover.py
@@ -453,8 +453,6 @@ class AbstractObjectMover(ABC):
                 stmt = self._move_from_temp_hf_delete_blob_chunk_query
                 cursor.execute(stmt)
 
-        # TODO: Make this an UPSERT for history free storages.
-        # This would obviate the need for the above delete query.
         if txn_has_blobs:
             stmt = self._move_from_temp_copy_blob_query
             __traceabck_info__ = stmt

--- a/src/relstorage/adapters/mysql/__init__.py
+++ b/src/relstorage/adapters/mysql/__init__.py
@@ -51,7 +51,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from relstorage.adapters.mysql.adapter import MySQLAdapter
-from relstorage.adapters.mysql.adapter import select_driver
+
 
 assert MySQLAdapter
-assert select_driver

--- a/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid.sql
+++ b/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid.sql
@@ -1,0 +1,7 @@
+CREATE PROCEDURE lock_and_choose_tid()
+COMMENT '{CHECKSUM}'
+BEGIN
+    DECLARE next_tid_64 BIGINT;
+    CALL lock_and_choose_tid_p(next_tid_64);
+    SELECT next_tid_64;
+END;

--- a/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_and_move.sql
+++ b/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_and_move.sql
@@ -1,5 +1,6 @@
 CREATE PROCEDURE lock_and_choose_tid_and_move(
-  p_committing_tid BIGINT
+  p_committing_tid BIGINT,
+  p_commit BOOLEAN
 )
 COMMENT '{CHECKSUM}'
 BEGIN
@@ -46,6 +47,10 @@ BEGIN
   FROM temp_blob_chunk;
 
   -- History free has no current_object to update.
+
+  IF p_commit THEN
+    COMMIT;
+  END IF;
 
   SELECT p_committing_tid;
 END;

--- a/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_and_move.sql
+++ b/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_and_move.sql
@@ -1,0 +1,49 @@
+CREATE PROCEDURE lock_and_choose_tid_and_move()
+COMMENT '{CHECKSUM}'
+BEGIN
+  DECLARE tid_64 BIGINT;
+
+  CALL lock_and_choose_tid_p(tid_64);
+
+  -- move_from_temp()
+  -- First the state for objects
+
+  INSERT INTO object_state (
+    zoid,
+    tid,
+    state_size,
+    state
+  )
+  SELECT zoid,
+         tid_64,
+         COALESCE(LENGTH(state), 0),
+         state
+  FROM temp_store
+  ORDER BY zoid
+  ON DUPLICATE KEY UPDATE
+     tid = VALUES(tid),
+     state_size = VALUES(state_size),
+     state = VALUES(state);
+
+  -- Then blob chunks. First delete in case we shrunk.
+  -- The MySQL optimizer, up
+  -- through at least 5.7.17 doesn't like actual subqueries in a DELETE
+  -- statement. See https://github.com/zodb/relstorage/issues/175
+  DELETE bc
+  FROM blob_chunk bc
+  INNER JOIN (SELECT zoid FROM temp_store) sq
+         ON bc.zoid = sq.zoid;
+
+  INSERT INTO blob_chunk (
+    zoid,
+    tid,
+    chunk_num,
+    chunk
+  )
+  SELECT zoid, tid_64, chunk_num, chunk
+  FROM temp_blob_chunk;
+
+  -- History free has no current_object to update.
+
+  SELECT tid_64;
+END;

--- a/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_and_move.sql
+++ b/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_and_move.sql
@@ -1,9 +1,11 @@
-CREATE PROCEDURE lock_and_choose_tid_and_move()
+CREATE PROCEDURE lock_and_choose_tid_and_move(
+  p_committing_tid BIGINT
+)
 COMMENT '{CHECKSUM}'
 BEGIN
-  DECLARE tid_64 BIGINT;
-
-  CALL lock_and_choose_tid_p(tid_64);
+  IF p_committing_tid IS NULL THEN
+    CALL lock_and_choose_tid_p(p_committing_tid);
+  END IF;
 
   -- move_from_temp()
   -- First the state for objects
@@ -15,7 +17,7 @@ BEGIN
     state
   )
   SELECT zoid,
-         tid_64,
+         p_committing_tid,
          COALESCE(LENGTH(state), 0),
          state
   FROM temp_store
@@ -40,10 +42,10 @@ BEGIN
     chunk_num,
     chunk
   )
-  SELECT zoid, tid_64, chunk_num, chunk
+  SELECT zoid, p_committing_tid, chunk_num, chunk
   FROM temp_blob_chunk;
 
   -- History free has no current_object to update.
 
-  SELECT tid_64;
+  SELECT p_committing_tid;
 END;

--- a/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_p.sql
+++ b/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_p.sql
@@ -1,0 +1,21 @@
+CREATE PROCEDURE lock_and_choose_tid_p(OUT next_tid_64 BIGINT)
+COMMENT '{CHECKSUM}'
+BEGIN
+    DECLARE scratch BIGINT;
+    DECLARE current_tid_64 BIGINT;
+
+    SELECT tid
+    INTO scratch
+    FROM commit_row_lock
+    FOR UPDATE;
+
+    SELECT COALESCE(MAX(tid), 0)
+    INTO current_tid_64
+    FROM object_state;
+
+    CALL make_current_tid(next_tid_64);
+
+    IF next_tid_64 <= current_tid_64 THEN
+        SET next_tid_64 = current_tid_64 + 1;
+    END IF;
+END;

--- a/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid.sql
+++ b/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid.sql
@@ -6,30 +6,13 @@ CREATE PROCEDURE lock_and_choose_tid(
 )
 COMMENT '{CHECKSUM}'
 BEGIN
-    DECLARE scratch BIGINT;
-    DECLARE next_tid_64, current_tid_64 BIGINT;
-
-    SELECT tid
-    INTO scratch
-    FROM commit_row_lock
-    FOR UPDATE;
-
-    SELECT COALESCE(MAX(tid), 0)
-    INTO current_tid_64
-    FROM transaction;
-
-    CALL make_current_tid(next_tid_64);
-
-    IF next_tid_64 <= current_tid_64 THEN
-        SET next_tid_64 = current_tid_64 + 1;
-    END IF;
-
-    INSERT INTO transaction (
-        tid, packed, username, description, extension
-    )
-    VALUES (
-        next_tid_64, p_packed, p_username, p_description, p_extension
-    );
-
-    SELECT next_tid_64;
+  DECLARE next_tid_64 BIGINT;
+  CALL lock_and_choose_tid_p(
+    next_tid_64,
+    p_packed,
+    p_username,
+    p_description,
+    p_extension
+  );
+  SELECT next_tid_64;
 END;

--- a/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid.sql
+++ b/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid.sql
@@ -1,0 +1,35 @@
+CREATE PROCEDURE lock_and_choose_tid(
+    p_packed BOOLEAN,
+    p_username BLOB,
+    p_description BLOB,
+    p_extension BLOB
+)
+COMMENT '{CHECKSUM}'
+BEGIN
+    DECLARE scratch BIGINT;
+    DECLARE next_tid_64, current_tid_64 BIGINT;
+
+    SELECT tid
+    INTO scratch
+    FROM commit_row_lock
+    FOR UPDATE;
+
+    SELECT COALESCE(MAX(tid), 0)
+    INTO current_tid_64
+    FROM transaction;
+
+    CALL make_current_tid(next_tid_64);
+
+    IF next_tid_64 <= current_tid_64 THEN
+        SET next_tid_64 = current_tid_64 + 1;
+    END IF;
+
+    INSERT INTO transaction (
+        tid, packed, username, description, extension
+    )
+    VALUES (
+        next_tid_64, p_packed, p_username, p_description, p_extension
+    );
+
+    SELECT next_tid_64;
+END;

--- a/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid_and_move.sql
+++ b/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid_and_move.sql
@@ -1,0 +1,52 @@
+CREATE PROCEDURE lock_and_choose_tid_and_move(
+    p_committing_tid BIGINT,
+    p_username BLOB,
+    p_description BLOB,
+    p_extension BLOB
+)
+COMMENT '{CHECKSUM}'
+BEGIN
+  IF p_committing_tid IS NULL THEN
+    CALL lock_and_choose_tid_p(p_committing_tid, FALSE, p_username, p_description, p_extension);
+  END IF;
+
+  -- move_from_temp()
+  -- First the object state.
+  INSERT INTO object_state (
+    zoid,
+    tid,
+    prev_tid,
+    md5,
+    state_size,
+    state
+  )
+  SELECT zoid,
+         p_committing_tid,
+         prev_tid,
+         md5,
+         COALESCE(LENGTH(state), 0),
+         state
+  FROM temp_store
+  ORDER BY zoid;
+
+  -- Now blob chunks.
+  INSERT INTO blob_chunk (
+    zoid,
+    tid,
+    chunk_num,
+    chunk
+  )
+  SELECT zoid, p_committing_tid, chunk_num, chunk
+  FROM temp_blob_chunk;
+
+  -- update_current
+  INSERT INTO current_object (zoid, tid)
+  SELECT zoid, tid
+  FROM object_state
+  WHERE tid = p_committing_tid
+  ORDER BY zoid
+  ON DUPLICATE KEY UPDATE
+     tid = VALUES(tid);
+
+  SELECT p_committing_tid;
+END;

--- a/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid_and_move.sql
+++ b/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid_and_move.sql
@@ -1,5 +1,6 @@
 CREATE PROCEDURE lock_and_choose_tid_and_move(
     p_committing_tid BIGINT,
+    p_commit BOOLEAN,
     p_username BLOB,
     p_description BLOB,
     p_extension BLOB
@@ -47,6 +48,10 @@ BEGIN
   ORDER BY zoid
   ON DUPLICATE KEY UPDATE
      tid = VALUES(tid);
+
+  IF p_commit THEN
+    COMMIT;
+  END IF;
 
   SELECT p_committing_tid;
 END;

--- a/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid_p.sql
+++ b/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid_p.sql
@@ -1,0 +1,34 @@
+CREATE PROCEDURE lock_and_choose_tid_p(
+  OUT next_tid_64 BIGINT,
+  IN p_packed BOOLEAN,
+  IN p_username BLOB,
+  IN p_description BLOB,
+  IN p_extension BLOB
+)
+COMMENT '{CHECKSUM}'
+BEGIN
+    DECLARE scratch BIGINT;
+    DECLARE current_tid_64 BIGINT;
+
+    SELECT tid
+    INTO scratch
+    FROM commit_row_lock
+    FOR UPDATE;
+
+    SELECT COALESCE(MAX(tid), 0)
+    INTO current_tid_64
+    FROM transaction;
+
+    CALL make_current_tid(next_tid_64);
+
+    IF next_tid_64 <= current_tid_64 THEN
+        SET next_tid_64 = current_tid_64 + 1;
+    END IF;
+
+    INSERT INTO transaction (
+        tid, packed, username, description, extension
+    )
+    VALUES (
+        next_tid_64, p_packed, p_username, p_description, p_extension
+    );
+END;

--- a/src/relstorage/adapters/mysql/procs/make_current_tid.sql
+++ b/src/relstorage/adapters/mysql/procs/make_current_tid.sql
@@ -1,0 +1,8 @@
+CREATE PROCEDURE make_current_tid(OUT tid_64 BIGINT)
+COMMENT '{CHECKSUM}'
+BEGIN
+  CALL make_tid_for_epoch(
+    UNIX_TIMESTAMP(UTC_TIMESTAMP(6)),
+    tid_64
+  );
+END;

--- a/src/relstorage/adapters/mysql/procs/make_tid_for_epoch.sql
+++ b/src/relstorage/adapters/mysql/procs/make_tid_for_epoch.sql
@@ -1,0 +1,44 @@
+CREATE PROCEDURE make_tid_for_epoch(
+      IN unix_ts REAL,
+      OUT tid_64 BIGINT)
+COMMENT '{CHECKSUM}'
+BEGIN
+  /*
+    Procedure to generate a new 64-bit TID based on the current time.
+    Not called from Python, only from SQL.
+
+    We'd really prefer to use the database clock, as there's only one
+    of it and it's more likely to be consistent than clocks spread
+    across many client machines. Our test cases tend to assume that
+    time.time() moves forward at exactly the same speed as the TID
+    clock, though, especially if we don't commit anything. This
+    doesn't hold true if we don't use the local clock for the TID
+    clock.
+
+   */
+
+  DECLARE ts TIMESTAMP;
+  DECLARE year, month, day, hour, minute INT;
+  DECLARE a1, a, b BIGINT;
+  DECLARE b1, second REAL;
+
+  SET ts = FROM_UNIXTIME(unix_ts) + 0.0;
+
+  SET year   = EXTRACT(YEAR from ts),
+      month  = EXTRACT(MONTH from ts),
+      day    = EXTRACT(DAY from ts),
+      hour   = EXTRACT(hour from ts),
+      minute = EXTRACT(minute from ts),
+      second = unix_ts % 60;
+
+
+  SET a1 = (((year - 1900) * 12 + month - 1) * 31 + day - 1);
+  SET a = (a1 * 24 + hour) *60 + minute;
+  -- This is a magic constant; see _timestamp.c
+  SET b1 = second / 1.3969838619232178e-08;
+  -- CAST(AS INTEGER) rounds, but the C and Python TimeStamp
+  -- simply truncate, and we must match them.
+  SET b = TRUNCATE(b1, 0);
+
+  SET tid_64 = (a << 32) + b;
+END;

--- a/src/relstorage/adapters/mysql/procs/set_min_oid.sql
+++ b/src/relstorage/adapters/mysql/procs/set_min_oid.sql
@@ -1,0 +1,46 @@
+CREATE PROCEDURE set_min_oid(min_oid BIGINT)
+COMMENT '{CHECKSUM}'
+BEGIN
+  -- Set the current allowed minimum OID in a single trip to the
+  -- server.
+
+  -- In order to avoid deadlocks, we only do this if
+  -- the number we want to insert is strictly greater than
+  -- what the current sequence value is. If we use a value less
+  -- than that, there's a chance a different session has already allocated
+  -- and inserted that value into the table, meaning its locked.
+  -- We obviously cannot JUST use MAX(zoid) to find this value, we can't see
+  -- what other sessions have done. But if that's already >= to the min_oid,
+  -- then we don't have to do anything.
+  DECLARE next_oid BIGINT;
+
+  SELECT COALESCE(MAX(ZOID), 0)
+  INTO next_oid
+  FROM new_oid;
+
+  IF next_oid < min_oid THEN
+    -- Can't say for sure. Just because we can only see values
+    -- less doesn't mean they're not there in another transaction.
+
+    -- This will never block.
+    INSERT INTO new_oid VALUES ();
+    SELECT LAST_INSERT_ID()
+    INTO next_oid;
+
+    IF min_oid > next_oid THEN
+      -- This is unlikely to block. We just confirmed that the
+      -- sequence value is strictly less than this, so no one else
+      -- should be doing this.
+      INSERT IGNORE INTO new_oid (zoid)
+      VALUES (min_oid);
+
+      SET next_oid = min_oid;
+    END IF;
+  ELSE
+    -- Return a NULL value to signal that this value cannot
+    -- be cached and used because we didn't allocate it.
+    SET next_oid = NULL;
+  END IF;
+
+  SELECT next_oid;
+END;

--- a/src/relstorage/adapters/mysql/tests/test_adapter.py
+++ b/src/relstorage/adapters/mysql/tests/test_adapter.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
-# Copyright (c) 2009 Zope Foundation and Contributors.
+# Copyright (c) 2019 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,
@@ -11,13 +12,27 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""TransactionControl implementations"""
-
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
-from ..txncontrol import GenericTransactionControl
+
+from hamcrest import assert_that
+from nti.testing.matchers import validly_provides
 
 
-class MySQLTransactionControl(GenericTransactionControl):
-    pass
+from relstorage.tests import TestCase
+
+from ..adapter import MySQLAdapter as Adapter
+
+from ... import interfaces
+
+class TestAdapter(TestCase):
+
+    def _makeOne(self):
+        return Adapter()
+
+    def test_implements(self):
+
+        adapter = self._makeOne()
+        assert_that(adapter, validly_provides(interfaces.IRelStorageAdapter))

--- a/src/relstorage/adapters/oracle/__init__.py
+++ b/src/relstorage/adapters/oracle/__init__.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 
 from relstorage.adapters.oracle.adapter import OracleAdapter
-from relstorage.adapters.oracle.adapter import select_driver
+
 
 assert OracleAdapter
-assert select_driver

--- a/src/relstorage/adapters/oracle/scriptrunner.py
+++ b/src/relstorage/adapters/oracle/scriptrunner.py
@@ -113,6 +113,9 @@ class CXOracleScriptRunner(OracleScriptRunner):
     def __init__(self, driver):
         self.driver = driver
 
+    def new_instance(self):
+        return type(self)(self.driver)
+
     def _outputtypehandler(self, cursor, name, defaultType,
                            size, precision, scale): # pylint:disable=unused-argument
         """cx_Oracle outputtypehandler that causes Oracle to send BLOBs inline.

--- a/src/relstorage/adapters/oracle/tests/test_adapter.py
+++ b/src/relstorage/adapters/oracle/tests/test_adapter.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from hamcrest import assert_that
+from nti.testing.matchers import validly_provides
+
+
+from relstorage.tests import TestCase
+from relstorage.tests import MockDriver
+
+from ..adapter import OracleAdapter as BaseAdapter
+
+from ... import interfaces
+
+
+class Adapter(BaseAdapter):
+    # We don't usually have cx_oracle installed, so
+    # fake it.
+
+    def _select_driver(self):
+        d = MockDriver()
+        d.connect = None
+        d.NUMBER = None
+        d.BLOB = None
+        d.BINARY = None
+        d.STRING = None
+        d.Binary = None
+        return d
+
+class TestAdapter(TestCase):
+
+    def _makeOne(self):
+        return Adapter()
+
+    def test_implements(self):
+        adapter = self._makeOne()
+        assert_that(adapter, validly_provides(interfaces.IRelStorageAdapter))

--- a/src/relstorage/adapters/oracle/tests/test_adapter.py
+++ b/src/relstorage/adapters/oracle/tests/test_adapter.py
@@ -33,7 +33,7 @@ class Adapter(BaseAdapter):
     # We don't usually have cx_oracle installed, so
     # fake it.
 
-    def _select_driver(self):
+    def _select_driver(self, options=None):
         d = MockDriver()
         d.connect = None
         d.NUMBER = None

--- a/src/relstorage/adapters/postgresql/__init__.py
+++ b/src/relstorage/adapters/postgresql/__init__.py
@@ -16,10 +16,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from relstorage.adapters.postgresql.adapter import PostgreSQLAdapter
-from relstorage.adapters.postgresql.adapter import select_driver
+
 
 assert PostgreSQLAdapter
-assert select_driver
 
 
 def debug_locks(cursor, me_only=False, exclusive_only=False): # pragma: no cover

--- a/src/relstorage/adapters/postgresql/tests/test_adapter.py
+++ b/src/relstorage/adapters/postgresql/tests/test_adapter.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
-# Copyright (c) 2009 Zope Foundation and Contributors.
+# Copyright (c) 2019 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,
@@ -11,13 +12,27 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""TransactionControl implementations"""
-
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
-from ..txncontrol import GenericTransactionControl
+
+from hamcrest import assert_that
+from nti.testing.matchers import validly_provides
 
 
-class MySQLTransactionControl(GenericTransactionControl):
-    pass
+from relstorage.tests import TestCase
+
+from ..adapter import PostgreSQLAdapter as Adapter
+
+from ... import interfaces
+
+class TestAdapter(TestCase):
+
+    def _makeOne(self):
+        return Adapter()
+
+    def test_implements(self):
+
+        adapter = self._makeOne()
+        assert_that(adapter, validly_provides(interfaces.IRelStorageAdapter))

--- a/src/relstorage/adapters/scriptrunner.py
+++ b/src/relstorage/adapters/scriptrunner.py
@@ -52,8 +52,11 @@ class ScriptRunner(object):
     format_vars = {
     }
 
+    def new_instance(self):
+        return type(self)()
+
     def with_format_vars(self, **new_vars):
-        inst = type(self)()
+        inst = self.new_instance()
         inst.format_vars = dict(self.format_vars)
         inst.format_vars.update(new_vars)
         return inst

--- a/src/relstorage/adapters/txncontrol.py
+++ b/src/relstorage/adapters/txncontrol.py
@@ -16,16 +16,11 @@
 from __future__ import absolute_import
 
 import abc
-import time
-
-from persistent.timestamp import TimeStamp
-from ZODB.utils import p64 as int64_to_8bytes
-from ZODB.utils import u64 as bytes8_to_int64
 
 from zope.interface import implementer
 
 from .._compat import ABC
-from .._util import timestamp_at_unixtime
+
 from ._util import noop_when_history_free
 
 from .schema import Schema
@@ -67,26 +62,6 @@ class AbstractTransactionControl(ABC):
         """Add a transaction"""
         raise NotImplementedError()
 
-    def lock_database_and_choose_next_tid(self, cursor, locker,
-                                          username,
-                                          description,
-                                          extension):
-        locker.hold_commit_lock(cursor, ensure_current=True)
-
-        # Choose a transaction ID.
-        #
-        # Base the transaction ID on the current time, but ensure that
-        # the tid of this transaction is greater than any existing
-        # tid.
-        last_tid = self.get_tid(cursor)
-        now = time.time()
-        stamp = timestamp_at_unixtime(now)
-        stamp = stamp.laterThan(TimeStamp(int64_to_8bytes(last_tid)))
-        tid = stamp.raw()
-
-        tid_int = bytes8_to_int64(tid)
-        self.add_transaction(cursor, tid_int, username, description, extension)
-        return tid_int
 
 @implementer(ITransactionControl)
 class GenericTransactionControl(AbstractTransactionControl):

--- a/src/relstorage/blobhelper.py
+++ b/src/relstorage/blobhelper.py
@@ -48,6 +48,9 @@ class NoBlobHelper(object):
 
     __slots__ = ()
 
+    NEEDS_DB_LOCK_TO_FINISH = False
+    NEEDS_DB_LOCK_TO_VOTE = False
+
     shared_blob_helper = False
     txn_has_blobs = False
     shared_blob_dir = None
@@ -89,7 +92,7 @@ class NoBlobHelper(object):
         raise AttributeError("NoBlobHelper has no 'fshelper'")
 
 
-@implementer(IBlobHelper)
+
 class _AbstractBlobHelper(object):
     """
     Stores blobs on the filesystem. This base class
@@ -310,6 +313,9 @@ class _AbstractBlobHelper(object):
 @implementer(IBlobHelper)
 class SharedBlobHelper(_AbstractBlobHelper):
 
+    NEEDS_DB_LOCK_TO_VOTE = True
+    NEEDS_DB_LOCK_TO_FINISH = False
+
     def __init__(self, options, adapter, fshelper=None):
         assert options.shared_blob_dir
 
@@ -400,8 +406,11 @@ class SharedBlobHelper(_AbstractBlobHelper):
         if not self._has_files(dirname):
             ZODB.blob.remove_committed_dir(dirname)
 
-
+@implementer(IBlobHelper)
 class CacheBlobHelper(_AbstractBlobHelper):
+
+    NEEDS_DB_LOCK_TO_VOTE = False
+    NEEDS_DB_LOCK_TO_FINISH = False
 
     class SizeLimited(object):
         """

--- a/src/relstorage/interfaces.py
+++ b/src/relstorage/interfaces.py
@@ -42,6 +42,9 @@ class IBlobHelper(Interface):
     BlobCacheChecker).
     """
 
+    NEEDS_DB_LOCK_TO_FINISH = Attribute("Boolean")
+    NEEDS_DB_LOCK_TO_VOTE = Attribute("Boolean")
+
     def new_instance(adapter):
         """
         Create a new instance for use in a new MVCC storage.

--- a/src/relstorage/storage/tpc/vote.py
+++ b/src/relstorage/storage/tpc/vote.py
@@ -75,6 +75,11 @@ class DatabaseLockedForTid(object):
         self.tid_int = tid_int
         self.release_commit_lock = adapter.locker.release_commit_lock
 
+    def __repr__(self):
+        return "<%s tid_int=%d>" %(
+            self.__class__.__name__,
+            self.tid_int
+        )
 
 class AbstractVote(AbstractTPCState):
     """
@@ -304,7 +309,8 @@ class AbstractVote(AbstractTPCState):
 
         self.prepared_txn = prepared_txn
         committing_tid_lock = self.committing_tid_lock
-        assert committing_tid_lock is None or committing_tid_int == committing_tid_lock.tid_int
+        assert committing_tid_lock is None or committing_tid_int == committing_tid_lock.tid_int, (
+            committing_tid_int, committing_tid_lock)
         if committing_tid_lock is None:
             self.committing_tid_lock = DatabaseLockedForTid(
                 int64_to_8bytes(committing_tid_int),

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -318,10 +318,15 @@ class DisconnectedException(Exception):
 class CloseException(Exception):
     pass
 
+class LockException(Exception):
+    pass
+
 class MockDriver(object):
 
     disconnected_exceptions = (DisconnectedException,)
     close_exceptions = (CloseException,)
+    lock_exceptions = (LockException,)
+    illegal_operation_exceptions = ()
 
     dialect = DefaultDialect()
 

--- a/src/relstorage/tests/blob/__init__.py
+++ b/src/relstorage/tests/blob/__init__.py
@@ -19,7 +19,14 @@ class TestBlobMixin(object):
         setUp(self)
         self._timer = MonotonicallyIncreasingTimeLayerMixin()
         self._timer.testSetUp()
-        self.blob_storage = self.create_storage(**self.DEFAULT_BLOB_STORAGE_KWARGS)
+        try:
+            self.blob_storage = self.create_storage(**self.DEFAULT_BLOB_STORAGE_KWARGS)
+        except:
+            # If setUp() raises an exception, tearDown is never called.
+            # That's bad: ZODB.tests.util.setUp() changes directories and
+            # monkeys with the contents of the stdlib tempfile.
+            tearDown(self)
+            raise
         self.database = DB(self.blob_storage)
 
     def tearDown(self):

--- a/src/relstorage/tests/blob/testblob.py
+++ b/src/relstorage/tests/blob/testblob.py
@@ -190,12 +190,15 @@ class BlobUndoTests(BlobTestBase):
 class RecoveryBlobStorage(BlobTestBase,
                           IteratorDeepCompare):
 
+    _dst = None
+
     def setUp(self):
         BlobTestBase.setUp(self)
         self._dst = self.create_storage('dest') # pylint:disable=no-member
 
     def tearDown(self):
-        self._dst.close()
+        if self._dst is not None:
+            self._dst.close()
         BlobTestBase.tearDown(self)
 
     # Requires a setUp() that creates a self._dst destination storage

--- a/src/relstorage/tests/blob/testblob.py
+++ b/src/relstorage/tests/blob/testblob.py
@@ -51,7 +51,11 @@ class BlobTestBase(TestCase,
 
     def setUp(self):
         super(BlobTestBase, self).setUp()
-        self._storage = self.create_storage() # pylint:disable=no-member
+        try:
+            self._storage = self.create_storage() # pylint:disable=no-member
+        except:
+            self.tearDown()
+            raise
 
 
 class BlobUndoTests(BlobTestBase):

--- a/src/relstorage/tests/hptestbase.py
+++ b/src/relstorage/tests/hptestbase.py
@@ -417,8 +417,8 @@ class HistoryPreservingRelStorageTests(GenericRelStorageTests,
     ###
 
     def __tid_clock_needs_care(self):
-        txncontrol = self._storage._adapter.txncontrol
-        return getattr(txncontrol, 'RS_TEST_TXN_PACK_NEEDS_SLEEP', False)
+        adapter = self._storage._adapter
+        return getattr(adapter, 'RS_TEST_TXN_PACK_NEEDS_SLEEP', False)
 
     def __maybe_ignore_monotonic(self, cls, method_name):
         if not self.__tid_clock_needs_care():
@@ -526,6 +526,9 @@ class HistoryPreservingRelStorageTests(GenericRelStorageTests,
 
     def checkPackAllRevisions(self):
         self._pack_to_latest('checkPackAllRevisions')
+
+    def checkPackOnlyOneObject(self):
+        self._pack_to_latest('checkPackOnlyOneObject')
 
     def checkPackUndoLog(self):
         packafter = []

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -307,7 +307,7 @@ class AbstractTestSuiteBuilder(ABC):
                 prefix = '%s_%s%s' % (
                     layer_prefix,
                     'Shared' if shared_blob_dir else 'Unshared',
-                    'WithHistory' if keep_history else 'NoHistory',
+                    'HistoryPreserving' if keep_history else 'HistoryFree',
                 )
 
                 # If the blob directory is a cache, don't test packing,


### PR DESCRIPTION
History-free and History-preserving both, including the commit (where possible). This takes us from 7 queries down to 1, which should be a nice win for gevent or threaded environments under load.

Note that the mere act of calling the stored procedure (before it was even attempting to commit) apparently crashes MySQL 5.7.12-log as deployed on AppVeyor (once we call it we get an error and abort the transaction, and the act of aborting tries to connect to the database and fails; from then on we can no longer connect: all connections are refused). 
```
Running:
 test_abort_transaction (relstorage.tests.blob.testblob.MySQLPyMySQL_SharedHistoryFreeTestBlobTransaction) (9.778 s)


Error in test test_abort_transaction (relstorage.tests.blob.testblob.MySQLPyMySQL_SharedHistoryFreeTestBlobTransaction)
raceback (most recent call last):
...
 File "\\relstorage\tests\blob\blob_transaction.py", line 75, in test_abort_transaction
   transaction.commit()
 File "\\\transaction\_manager.py", line 252, in commit
   return self.manager.commit()
...
 File "\\\transaction\_transaction.py", line 446, in _commitResources
   self._synchronizers.map(lambda s: s.afterCompletion(self))
 File "\\\transaction\weakset.py", line 61, in map
   f(elt)
 File "\\\transaction\_transaction.py", line 446, in <lambda>
   self._synchronizers.map(lambda s: s.afterCompletion(self))
 File "\\\ZODB\Connection.py", line 757, in afterCompletion
   self.newTransaction(transaction, False)
 File "\\\ZODB\Connection.py", line 737, in newTransaction
   invalidated = self._storage.poll_invalidations()
 File "\\relstorage\storage\__init__.py", line 637, in poll_invalidations
   self.__on_load_first_use
 File "\\relstorage\adapters\connections.py", line 151, in restart_and_call
   return self.call(callback, True, *args, **kw)
 File "\\relstorage\adapters\connections.py", line 174, in call
   self._open_connection()
 File "\\relstorage\adapters\connections.py", line 114, in _open_connection
   new_conn, new_cursor = self._new_connection()
 File "\\relstorage\adapters\connmanager.py", line 221, in open_for_load
   conn, cursor = self._do_open_for_load()
 File "\\relstorage\adapters\mysql\connmanager.py", line 106, in _do_open_for_load
   replica_selector=self.ro_replica_selector)
 File "\\relstorage\adapters\mysql\connmanager.py", line 77, in open
   conn = self._db_connect(**params)
  File "\\relstorage\adapters\mysql\drivers\pymysql.py", line 81, in connect
   return AbstractMySQLDriver.connect(self, *args, **kwargs)
 File "\\relstorage\adapters\_abstract_drivers.py", line 128, in connect
   return self._connect(*args, **kwargs)
 File "\\\pymysql\__init__.py", line 94, in Connect
   return Connection(*args, **kwargs)
 File "\\\pymysql\connections.py", line 325, in __init__
   self.connect()
 File "\\\pymysql\connections.py", line 630, in connect
   raise exc
pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on '127.0.0.1' ([WinError 10061] No connection could be made because the target machine actively refused it)")
```

That release is from early 2016 so I'm not *extremely* worried about it, but it would be nice to figure out eventually.