### PR TITLE
Speed up conflict resolution.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,13 @@
   release and then acquire the GIL while holding global locks. See
   :issue:`304`.
 
+- Make conflict resolution require fewer database round trips,
+  especially on PostgreSQL and MySQL, at the expense of using more
+  memory. In the ideal case it now only needs one (MySQL) or two
+  (PostgreSQL) queries. Previously it needed at least twice the number
+  of trips as there were conflicting objects. On both databases, the
+  benchmarks are 40% to 80% faster (depending on cache configuration).
+
 3.0a6 (2019-07-29)
 ==================
 

--- a/src/relstorage/adapters/mysql/connmanager.py
+++ b/src/relstorage/adapters/mysql/connmanager.py
@@ -72,7 +72,11 @@ class MySQLdbConnectionManager(AbstractConnectionManager):
             params = self._params
 
         while True:
-            __traceback_info__ = params
+            __traceback_info__ = {
+                k: v if k != 'passwd' else '<*****>'
+                for k, v in params.items()
+            }
+
             try:
                 conn = self._db_connect(**params)
                 cursor = self._db_driver.cursor(conn)

--- a/src/relstorage/adapters/mysql/mover.py
+++ b/src/relstorage/adapters/mysql/mover.py
@@ -96,7 +96,6 @@ class MySQLObjectMover(AbstractObjectMover):
     # more similar to what PostgreSQL uses, possibly allowing more
     # query sharing (with a smarter query runner/interpreter).
 
-    @metricmethod_sampled
     def store_temp(self, cursor, batcher, oid, prev_tid, data):
         suffix = """
         ON DUPLICATE KEY UPDATE
@@ -105,6 +104,12 @@ class MySQLObjectMover(AbstractObjectMover):
             md5 = VALUES(md5)
         """
         self._generic_store_temp(batcher, oid, prev_tid, data, suffix=suffix)
+
+    @metricmethod_sampled
+    def replace_temps(self, cursor, state_oid_tid_iter):
+        # We can use the regular batcher and store_temps -> store_temp
+        # method because of our upsert query.
+        self.store_temps(cursor, state_oid_tid_iter)
 
     @metricmethod_sampled
     def restore(self, cursor, batcher, oid, tid, data):

--- a/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
@@ -58,15 +58,16 @@ BEGIN
   -- readCurrent conflicts first so we don't waste time resolving
   -- state conflicts if we are going to fail the transaction.
 
-  SELECT zoid, {CURRENT_OBJECT}.tid, NULL
+  SELECT zoid, {CURRENT_OBJECT}.tid, NULL, NULL
   FROM {CURRENT_OBJECT}
   INNER JOIN temp_read_current USING (zoid)
   WHERE temp_read_current.tid <> {CURRENT_OBJECT}.tid
   UNION ALL
-  SELECT zoid, tid, prev_tid
-  FROM {CURRENT_OBJECT}
+  SELECT cur.zoid, cur.tid, temp_store.prev_tid, {OBJECT_STATE_NAME}.state
+  FROM {CURRENT_OBJECT} cur
   INNER JOIN temp_store USING (zoid)
-  WHERE temp_store.prev_tid <> {CURRENT_OBJECT}.tid;
+  {OBJECT_STATE_JOIN}
+  WHERE temp_store.prev_tid <> cur.tid;
 
 
 END;

--- a/src/relstorage/adapters/mysql/schema.py
+++ b/src/relstorage/adapters/mysql/schema.py
@@ -215,6 +215,16 @@ class MySQLSchemaInstaller(AbstractSchemaInstaller):
         # an appropriate value for both of those installed here.
         installed = self.list_procedures(cursor)
         current_object = 'current_object' if self.keep_history else 'object_state'
+        if self.keep_history:
+            object_state_join = """
+            INNER JOIN object_state ON (object_state.zoid = cur.zoid
+                                       AND object_state.tid = cur.tid)
+            """
+            object_state_name = 'object_state'
+        else:
+            object_state_join = ""
+            object_state_name = 'cur'
+
         major_version = self.version_detector.get_major_version(cursor)
         if self.version_detector.supports_nowait(cursor):
             set_lock_timeout = ''
@@ -232,6 +242,8 @@ class MySQLSchemaInstaller(AbstractSchemaInstaller):
             create_stmt = create_stmt.format(
                 CHECKSUM=checksum,
                 CURRENT_OBJECT=current_object,
+                OBJECT_STATE_NAME=object_state_name,
+                OBJECT_STATE_JOIN=object_state_join,
                 SET_LOCK_TIMEOUT=set_lock_timeout,
                 FOR_SHARE=for_share
             )

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -764,6 +764,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         self._init_after_create(cursor)
         log.debug("Done running init script.")
 
+    DROP_TABLE_TMPL = 'DROP TABLE {table}'
 
     def drop_all(self):
         """Drop all tables and sequences."""
@@ -773,7 +774,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
             todo.reverse()
             for table in todo:
                 if table in existent:
-                    cursor.execute("DROP TABLE %s" % table)
+                    cursor.execute(self.DROP_TABLE_TMPL.format(table=table))
             for sequence in self.list_sequences(cursor):
                 cursor.execute("DROP SEQUENCE %s" % sequence)
         self.connmanager.open_and_call(drop_all)

--- a/src/relstorage/adapters/sql/ast.py
+++ b/src/relstorage/adapters/sql/ast.py
@@ -27,6 +27,15 @@ class LiteralNode(Resolvable):
     def resolve_against(self, table):
         return self
 
+class NullNode(LiteralNode):
+    __slots__ = ()
+
+    def __init__(self):
+        super(NullNode, self).__init__(None)
+
+    def __compile_visit__(self, compiler):
+        compiler.emit_null()
+
 class BooleanNode(LiteralNode):
 
     __slots__ = ()
@@ -35,6 +44,8 @@ class TextNode(LiteralNode):
     __slots__ = ()
 
 def as_node(c):
+    if c is None:
+        return NullNode()
     if isinstance(c, bool):
         return BooleanNode(c)
     if isinstance(c, int):

--- a/src/relstorage/adapters/sql/dialect.py
+++ b/src/relstorage/adapters/sql/dialect.py
@@ -229,6 +229,9 @@ class Compiler(object):
         for content in contents:
             self.buf.write(content)
 
+    def emit_null(self):
+        self.emit('NULL')
+
     def emit_w_padding_space(self, value):
         ended_in_space = self.buf.getvalue().endswith(' ')
         value = value.strip()

--- a/src/relstorage/cache/storage_cache.py
+++ b/src/relstorage/cache/storage_cache.py
@@ -1079,18 +1079,22 @@ class _TemporaryStorage(object):
         return self._read_temp_state(startpos, endpos)
 
     def __iter__(self):
+        return self.iter_for_oids(None)
+
+    def iter_for_oids(self, oids):
         read_temp_state = self._read_temp_state
-        for startpos, endpos, oid_int, prev_tid_int in self.items():
+        for startpos, endpos, oid_int, prev_tid_int in self.items(oids):
             state = read_temp_state(startpos, endpos)
             yield state, oid_int, prev_tid_int
 
-    def items(self):
+    def items(self, oids=None):
         # Order the queue by file position, which should help
         # if the file is large and needs to be read
         # sequentially from disk.
         items = [
             (startpos, endpos, oid_int, prev_tid_int)
             for (oid_int, (startpos, endpos, prev_tid_int)) in iteroiditems(self._queue_contents)
+            if oids is None or oid_int in oids
         ]
         items.sort()
         return items

--- a/src/relstorage/storage/tpc/restore.py
+++ b/src/relstorage/storage/tpc/restore.py
@@ -123,8 +123,8 @@ class Restore(object):
         # Note also that this doesn't go through the cache.
 
         # TODO: Make it go through the cache, or at least the same
-        # sort of queing thing, so that we can do a bulk COPY?
-        # This complicates restoreBlob() and it complicates voting.
+        # sort of queing thing, so that we can do a bulk COPY.
+        # The way we do it now complicates restoreBlob() and it complicates voting.
         adapter.mover.restore(
             cursor, self.batcher, oid_int, tid_int, data)
 

--- a/src/relstorage/tests/testpostgresql.py
+++ b/src/relstorage/tests/testpostgresql.py
@@ -25,6 +25,7 @@ from relstorage.storage import bytes8_to_int64
 from relstorage.adapters.postgresql import PostgreSQLAdapter
 
 from .util import AbstractTestSuiteBuilder
+from .util import DEFAULT_DATABASE_SERVER_HOST
 from . import StorageCreatingMixin
 from . import TestCase
 
@@ -46,13 +47,9 @@ class PostgreSQLAdapterMixin(object):
             else:
                 dbname = self.base_dbname + '_hf'
         dsn = (
-            "dbname='%s' user='relstoragetest' password='relstoragetest'"
-            % dbname
+            "dbname='%s' user='relstoragetest' password='relstoragetest' host='%s'"
+            % (dbname, DEFAULT_DATABASE_SERVER_HOST)
         )
-        # psycopg2cffi can have a unix socket path hardcoded in it,
-        # and that path may not be right
-        if 'cffi' in self.driver_name.lower():
-            dsn += " host='127.0.0.1'"
         return dsn
 
     def get_adapter_zconfig(self):

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -59,8 +59,9 @@ USE_SMALL_BLOBS = ((RUNNING_ON_CI # slow here
 # still try to use the socket.) (The TCP port can be bound
 # by non-root, but the default Unix socket often requires
 # root permissions to open.)
+STANDARD_DATABASE_SERVER_HOST = '127.0.0.1'
 DEFAULT_DATABASE_SERVER_HOST = os.environ.get('RS_DB_HOST',
-                                              '127.0.0.1')
+                                              STANDARD_DATABASE_SERVER_HOST)
 
 
 TEST_UNAVAILABLE_DRIVERS = not bool(os.environ.get('RS_SKIP_UNAVAILABLE_DRIVERS'))


### PR DESCRIPTION
- Get committed data in bulk;
- Store replacement data in bulk.

This eliminates lots of database queries if there's more than one conflict. Since this happens while rows are locked, the faster this is, and the fewer round trips, the better. Results are 40-90%
improvements, depending on cache configuration. It does take a little more memory to store the committed data.

(The benchmark has half of the workers conflict on half of the objects.)

| Benchmark                                   | Master | This branch |
|---------------------------------------------|-----------------------------------------|-----------------------------------------|
| psycopg2_hf: update 100 conflicting objects (no cache) | 1.55 sec                                | 878 ms: 1.76x faster (-43%)             |
| psycopg2_hf: update 100 conflicting objects (cached) | 789 ms                                | 94.1 ms: 8.39x faster (-88%)          |
| mysqlclient_hf: update 100 conflicting objects (no cache) | 1.47 sec                                | 855 ms: 1.72x faster (-42%)             |
| mysqlclient_hf: update 100 conflicting objects (cached) | 657 ms                                | 122 ms: 5.39x faster (-81%)           |
