### PR TITLE
Use weaker locks for readCurrent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,13 @@
   database locks to allow other transactions to make progress
   immediately. See :issue:`50`.
 
+- Reduce the strength of locks taken by ``Connection.readCurrent`` so
+  that they don't conflict with other connections that just want to
+  verify they haven't changed. This also lets us immediately detect a
+  conflict error with an in-progress transaction that is trying to
+  alter those objects.
+
+
 3.0a6 (2019-07-29)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,13 @@
   that they don't conflict with other connections that just want to
   verify they haven't changed. This also lets us immediately detect a
   conflict error with an in-progress transaction that is trying to
-  alter those objects.
+  alter those objects. See :issue:`302`.
+
+- Make databases that use row-level locks (MySQL and PostgreSQL) raise
+  specific exceptions on failures to acquire those locks. A different
+  exception is raised for rows a transaction needs to modify compared
+  to rows it only needs to read. Both are considered transient to
+  encourage transaction middleware to retry. See :issue:`303`.
 
 
 3.0a6 (2019-07-29)

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -67,10 +67,12 @@ def iteroiditems(d):
 if PY3:
     string_types = (str,)
     unicode = str
+    number_types = (int, float)
     from io import StringIO as NStringIO
 else:
     string_types = (basestring,)
     unicode = unicode
+    number_types = (int, long, float)
     from io import BytesIO as NStringIO
 
 try:

--- a/src/relstorage/adapters/batch.py
+++ b/src/relstorage/adapters/batch.py
@@ -150,8 +150,9 @@ class RowBatcher(object):
             if these_params_need_flattened:
                 params = self._flatten_params(params)
             stmt += suffix
-            __traceback_info__ = params
+            __traceback_info__ = stmt, params
             self.cursor.execute(stmt, params)
+
         return count
 
     def _flatten_params(self, params):

--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -31,7 +31,10 @@ from relstorage._util import Lazy
 from ._util import query_property as _query_property
 from ._util import DatabaseHelpersMixin
 from .schema import Schema
+
 from .interfaces import UnableToAcquireCommitLockError
+from .interfaces import UnableToLockRowsToModifyError
+from .interfaces import UnableToLockRowsToReadCurrentError
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -55,8 +58,7 @@ class AbstractLocker(DatabaseHelpersMixin,
         This implementation calls :meth:`_on_store_opened_set_row_lock_timeout`
         when the store connection is initially opened.
         """
-        if not restart:
-            self._on_store_opened_set_row_lock_timeout(cursor)
+        self._on_store_opened_set_row_lock_timeout(cursor, restart)
 
     def _on_store_opened_set_row_lock_timeout(self, cursor, restart=False):
         """
@@ -138,6 +140,7 @@ class AbstractLocker(DatabaseHelpersMixin,
             lock=self._lock_current_clause
         )
 
+    @metricmethod
     def lock_current_objects(self, cursor, current_oids):
         # We need to be sure to take the locks in a deterministic
         # order; the easiest way to do that is to order them by OID.
@@ -178,26 +181,77 @@ class AbstractLocker(DatabaseHelpersMixin,
         # consume all the rows.
 
         # See docs in vote.py.
+
         # First, lock the rows we need exclusive access to.
-        stmt = self._lock_current_objects_query
-        cursor.execute(stmt)
-        rows = cursor
-        consume(rows)
+        # This will block for up to ``commit_lock_timeout``.
+        # Doing this first matters; always take the most exclusive locks
+        # first.
+        self._lock_rows_being_modified(cursor)
 
-        # Then lock rows we need shared access to. This may deadlock.
+        # Next, lock rows we need shared access to.
         if current_oids:
-            _, table = self._get_current_objects_query
-            oids_to_lock = sorted(set(current_oids))
+            self._lock_readCurrent_oids_for_share(cursor, current_oids)
 
-            batcher = self.make_batcher(cursor, row_limit=1000)
 
+    def _lock_readCurrent_oids_for_share(self, cursor, current_oids):
+        _, table = self._get_current_objects_query
+        oids_to_lock = sorted(set(current_oids))
+        batcher = self.make_batcher(cursor, row_limit=1000)
+
+        locking_suffix = ' %s ' % (self._lock_share_clause)
+        try:
             rows = batcher.select_from(
                 ('zoid',), table,
-                suffix='  %s ' % self._lock_share_clause,
+                suffix=locking_suffix,
                 **{'zoid': oids_to_lock}
             )
+            consume(rows)
+        except self.illegal_operation_exceptions:
+            # Bug in our code
+            raise
+        except self.lock_exceptions:
+            self.__reraise_commit_lock_error(
+                cursor,
+                'SELECT zoid FROM {table} WHERE zoid IN () {lock}'.format(
+                    table=table,
+                    lock=locking_suffix
+                ),
+                UnableToLockRowsToReadCurrentError
+            )
 
+    def _lock_rows_being_modified(self, cursor):
+        stmt = self._lock_current_objects_query
+        try:
+            cursor.execute(stmt)
+            rows = cursor
+            consume(rows)
+        except self.illegal_operation_exceptions:
+            # Bug in our code
+            raise
+        except self.lock_exceptions:
+            self.__reraise_commit_lock_error(
+                cursor,
+                stmt,
+                UnableToLockRowsToModifyError
+            )
 
+    def __reraise_commit_lock_error(self, cursor, lock_stmt, kind):
+        try:
+            debug_info = self._get_commit_lock_debug_info(cursor, True)
+        except Exception as nested: # pylint:disable=broad-except
+            logger.exception("Failed to get lock debug info")
+            debug_info = "%r(%r)" % (type(nested), nested)
+        __traceback_info__ = lock_stmt, debug_info
+        if debug_info:
+            logger.debug("Failed to acquire commit lock:\n%s", debug_info)
+        message = "Acquiring a commit lock failed: %s%s" % (
+            sys.exc_info()[1],
+            '\n' + debug_info if debug_info else ''
+        )
+        six.reraise(
+            kind,
+            kind(message),
+            sys.exc_info()[2])
 
     # MySQL allows aggregates in the top level to use FOR UPDATE,
     # but PostgreSQL does not, so we have to use the second form.
@@ -228,6 +282,8 @@ class AbstractLocker(DatabaseHelpersMixin,
     @metricmethod
     def hold_commit_lock(self, cursor, ensure_current=False, nowait=False):
         # pylint:disable=unused-argument
+        #
+        # This method is not used for PostgreSQL or MySQL.
         lock_stmt = self._commit_lock_query
         if nowait: # pragma: no cover
             if self._supports_row_lock_nowait:
@@ -240,32 +296,22 @@ class AbstractLocker(DatabaseHelpersMixin,
             rows = cursor.fetchall()
             if not rows or not rows[0]:
                 raise UnableToAcquireCommitLockError("No row returned from commit_row_lock")
-        except self.illegal_operation_exceptions as e:
+        except self.illegal_operation_exceptions:
             # Bug in our code.
             raise
-        except self.lock_exceptions as e:
+        except self.lock_exceptions:
             if nowait:
                 return False
-
-            try:
-                debug_info = self._get_commit_lock_debug_info(cursor)
-            except Exception as nested: # pylint:disable=broad-except
-                logger.exception("Failed to get lock debug info")
-                debug_info = "%r(%r)" % (type(nested), nested)
-            __traceback_info__ = lock_stmt, debug_info
-            if debug_info:
-                logger.debug("Failed to acquire commit lock:\n%s", debug_info)
-            message = "Acquiring a commit lock failed: %s%s" % (
-                e,
-                '\n' + debug_info if debug_info else ''
+            self.__reraise_commit_lock_error(
+                cursor,
+                lock_stmt,
+                UnableToAcquireCommitLockError
             )
-            six.reraise(
-                UnableToAcquireCommitLockError,
-                UnableToAcquireCommitLockError(message),
-                sys.exc_info()[2])
+
         return True
 
-    def _get_commit_lock_debug_info(self, cursor): # pylint:disable=unused-argument
+    def _get_commit_lock_debug_info(self, cursor, was_failure=False):
+        # pylint:disable=unused-argument
         """
         Subclasses can implement this to return a string
         that will be added to the exception message when a commit lock cannot

--- a/src/relstorage/adapters/mysql/locker.py
+++ b/src/relstorage/adapters/mysql/locker.py
@@ -95,6 +95,9 @@ class MySQLLocker(AbstractLocker):
     advisory locks anyway.
     """
 
+    # The old MySQL 5.7 syntax is the default
+    _lock_share_clause = 'LOCK IN SHARE MODE'
+
     def __init__(self, options, driver, batcher_factory):
         super(MySQLLocker, self).__init__(options, driver, batcher_factory)
         self._supports_row_lock_nowait = None
@@ -124,6 +127,8 @@ class MySQLLocker(AbstractLocker):
             major = int(ver[0])
             __traceback_info__ = ver, major
             self._supports_row_lock_nowait = (major >= 8)
+            if self._supports_row_lock_nowait:
+                self._lock_share_clause = 'FOR SHARE NOWAIT'
 
     def _on_store_opened_set_row_lock_timeout(self, cursor, restart=False):
         if restart:

--- a/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_p.sql
+++ b/src/relstorage/adapters/mysql/procs/hf/lock_and_choose_tid_p.sql
@@ -4,6 +4,11 @@ BEGIN
     DECLARE scratch BIGINT;
     DECLARE current_tid_64 BIGINT;
 
+    -- We're in the commit phase of two-phase commit.
+    -- It's very important not to error out here.
+    -- So we need a very long wait to get the commit lock.
+    SET SESSION innodb_lock_wait_timeout = 500;
+
     SELECT tid
     INTO scratch
     FROM commit_row_lock

--- a/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid_p.sql
+++ b/src/relstorage/adapters/mysql/procs/hp/lock_and_choose_tid_p.sql
@@ -10,6 +10,11 @@ BEGIN
     DECLARE scratch BIGINT;
     DECLARE current_tid_64 BIGINT;
 
+    -- We're in the commit phase of two-phase commit.
+    -- It's very important not to error out here.
+    -- So we need a very long wait to get the commit lock.
+    SET SESSION innodb_lock_wait_timeout = 500;
+
     SELECT tid
     INTO scratch
     FROM commit_row_lock

--- a/src/relstorage/adapters/oracle/adapter.py
+++ b/src/relstorage/adapters/oracle/adapter.py
@@ -18,8 +18,6 @@ import logging
 
 from zope.interface import implementer
 
-from ...options import Options
-
 from ..adapter import AbstractAdapter
 from ..dbiter import HistoryFreeDatabaseIterator
 from ..dbiter import HistoryPreservingDatabaseIterator
@@ -69,13 +67,16 @@ class OracleAdapter(AbstractAdapter):
         self._password = password
         self._dsn = dsn
         self._twophase = twophase
-        if options is None:
-            options = Options()
-        self.options = options
-        self.keep_history = options.keep_history
 
-        self.driver = driver = self._select_driver()
-        log.debug("Using driver %s", driver)
+        super(OracleAdapter, self).__init__(options)
+
+    def _create(self):
+        driver = self.driver
+        user = self._user
+        password = self._password
+        twophase = self._twophase
+        options = self.options
+        dsn = self._dsn
 
         self.connmanager = CXOracleConnectionManager(
             driver,

--- a/src/relstorage/adapters/postgresql/drivers/__init__.py
+++ b/src/relstorage/adapters/postgresql/drivers/__init__.py
@@ -48,6 +48,11 @@ class AbstractPostgreSQLDriver(AbstractModuleDriver):
                                application_name=None):
         raise NotImplementedError
 
+    def set_lock_timeout(self, cursor, timeout):
+        # PG8000 needs a literal embedded in the string; prepared
+        # statements can't be SET with a variable.
+        cursor.execute('SET lock_timeout = %s', (timeout,))
+
 database_type = 'postgresql'
 
 implement_db_driver_options(

--- a/src/relstorage/adapters/postgresql/drivers/pg8000.py
+++ b/src/relstorage/adapters/postgresql/drivers/pg8000.py
@@ -23,6 +23,8 @@ from collections import deque
 
 from zope.interface import implementer
 
+from relstorage._compat import number_types
+
 from ...interfaces import IDBDriver
 from ...sql import Compiler
 
@@ -256,3 +258,9 @@ class PG8000Driver(AbstractPostgreSQLDriver):
         return conn, cursor
 
     sql_compiler_class = PG8000Compiler
+
+    def set_lock_timeout(self, cursor, timeout):
+        # PG8000 needs a literal embedded in the string; prepared
+        # statements can't be SET with a variable.
+        assert isinstance(timeout, number_types)
+        cursor.execute('SET lock_timeout = %s' % (timeout,))

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -30,28 +30,35 @@ class PostgreSQLLocker(AbstractLocker):
     def _on_store_opened_set_row_lock_timeout(self, cursor, restart=False):
         # This only lasts beyond the current transaction if it
         # commits.
-        self._set_row_lock_timeout(cursor, self.commit_lock_timeout)
+        if not restart:
+            # We never change our lock timeout setting; the lock_and_choose_tid
+            # functions have it as part of their function definition, and
+            # we have NOWAIT for when we need a 0 timeout.
+            self._set_row_lock_timeout(cursor, self.commit_lock_timeout)
 
     def _set_row_lock_timeout(self, cursor, timeout):
         # This will rollback if the transaction rolls back,
         # which should restart our store.
         # Maybe for timeout == 0, we should do SET LOCAL, which
         # is guaranteed not to persist?
-        cursor.execute('SET lock_timeout = %s', (timeout,))
+        # Recall postgresql uses milliseconds, but our configuration is given
+        # in seconds.
+        self.driver.set_lock_timeout(cursor, timeout * 1000)
 
     def release_commit_lock(self, cursor):
         # no action needed, locks released with transaction.
         pass
 
-    def _get_commit_lock_debug_info(self, cursor):
+    def _get_commit_lock_debug_info(self, cursor, was_failure=False):
         # When we're called, the transaction is guaranteed to be
         # aborted, so to be able to execute any queries we need to
         # rollback. Unfortunately, that would release the locks that
-        # we're holding (which may already have been released?
-        # Unclear.)
-        #
-        # This method isn't specifically tested under those failures
-        # circumstances, and probably doesn't work.
+        # we're holding, which have probably(?) already have been released
+        # anyway. The output can be excessive.
+        if was_failure:
+            cursor.connection.rollback()
+            return 'Transaction failed; no lock info available'
+
         from . import debug_locks
         debug_locks(cursor)
         return self._rows_as_pretty_string(cursor)

--- a/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid.sql
+++ b/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid.sql
@@ -1,5 +1,11 @@
 CREATE OR REPLACE FUNCTION lock_and_choose_tid()
 RETURNS BIGINT
+  -- We're in the commit phase of two-phase commit.
+  -- It's very important not to error out here.
+  -- So we need a very long wait to get the commit lock.
+  -- Recall PostgreSQL uses milliseconds (it can also parse
+  -- strings like '10min').
+    SET lock_timeout = 600000
 AS
 $$
 DECLARE
@@ -14,7 +20,6 @@ BEGIN
   -- to indicate that the TIDs were the same, and a later view of the
   -- transaction would be incorrect (containing multiple distinct
   -- transactions).
-
   SELECT tid
   INTO scratch
   FROM commit_row_lock

--- a/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid.sql
+++ b/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid.sql
@@ -7,6 +7,14 @@ DECLARE
   current_tid_64 BIGINT;
   next_tid_64 BIGINT;
 BEGIN
+  -- In a history-free database, if we don't have a lock for the TID,
+  -- we could potentially end up with multiple processes choosing the
+  -- same TID (because there's no unique index on tids). As long as they were
+  -- working with different objects, there would be no database error
+  -- to indicate that the TIDs were the same, and a later view of the
+  -- transaction would be incorrect (containing multiple distinct
+  -- transactions).
+
   SELECT tid
   INTO scratch
   FROM commit_row_lock

--- a/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid_and_move.sql
+++ b/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid_and_move.sql
@@ -12,7 +12,10 @@ BEGIN
 
   -- move_from_temp()
   -- First the state for objects
-
+  -- TODO: We probably do not need to order the
+  -- temp rows. The locks we need are already held.
+  -- Skipping that appears to make a difference in plans and
+  -- benchmarks. Confirm that and remove.
   INSERT INTO object_state (
     zoid,
     tid,

--- a/src/relstorage/adapters/postgresql/procs/hp/lock_and_choose_tid.sql
+++ b/src/relstorage/adapters/postgresql/procs/hp/lock_and_choose_tid.sql
@@ -5,6 +5,11 @@ CREATE OR REPLACE FUNCTION lock_and_choose_tid(
   p_extension BYTEA
 )
 RETURNS BIGINT
+  -- We're in the commit phase of two-phase commit.
+  -- It's very important not to error out here.
+  -- So we need a very long wait to get the commit lock.
+  -- Recall PostgreSQL uses milliseconds
+    SET lock_timeout = 500000
 AS
 $$
 DECLARE

--- a/src/relstorage/options.py
+++ b/src/relstorage/options.py
@@ -110,7 +110,7 @@ class Options(object):
     #: storage.
     cache_local_storage = None
 
-    #: How long to wait for a commit lock
+    #: How long to wait for a commit lock, in seconds.
     commit_lock_timeout = 30
     #: Lock ID for Oracle
     commit_lock_id = 0


### PR DESCRIPTION
We don't need to block others from readCurrent on them, just from updating them.

Fixes #302 and fixes #303 