### PR TITLE
Use gevent's threadpool to clean up blobs when monkey-patched.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ env:
 script:
 # coverage slows PyPy down from 2minutes to 12+.
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --rcfile=.pylintrc relstorage -f parseable -r n; fi
+  - python -m gevent.monkey `which zope-testrunner` --test-path=src --color -vvv -t BlobCache --layer gevent
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then python $RS_TEST_CMD; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run $RS_TEST_CMD; fi
 after_success:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,14 @@
 - Optimize the ``loadBefore`` method. It appears to be mostly used in
   the tests.
 
+- Fix the blob cache cleanup thread to use a real native thread if
+  we're monkey-patched by gevent, using gevent's thread pool.
+  Previously, cleaning up the blob cache would block the event loop
+  for the duration. See :issue:`296`.
+
+- Improve the thread safety and resource usage of blob cache cleanup.
+  Previously it could spawn many useless threads.
+
 3.0a6 (2019-07-29)
 ==================
 


### PR DESCRIPTION
Also make that process thread safe, and avoid spawning lots and lots of threads.