### PR TITLE
Use approximate sizes for the database in PostgreSQL.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -104,3 +104,7 @@ max-locals=20
 # pylint leaves it off. This is the proximal cause of the
 # undefined-all-variable crash.
 #unsafe-load-any-extension = no
+
+# Local Variables:
+# mode: conf-space
+# End:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,6 +143,11 @@ PostgreSQL
   single database call. With pg8000, however, it still takes two, with
   the second call being the COMMIT call that releases locks.
 
+- Speed up getting the approximate number of objects
+  (``len(storage)``) in a database by using the estimates collected by
+  the autovacuum process or analyzing tables, instead of asking for a
+  full table scan.
+
 3.0a5 (2019-07-11)
 ==================
 

--- a/src/relstorage/adapters/postgresql/stats.py
+++ b/src/relstorage/adapters/postgresql/stats.py
@@ -30,8 +30,8 @@ class PostgreSQLStats(AbstractStats):
     # out of date.
     # (https://www.postgresql.org/docs/11/monitoring-stats.html#PG-STAT-ALL-TABLES-VIEW)
     _get_object_count_queries = (
-        "SELECT reltuples FROM pg_class WHERE relname = 'current_object'",
-        "SELECT reltuples FROM pg_class WHERE relname = 'object_state'"
+        "SELECT reltuples::bigint FROM pg_class WHERE relname = 'current_object'",
+        "SELECT reltuples::bigint FROM pg_class WHERE relname = 'object_state'"
     )
 
 

--- a/src/relstorage/adapters/stats.py
+++ b/src/relstorage/adapters/stats.py
@@ -18,9 +18,10 @@ import abc
 
 from .._compat import ABC
 from ._util import query_property
+from ._util import DatabaseHelpersMixin
 
 
-class AbstractStats(ABC):
+class AbstractStats(DatabaseHelpersMixin, ABC):
 
     def __init__(self, connmanager, keep_history):
         self.connmanager = connmanager
@@ -46,3 +47,11 @@ class AbstractStats(ABC):
     def get_db_size(self):
         """Returns the approximate size of the database in bytes"""
         raise NotImplementedError()
+
+
+    def large_database_change(self):
+        """
+        Call this when the database has changed substantially,
+        and it would be a good time to perform any updates or
+        optimizations.
+        """

--- a/src/relstorage/storage/__init__.py
+++ b/src/relstorage/storage/__init__.py
@@ -664,6 +664,7 @@ class RelStorage(LegacyMethodsMixin,
 
     def copyTransactionsFrom(self, other):
         Copy(self.blobhelper, self, self).copyTransactionsFrom(other)
+        self._adapter.stats.large_database_change()
 
     def pack(self, t, referencesf, prepack_only=False, skip_prepack=False):
         pack = Pack(self._options, self._adapter, self.blobhelper, self._cache)

--- a/src/relstorage/storage/pack.py
+++ b/src/relstorage/storage/pack.py
@@ -44,6 +44,7 @@ class Pack(object):
         'blobhelper',
         'cache',
         'packundo',
+        'stats',
     )
 
     def __init__(self, options, adapter, blobhelper, cache):
@@ -51,6 +52,7 @@ class Pack(object):
         self.locker = adapter.locker
         self.connmanager = adapter.connmanager
         self.packundo = adapter.packundo.with_options(options)
+        self.stats = adapter.stats
         self.blobhelper = blobhelper
         self.cache = cache
 
@@ -205,3 +207,5 @@ class Pack(object):
                 self.locker.release_pack_lock(lock_cursor)
         finally:
             self.connmanager.rollback_and_close(lock_conn, lock_cursor)
+
+        self.stats.large_database_change()

--- a/src/relstorage/tests/RecoveryStorage.py
+++ b/src/relstorage/tests/RecoveryStorage.py
@@ -47,7 +47,9 @@ class IteratorDeepCompare(object):
         """Confirm that storage1 and storage2 contain equivalent data"""
         eq = self.assertEqual
         missing = object()
-        self.assertEqual(len(storage1), len(storage2))
+        # len(storage) is only required to be approximate and for "informational purposes."
+        # So we cannot use it as a hard check.
+        # self.assertEqual(len(storage1), len(storage2))
         iter1 = self._closing(storage1.iterator())
         iter2 = self._closing(storage2.iterator())
         for txn1, txn2 in zip(iter1, iter2):

--- a/src/relstorage/tests/hptestbase.py
+++ b/src/relstorage/tests/hptestbase.py
@@ -381,6 +381,7 @@ class HistoryPreservingRelStorageTests(GenericRelStorageTests,
         self.assertEqual(len(state), history[1]['size'])
 
         # Length is still 2
+        storage._adapter.stats.large_database_change()
         self.assertEqual(len(storage), 2)
 
         # The most recent size is 0 too

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -340,7 +340,8 @@ class GenericRelStorageTests(
 
     def checkLen(self):
         # Override the version from BasicStorage because we
-        # actually do guarantee to keep track of the counts.
+        # actually do guarantee to keep track of the counts,
+        # within certain limits.
 
         # len(storage) reports the number of objects.
         # check it is zero when empty
@@ -350,6 +351,7 @@ class GenericRelStorageTests(
         # of this number
         self._dostore(data=PersistentMapping())
         self._dostore(data=PersistentMapping())
+        self._storage._adapter.stats.large_database_change()
         self.assertEqual(len(self._storage), 2)
 
     def checkDropAndPrepare(self):


### PR DESCRIPTION
Fixes #291 

Also use a better method of loading procs that doesn't require multiple iterations and multiple transactions.