### PR TITLE
Move MySQL object locking and conflict detection into a stored proc.

### DIFF
--- a/.travis/mysql.sh
+++ b/.travis/mysql.sh
@@ -5,15 +5,21 @@
 # specify the address of the virtual machine.
 # docker run  --publish 3306:3306 --rm --name mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8.0
 HOST="-h ${RS_DB_HOST-localhost}"
+DBNAME=${RELSTORAGETEST_DBNAME:-relstoragetest}
+DBNAME2=${DBNAME}2
+DBNAME_HF=${DBNAME}_hf
+DBNAME2_HF=${DBNAME}2_hf
+echo $DBNAME_hf
+echo $DBNAME2_hf
 mysql -uroot $HOST -e "CREATE USER 'relstoragetest' IDENTIFIED BY 'relstoragetest';"
-mysql -uroot $HOST -e "CREATE DATABASE relstoragetest;"
-mysql -uroot $HOST -e "GRANT ALL ON relstoragetest.* TO 'relstoragetest';"
-mysql -uroot $HOST -e "CREATE DATABASE relstoragetest2;"
-mysql -uroot $HOST -e "GRANT ALL ON relstoragetest2.* TO 'relstoragetest';"
-mysql -uroot $HOST -e "CREATE DATABASE relstoragetest_hf;"
-mysql -uroot $HOST -e "GRANT ALL ON relstoragetest_hf.* TO 'relstoragetest';"
-mysql -uroot $HOST -e "CREATE DATABASE relstoragetest2_hf;"
-mysql -uroot $HOST -e "GRANT ALL ON relstoragetest2_hf.* TO 'relstoragetest';"
+mysql -uroot $HOST -e "CREATE DATABASE $DBNAME;"
+mysql -uroot $HOST -e "GRANT ALL ON $DBNAME.* TO 'relstoragetest';"
+mysql -uroot $HOST -e "CREATE DATABASE $DBNAME2;"
+mysql -uroot $HOST -e "GRANT ALL ON $DBNAME2.* TO 'relstoragetest';"
+mysql -uroot $HOST -e "CREATE DATABASE $DBNAME_HF;"
+mysql -uroot $HOST -e "GRANT ALL ON $DBNAME_HF.* TO 'relstoragetest';"
+mysql -uroot $HOST -e "CREATE DATABASE $DBNAME2_HF;"
+mysql -uroot $HOST -e "GRANT ALL ON $DBNAME2_HF.* TO 'relstoragetest';"
 mysql -uroot $HOST -e "GRANT SELECT ON performance_schema.* TO 'relstoragetest'"
 mysql -uroot $HOST -e "GRANT SELECT ON sys.* TO 'relstoragetest'"
 mysql -uroot $HOST -e "GRANT PROCESS ON *.* TO 'relstoragetest'"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,11 @@
   to rows it only needs to read. Both are considered transient to
   encourage transaction middleware to retry. See :issue:`303`.
 
+- Move more of the vote phase of transaction commit into a database
+  stored procedure on MySQL, beginning with taking the row-level
+  locks. This eliminates several more database round trips and the
+  need for the Python thread (or greenlet) to repeatedly release and
+  then acquire the GIL while holding global locks.
 
 3.0a6 (2019-07-29)
 ==================

--- a/docs/relstorage-options.rst
+++ b/docs/relstorage-options.rst
@@ -441,6 +441,11 @@ Persistent Local Caching
 Like ZEO, RelStorage can store its local cache to disk for a quicker
 application warmup period.
 
+.. versionchanged:: 3.0a7
+   Raise a descriptive error if the ``sqlite3`` library is too old to
+   be used by the local cache. RelStorage requires at least 3.8.3 but
+   works better with 3.15 and best with 3.24 or newer.
+
 .. versionchanged:: 3.0a1
    The persistent file format and contents have been substantially
    changed to produce much better hit rates.
@@ -500,6 +505,11 @@ cache-local-dir
            If the database (ZODB.DB object) is not properly
            :class:`closed <ZODB.interfaces.IDatabase>`, then the cache files will not be written.
 
+        .. tip::
+           This requires at least sqlite3 3.8.3 or better. Improved
+           performance comes with version 3.15 and the best
+           performance is with 3.24 or higher.
+
 cache-local-dir-count
         How many files that ``cache-local-dir`` will be allowed to
         contain before files start getting reused. Set this equal to
@@ -508,7 +518,7 @@ cache-local-dir-count
         The default is 20.
 
         .. versionchanged:: 3.0a1
-           This setting is now ignored and a single file is used.
+           This setting is now ignored and deprecated and a single file is used.
 
 cache-local-dir-compress
         Whether to compress the persistent cache files on disk. The
@@ -521,7 +531,7 @@ cache-local-dir-compress
         .. versionadded:: 2.0b5
 
         .. versionchanged:: 3.0a1
-           This setting is now ignored and no extra compression is applied.
+           This setting is now ignored and deprecated and no extra compression is applied.
 
 cache-local-dir-read-count
         The maximum number of files to read to populate the cache on
@@ -550,7 +560,7 @@ cache-local-dir-read-count
         .. versionadded:: 2.0b5
 
         .. versionchanged:: 3.0a1
-           This setting is now ignored and a single file is used.
+           This setting is now ignored and deprecated and a single file is used.
 
 cache-local-dir-write-max-size
         The *approximate* maximum size of each individual cache file

--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -215,11 +215,11 @@ class AbstractLocker(DatabaseHelpersMixin,
                 **{'zoid': oids_to_lock}
             )
             consume(rows)
-        except self.illegal_operation_exceptions:
+        except self.illegal_operation_exceptions: # pragma: no cover
             # Bug in our code
             raise
         except self.lock_exceptions:
-            self.__reraise_commit_lock_error(
+            self.reraise_commit_lock_error(
                 cursor,
                 'SELECT zoid FROM {table} WHERE zoid IN () {lock}'.format(
                     table=table,
@@ -234,17 +234,17 @@ class AbstractLocker(DatabaseHelpersMixin,
             cursor.execute(stmt)
             rows = cursor
             consume(rows)
-        except self.illegal_operation_exceptions:
+        except self.illegal_operation_exceptions: # pragma: no cover
             # Bug in our code
             raise
         except self.lock_exceptions:
-            self.__reraise_commit_lock_error(
+            self.reraise_commit_lock_error(
                 cursor,
                 stmt,
                 UnableToLockRowsToModifyError
             )
 
-    def __reraise_commit_lock_error(self, cursor, lock_stmt, kind):
+    def reraise_commit_lock_error(self, cursor, lock_stmt, kind):
         try:
             debug_info = self._get_commit_lock_debug_info(cursor, True)
         except Exception as nested: # pylint:disable=broad-except
@@ -305,13 +305,13 @@ class AbstractLocker(DatabaseHelpersMixin,
             rows = cursor.fetchall()
             if not rows or not rows[0]:
                 raise UnableToAcquireCommitLockError("No row returned from commit_row_lock")
-        except self.illegal_operation_exceptions:
+        except self.illegal_operation_exceptions: # pragma: no cover
             # Bug in our code.
             raise
         except self.lock_exceptions:
             if nowait:
                 return False
-            self.__reraise_commit_lock_error(
+            self.reraise_commit_lock_error(
                 cursor,
                 lock_stmt,
                 UnableToAcquireCommitLockError

--- a/src/relstorage/adapters/mysql/drivers/__init__.py
+++ b/src/relstorage/adapters/mysql/drivers/__init__.py
@@ -51,13 +51,18 @@ class AbstractMySQLDriver(AbstractModuleDriver):
     # Don't try to decode pickle states as UTF-8 (or whatever the
     # environment is configured as); See
     # https://github.com/zodb/relstorage/issues/57. This varies
-    # depending on Python 2/3 and which driver. Everything except
-    # mysqlclient on Python 3 can handle all names being binary; that
-    # driver, though, can only do that on Python 2. For Python 3, only
-    # the character_set_results can be binary. (See
-    # https://github.com/zodb/relstorage/issues/213)
-    # Subclasses can set to None if they don't need to do this.
-    MY_CHARSET_STMT = 'SET names binary'
+    # depending on Python 2/3 and which driver.
+    #
+    # In the past, we used 'SET names binary' for everything except
+    # mysqlclient on Python 3, which set the character_set_results
+    # only (because of an issue decoding column names (See
+    # https://github.com/zodb/relstorage/issues/213)). But having
+    # binary be the default encoding for string literals prevents
+    # using the JSON type. So we took another look at connection
+    # parameters and got things working with ``character_set_results``
+    # everywhere.
+    MY_CHARSET_STMT = 'SET character_set_results = binary'
+
 
     # Make the default timezone UTC. That way UTC_TIMESTAMP()
     # and UNIX_TIMESTAMP() and FROM_UNIXTIME are all self-consistent.

--- a/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
@@ -56,6 +56,10 @@ class PyMySQLConnectorDriver(AbstractMySQLDriver):
         # conn.close() -> InternalError: Unread result found
         # By the time we get to a close(), it's too late to do anything about it.
         self.close_exceptions += (self.driver_module.InternalError,)
+
+        if self.Binary is str:
+            self.Binary = bytearray
+
         if PYPY:
             # Patch to work around JIT bug found in (at least) 7.1.1
             # https://bitbucket.org/pypy/pypy/issues/3014/jit-issue-inlining-structunpack-hh
@@ -156,6 +160,7 @@ class PyMySQLConnectorDriver(AbstractMySQLDriver):
         kwargs['use_pure'] = self.USE_PURE
         converter_class = self._get_converter_class()
         kwargs['converter_class'] = converter_class
+        kwargs['get_warnings'] = True
 
         con = self.driver_module.connect(*args, **kwargs)
 

--- a/src/relstorage/adapters/mysql/drivers/mysqldb.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqldb.py
@@ -23,7 +23,7 @@ from zope.interface import implementer
 from relstorage.adapters.interfaces import IDBDriver
 
 from relstorage._util import Lazy
-from relstorage._compat import PY3
+
 from . import AbstractMySQLDriver
 
 __all__ = [

--- a/src/relstorage/adapters/mysql/drivers/mysqldb.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqldb.py
@@ -40,13 +40,6 @@ class MySQLdbDriver(AbstractMySQLDriver):
     PRIORITY_PYPY = 3
     _GEVENT_CAPABLE = False
 
-    if PY3:
-        # Setting the character_set_client = binary results in
-        # mysqlclient failing to decode column names. I haven't
-        # seen any UTF related warnings from this driver for the state
-        # values.
-        MY_CHARSET_STMT = 'SET character_set_results = binary'
-
     fetchall_on_rollback = True
 
     @Lazy

--- a/src/relstorage/adapters/mysql/drivers/pymysql.py
+++ b/src/relstorage/adapters/mysql/drivers/pymysql.py
@@ -78,4 +78,9 @@ class PyMySQLDriver(AbstractMySQLDriver):
 
     def connect(self, *args, **kwargs):
         kwargs['conv'] = self._conversions
+        # For bytes and bytearrays, put the "_binary" character set introducer
+        # in front. If we haven't set the ``connection_charset`` to binary --- and we can't
+        # because that breaks JSON types --- then this is needed for sending state data
+        # to avoid warnings about invalid character sequences.
+        kwargs['binary_prefix'] = True
         return AbstractMySQLDriver.connect(self, *args, **kwargs)

--- a/src/relstorage/adapters/mysql/mover.py
+++ b/src/relstorage/adapters/mysql/mover.py
@@ -210,6 +210,7 @@ class MySQLObjectMover(AbstractObjectMover):
 
         If serial is None, upload to the temporary table.
         """
+        Binary = self.driver.Binary
         if tid is not None:
             if self.keep_history:
                 delete_stmt = """
@@ -245,8 +246,8 @@ class MySQLObjectMover(AbstractObjectMover):
                     # chunk, even if the blob file is empty.
                     break
                 if use_tid:
-                    params = (oid, tid, chunk_num, chunk)
+                    params = (oid, tid, chunk_num, Binary(chunk))
                 else:
-                    params = (oid, chunk_num, chunk)
+                    params = (oid, chunk_num, Binary(chunk))
                 cursor.execute(insert_stmt, params)
                 chunk_num += 1

--- a/src/relstorage/adapters/mysql/mover.py
+++ b/src/relstorage/adapters/mysql/mover.py
@@ -44,6 +44,8 @@ class MySQLObjectMover(AbstractObjectMover):
             # DDL and not transaction ending).
             stmt = "TRUNCATE TABLE temp_store"
             cursor.execute(stmt)
+            stmt = "TRUNCATE TABLE temp_read_current"
+            cursor.execute(stmt)
             stmt = "TRUNCATE TABLE temp_blob_chunk"
             cursor.execute(stmt)
         else:
@@ -60,6 +62,14 @@ class MySQLObjectMover(AbstractObjectMover):
                 prev_tid    BIGINT UNSIGNED NOT NULL,
                 md5         CHAR(32),
                 state       LONGBLOB
+            ) ENGINE InnoDB
+            """
+            cursor.execute(stmt)
+
+            stmt = """
+            CREATE TEMPORARY TABLE temp_read_current (
+                zoid        BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+                tid         BIGINT UNSIGNED NOT NULL
             ) ENGINE InnoDB
             """
             cursor.execute(stmt)

--- a/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
@@ -1,11 +1,12 @@
 CREATE PROCEDURE lock_objects_and_detect_conflicts(
-  read_current_oids_tids JSON
+  read_current_oids_tids_text TEXT
 )
   COMMENT '{CHECKSUM}'
 BEGIN
   DECLARE dummy BIGINT;
   DECLARE len INT;
   DECLARE i INT DEFAULT 0;
+  DECLARE read_current_oids_tids JSON;
 
   SELECT COUNT(*)
   FROM (
@@ -25,7 +26,16 @@ BEGIN
   -- We detect the MySQL version when we install the
   -- procedure and choose the appropriate statements.
 
-  IF read_current_oids_tids IS NOT NULL THEN
+  IF read_current_oids_tids_text IS NOT NULL THEN
+    -- We must send the parameter in as TEXT; on Python 2 with
+    -- mysqlclient, trying to send it directly as JSON always fails
+    -- with "Cannot create a JSON value from a string with CHARACTER
+    -- SET 'binary'.", no matter what the character_set_client or
+    -- character_set_connection is, and no matter whether the
+    -- parameter in Python is bytes or unicode. This has also been seen
+    -- with Python 3 on Travis CI, but not locally on the mac, so there's
+    -- some system dependent behaviour involved.
+    SET read_current_oids_tids = CAST(read_current_oids_tids_text AS JSON);
     SET len = JSON_LENGTH(read_current_oids_tids);
     WHILE i < len DO
       INSERT INTO temp_read_current (zoid, tid)

--- a/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
@@ -10,7 +10,7 @@ BEGIN
   -- otherwise not all rows actually get locked.
   CREATE TEMPORARY TABLE IF NOT EXISTS temp_locked_zoid (
     zoid BIGINT PRIMARY KEY
-  ) ENGINE MEMORY;
+  );
 
   DELETE FROM temp_locked_zoid;
 
@@ -41,7 +41,7 @@ BEGIN
 
     {SET_LOCK_TIMEOUT}
 
-      DELETE FROM temp_locked_zoid;
+    DELETE FROM temp_locked_zoid;
 
     INSERT INTO temp_locked_zoid
     SELECT zoid

--- a/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
@@ -22,8 +22,9 @@ BEGIN
 
   -- lock in share should NOWAIT
   -- or have a minimum lock timeout.
-  -- we use the timeout because it works on 5.7 and 8
-  -- while NOWAIT only works on 8.
+  -- We detect the MySQL version when we install the
+  -- procedure and choose the appropriate statements.
+
   IF read_current_oids_tids IS NOT NULL THEN
     SET len = JSON_LENGTH(read_current_oids_tids);
     WHILE i < len DO
@@ -33,7 +34,7 @@ BEGIN
       SET i = i + 1;
     END WHILE;
 
-    SET SESSION innodb_lock_wait_timeout = 1;
+    {SET_LOCK_TIMEOUT}
 
     SELECT COUNT(*)
     FROM (
@@ -44,7 +45,7 @@ BEGIN
         FROM temp_read_current
       )
       ORDER BY zoid
-      LOCK IN SHARE MODE
+      {FOR_SHARE}
     ) t
     INTO dummy;
 

--- a/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
@@ -1,0 +1,67 @@
+CREATE PROCEDURE lock_objects_and_detect_conflicts(
+  read_current_oids_tids JSON
+)
+  COMMENT '{CHECKSUM}'
+BEGIN
+  DECLARE dummy BIGINT;
+  DECLARE len INT;
+  DECLARE i INT DEFAULT 0;
+
+  SELECT COUNT(*)
+  FROM (
+    SELECT zoid
+    FROM {CURRENT_OBJECT}
+    WHERE zoid IN (
+      SELECT zoid
+      FROM temp_store
+    )
+    ORDER BY zoid
+    FOR UPDATE
+  ) t
+  INTO dummy;
+
+  -- lock in share should NOWAIT
+  -- or have a minimum lock timeout.
+  -- we use the timeout because it works on 5.7 and 8
+  -- while NOWAIT only works on 8.
+  IF read_current_oids_tids IS NOT NULL THEN
+    SET len = JSON_LENGTH(read_current_oids_tids);
+    WHILE i < len DO
+      INSERT INTO temp_read_current (zoid, tid)
+      SELECT JSON_EXTRACT(read_current_oids_tids, CONCAT('$[', i, '][0]')),
+             JSON_EXTRACT(read_current_oids_tids, CONCAT('$[', i, '][1]'));
+      SET i = i + 1;
+    END WHILE;
+
+    SET SESSION innodb_lock_wait_timeout = 1;
+
+    SELECT COUNT(*)
+    FROM (
+      SELECT zoid
+      FROM {CURRENT_OBJECT}
+      WHERE zoid IN (
+        SELECT zoid
+        FROM temp_read_current
+      )
+      ORDER BY zoid
+      LOCK IN SHARE MODE
+    ) t
+    INTO dummy;
+
+  END IF;
+
+  -- readCurrent conflicts first so we don't waste time resolving
+  -- state conflicts if we are going to fail the transaction.
+
+  SELECT zoid, {CURRENT_OBJECT}.tid, NULL
+  FROM {CURRENT_OBJECT}
+  INNER JOIN temp_read_current USING (zoid)
+  WHERE temp_read_current.tid <> {CURRENT_OBJECT}.tid
+  UNION ALL
+  SELECT zoid, tid, prev_tid
+  FROM {CURRENT_OBJECT}
+  INNER JOIN temp_store USING (zoid)
+  WHERE temp_store.prev_tid <> {CURRENT_OBJECT}.tid;
+
+
+END;

--- a/src/relstorage/adapters/mysql/schema.py
+++ b/src/relstorage/adapters/mysql/schema.py
@@ -243,7 +243,6 @@ class MySQLSchemaInstaller(AbstractSchemaInstaller):
                 collation_connection = installed_proc.collation_connection
                 expected = (checksum, 'utf8', 'utf8_general_ci')
                 if expected != (stored_checksum, character_set_client, collation_connection):
-                    print("CREATING", expected, installed_proc)
                     logger.info(
                         "Re-creating procedure %s due to mismatch %s != %s",
                         name,

--- a/src/relstorage/adapters/mysql/schema.py
+++ b/src/relstorage/adapters/mysql/schema.py
@@ -198,10 +198,14 @@ class MySQLSchemaInstaller(AbstractSchemaInstaller):
 
     def create_procedures(self, cursor):
         installed = self.list_procedures(cursor)
+        current_object = 'current_object' if self.keep_history else 'object_state'
         for name, create_stmt in self.procedures.items():
             __traceback_info__ = name
             checksum = self._checksum_for_str(create_stmt)
-            create_stmt = create_stmt.format(CHECKSUM=checksum)
+            create_stmt = create_stmt.format(
+                CHECKSUM=checksum,
+                CURRENT_OBJECT=current_object
+            )
             assert checksum in create_stmt
             if name in installed:
                 stored_checksum = installed[name]

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -194,13 +194,13 @@ class PostgreSQLAdapter(AbstractAdapter):
         tid, = cursor.fetchone()
         return tid
 
-    def tpc_prepare_phase1(self,
-                           store_connection,
-                           blobhelper,
-                           ude,
-                           commit=True,
-                           committing_tid_int=None,
-                           after_selecting_tid=lambda tid: None):
+    def lock_database_and_move(self,
+                               store_connection,
+                               blobhelper, # pylint:disable=unused-argument
+                               ude,
+                               commit=True,
+                               committing_tid_int=None,
+                               after_selecting_tid=lambda tid: None):
 
         # In all versions of Postgres (up through 11 anyway),
         # stored functions cannot COMMIT. In Postgres 11,

--- a/src/relstorage/cache/local_database.py
+++ b/src/relstorage/cache/local_database.py
@@ -32,6 +32,9 @@ from relstorage._compat import OID_TID_MAP_TYPE
 from relstorage._util import log_timed
 from relstorage.adapters.batch import RowBatcher
 
+from .persistence import SQ3_SUPPORTS_UPSERT as SUPPORTS_UPSERT
+from .persistence import SQ3_SUPPORTS_PAREN_UPDATE as SUPPORTS_PAREN_UPDATE
+
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -56,10 +59,7 @@ class SimpleQueryProperty(object):
         cur.close()
         return result
 
-SUPPORTS_WINDOW = sqlite3.sqlite_version_info >= (3, 25) # 2018-09-15
-SUPPORTS_UPSERT = sqlite3.sqlite_version_info >= (3, 24) # 2018-06-04
-SUPPORTS_PAREN_UPDATE = sqlite3.sqlite_version_info >= (3, 15) # 2016-10-14
-SUPPORTS_CTE = sqlite3.sqlite_version_info >= (3, 8, 3) # 2014-02-03
+
 
 class Database(ABC):
     """

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -1423,8 +1423,15 @@ class GenericRelStorageTests(
         #
         # NOTE: When we move these steps into a stored procedure, this test will break
         # because we won't be able to force the interleaving.
+
+        if 'lock_objects_and_detect_conflicts' in vars(type(self._storage._adapter)):
+            raise unittest.SkipTest("%s does not allow manual interleaving" % (
+                self._storage._adapter
+            ))
+
         from relstorage.adapters.interfaces import UnableToLockRowsToReadCurrentError
         storageA = self._closing(self._storage.new_instance())
+
 
         storageA._adapter.locker.lock_current_objects = partial(
             self.__lock_rows_being_modified_only,


### PR DESCRIPTION
Eliminating a number of round trips.

On my local machine, I haven't been able to detect a significant speed difference for this branch compared to master on any combination of cp37/cp27 mysql8/mysql57 threads/gevent/processes in the add/update/readCurrent benchmarks. So apparently locally the round trips were not the bottleneck. 

But it still seems like the correct idea.