### PR TITLE
History-free caches prune unused old revisions automatically as new ones are added

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,12 @@
 - Improve the thread safety and resource usage of blob cache cleanup.
   Previously it could spawn many useless threads.
 
+- When caching blobs for a history free storage, if there's an older
+  revision of the blob in the cache, and it is not in use, go ahead
+  and preemptively remove it from disk. This can help prevent the
+  cache size from growing out of hand and limit the number of
+  expensive full cache checks required. See :issue:`297`.
+
 3.0a6 (2019-07-29)
 ==================
 

--- a/src/relstorage/_util.py
+++ b/src/relstorage/_util.py
@@ -26,8 +26,28 @@ import traceback
 
 from persistent.timestamp import TimeStamp
 
+from ZODB.utils import p64
+from ZODB.utils import u64
+
 logger = __import__('logging').getLogger(__name__)
 
+int64_to_8bytes = p64
+bytes8_to_int64 = u64
+
+__all__ = [
+    'int64_to_8bytes',
+    'bytes8_to_int64',
+    'timestamp_at_unixtime',
+    'timer',
+    'log_timed',
+    'spawn',
+    'get_memory_usage',
+    'byte_display',
+    'Lazy',
+    'CachedIn',
+    'to_utf8',
+    'consume',
+]
 
 def timestamp_at_unixtime(now):
     """

--- a/src/relstorage/interfaces.py
+++ b/src/relstorage/interfaces.py
@@ -140,6 +140,18 @@ class IBlobHelper(Interface):
     def close():
         pass
 
+
+class IAuthoritativeBlobHelper(IBlobHelper):
+    """
+    A blob helper that has the only copy of the blob data.
+    """
+
+class ICachedBlobHelper(IBlobHelper):
+    """
+    A blob helper that is only a cache; the real data is elsewhere.
+    """
+
+
 class INoBlobHelper(IBlobHelper):
     """
     An object that does nothing with blobs.

--- a/src/relstorage/storage/__init__.py
+++ b/src/relstorage/storage/__init__.py
@@ -33,22 +33,24 @@ from ZODB.mvccadapter import HistoricalStorageAdapter
 
 from ZODB.POSException import ReadConflictError
 
-from ZODB.utils import p64 as int64_to_8bytes
-from ZODB.utils import u64 as bytes8_to_int64
 from ZODB.utils import z64
 from zope import interface
 from zope.interface import implementer
 
-from relstorage._compat import clear_frames
+from ..blobhelper import BlobHelper
+from ..blobhelper import NoBlobHelper
+from ..cache import StorageCache
+from ..options import Options
+from ..interfaces import IRelStorage
+from ..interfaces import IBlobHelper
+from ..interfaces import INoBlobHelper
+from ..adapters.connections import LoadConnection
+from ..adapters.connections import StoreConnection
+from ..adapters.connections import ClosedConnection
+from .._compat import clear_frames
+from .._util import int64_to_8bytes
+from .._util import bytes8_to_int64
 
-
-from relstorage.blobhelper import BlobHelper
-from relstorage.blobhelper import NoBlobHelper
-from relstorage.cache import StorageCache
-from relstorage.options import Options
-from relstorage.interfaces import IRelStorage
-from relstorage.interfaces import IBlobHelper
-from relstorage.interfaces import INoBlobHelper
 
 from .transaction_iterator import TransactionIterator
 
@@ -64,9 +66,6 @@ from .pack import Pack
 from .store import Storer
 from .store import BlobStorer
 
-from ..adapters.connections import LoadConnection
-from ..adapters.connections import StoreConnection
-from ..adapters.connections import ClosedConnection
 
 from .tpc import ABORT_EARLY
 from .tpc import NotInTransaction

--- a/src/relstorage/tests/blob/__init__.py
+++ b/src/relstorage/tests/blob/__init__.py
@@ -2,13 +2,12 @@
 
 It is especially useful for testing RelStorage + ZODB 3.8.
 """
-
+import os
 from nti.testing.time import MonotonicallyIncreasingTimeLayerMixin
 
 from ZODB.DB import DB
 from ZODB.tests.util import setUp
 from ZODB.tests.util import tearDown
-
 
 class TestBlobMixin(object):
 
@@ -35,3 +34,24 @@ class TestBlobMixin(object):
         self._timer.testTearDown()
         tearDown(self)
         super(TestBlobMixin, self).tearDown()
+
+    def _count_and_size_blobs_in_directory(self):
+        size = 0
+        count = 0
+        d = self.blob_storage.blobhelper.blob_dir
+        for base, _, files in os.walk(d):
+            for f in files:
+                if f.endswith('.blob'):
+                    count += 1
+                    try:
+                        size += os.stat(os.path.join(base, f)).st_size
+                    except OSError:
+                        if os.path.exists(os.path.join(base, f)):
+                            raise
+        return count, size
+
+    def _size_blobs_in_directory(self):
+        return self._count_and_size_blobs_in_directory()[1]
+
+    def _count_blobs_in_directory(self):
+        return self._count_and_size_blobs_in_directory()[0]

--- a/src/relstorage/tests/blob/blob_cache.py
+++ b/src/relstorage/tests/blob/blob_cache.py
@@ -20,7 +20,6 @@ This test is only for the non-shared (aka, "cached") case.
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
 import threading
 
 import random2
@@ -109,18 +108,6 @@ class TestBlobCacheMixin(TestBlobMixin):
             self._verify_blob_number(blob_number, conn, mode)
         conn.close()
 
-    def _size_blobs_in_directory(self):
-        size = 0
-        d = self.blob_storage.blobhelper.blob_dir
-        for base, _, files in os.walk(d):
-            for f in files:
-                if f.endswith('.blob'):
-                    try:
-                        size += os.stat(os.path.join(base, f)).st_size
-                    except OSError:
-                        if os.path.exists(os.path.join(base, f)):
-                            raise
-        return size
 
     def _wait_for_shrinks_to_finish(self):
         cache_checker = self.blob_storage.blobhelper.cache_checker

--- a/src/relstorage/tests/blob/testblob.py
+++ b/src/relstorage/tests/blob/testblob.py
@@ -580,7 +580,7 @@ def storage_reusable_suite(prefix, factory,
             attr,
         )
         new_class.__module__ = klass.__module__
-        new_class = unittest.skipUnless(storage_is_available, "Storage not available")(new_class)
+        new_class = unittest.skipUnless(storage_is_available, str(storage_is_available))(new_class)
         suite.addTest(unittest.makeSuite(new_class))
 
     add_test_based_on_test_class(TestBlobTransaction)


### PR DESCRIPTION
Fixes #297.