### PR TITLE
Change the order of locking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,21 @@
 3.0a8 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Switch the order in which object locks are taken: try shared locks
+  first and only then attempt exclusive locks. Shared locks do not
+  have to block, so a quick lock timeout here means that a
+  ``ReadConflictError`` is inevitable. This works best on PostgreSQL
+  and MySQL 8, which support true non-blocking locks. On MySQL 5.7,
+  non-blocking locks are emulated with a 1s timeout See :issue:`310`.
 
+- Fix MySQL to immediately rollback its transaction when it gets a
+  lock timeout, while still in the stored procedure on the database.
+  Previously it would have required a round trip to the Python
+  process, which could take an arbitrary amount of time while the
+  transaction may have still been holding some locks. (After
+  :issue:`310` they would only be shared locks, but before they would
+  have been exclusive locks.) This should make for faster recovery in
+  heavily loaded environments with lots of conflicts. See :`313`.
 
 3.0a7 (2019-08-07)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,13 @@
   have to block, so a quick lock timeout here means that a
   ``ReadConflictError`` is inevitable. This works best on PostgreSQL
   and MySQL 8, which support true non-blocking locks. On MySQL 5.7,
-  non-blocking locks are emulated with a 1s timeout See :issue:`310`.
+  non-blocking locks are emulated with a 1s timeout. See :issue:`310`.
+
+  .. note:: The transaction machinery will retry read conflict errors
+            by default. The more rapid detection of them may lead to
+            extra retries if there was a process still finishing its
+            commit. Consider adding small sleep backoffs to retry
+            logic.
 
 - Fix MySQL to immediately rollback its transaction when it gets a
   lock timeout, while still in the stored procedure on the database.

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -69,11 +69,27 @@ if PY3:
     unicode = str
     number_types = (int, float)
     from io import StringIO as NStringIO
+    from perfmetrics import metricmethod
+    from perfmetrics import Metric
 else:
     string_types = (basestring,)
     unicode = unicode
     number_types = (int, long, float)
     from io import BytesIO as NStringIO
+
+    # On Python 2, functools.update_wrapper doesn't set the '__wrapped__'
+    # attribute, and we need that.
+    from perfmetrics import Metric as _PMetric
+    class Metric(_PMetric):
+        def __call__(self, f):
+            new_f = _PMetric.__call__(self, f)
+            new_f.__wrapped__ = f
+            return new_f
+
+    metricmethod = Metric(method=True)
+
+metricmethod_sampled = Metric(method=True, rate=0.1)
+
 
 try:
     from abc import ABC

--- a/src/relstorage/_util.py
+++ b/src/relstorage/_util.py
@@ -26,6 +26,7 @@ import traceback
 
 from persistent.timestamp import TimeStamp
 
+
 from ZODB.utils import p64
 from ZODB.utils import u64
 

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -159,6 +159,8 @@ class AbstractAdapter(object):
         try:
             return self._best_lock_objects_and_detect_conflicts(cursor, read_current_oids)
         except self.locker.lock_exceptions:
+            # Heuristic to guess. If the stored proc or stored proc runner can do better,
+            # they should.
             elapsed = time.time() - begin
             kind = UnableToLockRowsToModifyError
             if read_current_oids and elapsed < self.locker.commit_lock_timeout:

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -24,12 +24,13 @@ from __future__ import print_function
 import time
 
 from persistent.timestamp import TimeStamp
-from perfmetrics import metricmethod
+
 
 from ZODB.POSException import ReadConflictError
 from ZODB.utils import p64 as int64_to_8bytes
 from ZODB.utils import u64 as bytes8_to_int64
 
+from .._compat import metricmethod
 from .._util import timestamp_at_unixtime
 from ..options import Options
 
@@ -137,12 +138,21 @@ class AbstractAdapter(object):
 
         return committing_tid_int, prepared_txn_id
 
-    lock_objects_and_detect_conflicts_interleavable = True
+    DEFAULT_LOCK_OBJECTS_AND_DETECT_CONFLICTS_INTERLEAVABLE = True
+
+    # Hooks for unit tests.
+    force_lock_objects_and_detect_conflicts_interleavable = False
+    force_lock_readCurrent_for_share_blocking = False
 
     @metricmethod
     def lock_objects_and_detect_conflicts(self, cursor, read_current_oids):
-        if self.locker.lock_readCurrent_for_share_blocks:
-            # Delegate to the individual statements that can control lock timeouts.
+        if (
+                self.force_lock_readCurrent_for_share_blocking
+                or self.force_lock_objects_and_detect_conflicts_interleavable
+        ):
+            # Delegate to the individual statements that can control lock timeouts,
+            # or that allow a controlling test to carefully interleave operations to simulate
+            # various concurrency situations.
             return self._composed_lock_objects_and_detect_conflicts(cursor,
                                                                     read_current_oids)
         begin = time.time()
@@ -163,7 +173,8 @@ class AbstractAdapter(object):
     def _composed_lock_objects_and_detect_conflicts(self, cursor, read_current_oids):
         read_current_oid_ints = read_current_oids.keys()
 
-        self.locker.lock_current_objects(cursor, read_current_oid_ints)
+        self.locker.lock_current_objects(cursor, read_current_oid_ints,
+                                         self.force_lock_readCurrent_for_share_blocking)
 
         current = self.mover.current_object_tids(cursor, read_current_oid_ints)
         # We go ahead and compare the readCurrent TIDs here, so that we don't have to

--- a/src/relstorage/adapters/connmanager.py
+++ b/src/relstorage/adapters/connmanager.py
@@ -13,10 +13,10 @@
 ##############################################################################
 from __future__ import absolute_import, print_function
 
-from perfmetrics import metricmethod
+
 from zope.interface import implementer
 
-
+from .._compat import metricmethod
 from .interfaces import IConnectionManager
 from .interfaces import ReplicaClosedException
 from .replica import ReplicaSelector

--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -71,15 +71,15 @@ class AbstractLocker(DatabaseHelpersMixin,
         """
 
     #: Set this to a false value if you don't support ``NOWAIT`` and we'll
-    #: instead set the lock timeout to 0.
-    _supports_row_lock_nowait = True
+    #: instead set the lock timeout to a low value.
+    supports_row_lock_nowait = True
 
     def _set_row_lock_timeout(self, cursor, timeout):
         "Implement this to change the row lock timeout."
 
     def _set_row_lock_nowait(self, cursor): # pragma: no cover
         """
-        If :attr:`_supports_row_lock_timeout` is not true, then this
+        If :attr:`supports_row_lock_timeout` is not true, then this
         class will call this method when :meth:`hold_commit_lock` is
         called with a false value for *nowait*.
 
@@ -181,19 +181,17 @@ class AbstractLocker(DatabaseHelpersMixin,
         # locked when they are returned by the cursor, so we must
         # consume all the rows.
 
-        # See docs in vote.py.
+        # Lock order is explained in IRelStorageAdapter.lock_objects_and_detect_conflicts.
 
-        # First, lock the rows we need exclusive access to.
-        # This will block for up to ``commit_lock_timeout``.
-        # Doing this first matters; always take the most exclusive locks
-        # first.
-        self._lock_rows_being_modified(cursor)
-
-        # Next, lock rows we need shared access to.
+        # First lock rows we need shared access to, typically without blocking.
         if read_current_oid_ints:
             self._lock_readCurrent_oids_for_share(cursor, read_current_oid_ints,
                                                   shared_locks_block)
 
+
+        # Then lock the rows we need exclusive access to.
+        # This will block for up to ``commit_lock_timeout``.
+        self._lock_rows_being_modified(cursor)
 
     def _lock_readCurrent_oids_for_share(self, cursor, current_oids, shared_locks_block):
         _, table = self._get_current_objects_query
@@ -293,7 +291,7 @@ class AbstractLocker(DatabaseHelpersMixin,
         # This method is not used for PostgreSQL or MySQL.
         lock_stmt = self._commit_lock_query
         if nowait: # pragma: no cover
-            if self._supports_row_lock_nowait:
+            if self.supports_row_lock_nowait:
                 lock_stmt = self._commit_lock_nowait_query
             else:
                 self._set_row_lock_nowait(cursor)

--- a/src/relstorage/adapters/mover.py
+++ b/src/relstorage/adapters/mover.py
@@ -18,10 +18,11 @@ from __future__ import absolute_import
 from hashlib import md5
 from abc import abstractmethod
 
-from perfmetrics import Metric
+
 from zope.interface import implementer
 
 from .._compat import OID_TID_MAP_TYPE
+from .._compat import metricmethod_sampled
 from ._util import noop_when_history_free
 from ._util import query_property as _query_property
 from .._compat import ABC
@@ -32,7 +33,7 @@ from .schema import Schema
 objects = Schema.all_current_object_state
 object_state = Schema.object_state
 
-metricmethod_sampled = Metric(method=True, rate=0.1)
+
 
 @implementer(IObjectMover)
 class AbstractObjectMover(ABC):

--- a/src/relstorage/adapters/mysql/adapter.py
+++ b/src/relstorage/adapters/mysql/adapter.py
@@ -259,7 +259,7 @@ class MySQLAdapter(AbstractAdapter):
         after_selecting_tid(tid_int)
         return tid_int, "-"
 
-    lock_objects_and_detect_conflicts_interleavable = False
+    DEFAULT_LOCK_OBJECTS_AND_DETECT_CONFLICTS_INTERLEAVABLE = False
 
     def _best_lock_objects_and_detect_conflicts(self, cursor, read_current_oids):
         read_current_param = None

--- a/src/relstorage/adapters/mysql/adapter.py
+++ b/src/relstorage/adapters/mysql/adapter.py
@@ -63,10 +63,11 @@ from ..adapter import AbstractAdapter
 from ..dbiter import HistoryFreeDatabaseIterator
 from ..dbiter import HistoryPreservingDatabaseIterator
 from ..interfaces import IRelStorageAdapter
-
+from ..interfaces import UnableToLockRowsToReadCurrentError
 from ..poller import Poller
 from ..scriptrunner import ScriptRunner
 from ..batch import RowBatcher
+
 from . import drivers
 from .connmanager import MySQLdbConnectionManager
 from .locker import MySQLLocker
@@ -287,11 +288,20 @@ class MySQLAdapter(AbstractAdapter):
             read_current_param = json.dumps(list(read_current_oids.items()))
 
         proc = 'lock_objects_and_detect_conflicts(%s)'
-        multi_results = self.driver.callproc_multi_result(
-            cursor,
-            proc,
-            (read_current_param,)
-        )
+        try:
+            multi_results = self.driver.callproc_multi_result(
+                cursor,
+                proc,
+                (read_current_param,)
+            )
+        except self.locker.lock_exceptions as e:
+            if 'shared locks' in str(e):
+                self.locker.reraise_commit_lock_error(
+                    cursor,
+                    self._describe_best_lock_objects_and_detect_conflicts(),
+                    UnableToLockRowsToReadCurrentError
+                )
+            raise
         conflicts = multi_results[0]
         return conflicts
 

--- a/src/relstorage/adapters/mysql/locker.py
+++ b/src/relstorage/adapters/mysql/locker.py
@@ -154,7 +154,8 @@ class MySQLLocker(AbstractLocker):
 
     def __init__(self, options, driver, batcher_factory, version_detector):
         super(MySQLLocker, self).__init__(options, driver, batcher_factory)
-        self._supports_row_lock_nowait = None
+        assert self.supports_row_lock_nowait # Set by default in the class.
+        self.supports_row_lock_nowait = None
         self.version_detector = version_detector
 
         # No good preparing this, mysql can't take parameters in EXECUTE,
@@ -172,10 +173,10 @@ class MySQLLocker(AbstractLocker):
         # sys.version_major() is 5.7.9+, but we don't have execute
         # permissions on that function by default, so we do it the old fashioned
         # way with version()
-        if self._supports_row_lock_nowait is None:
-            self._supports_row_lock_nowait = self.version_detector.supports_nowait(cursor)
+        if self.supports_row_lock_nowait is None:
+            self.supports_row_lock_nowait = self.version_detector.supports_nowait(cursor)
 
-            if self._supports_row_lock_nowait:
+            if self.supports_row_lock_nowait:
                 self._lock_share_clause = 'FOR SHARE'
                 self._lock_share_clause_nowait = 'FOR SHARE NOWAIT'
             else:

--- a/src/relstorage/adapters/mysql/locker.py
+++ b/src/relstorage/adapters/mysql/locker.py
@@ -197,13 +197,14 @@ class MySQLLocker(AbstractLocker):
         cursor.fetchone()
 
 
-    def __lock_readCurrent_nowait(self, cursor, current_oids):
+    def __lock_readCurrent_nowait(self, cursor, current_oids, shared_locks_block):
         # For MySQL 5.7, we emulate NOWAIT by setting the lock timeout
-        if self.lock_readCurrent_for_share_blocks:
-            return AbstractLocker._lock_readCurrent_oids_for_share(self, cursor, current_oids)
+        if shared_locks_block:
+            return AbstractLocker._lock_readCurrent_oids_for_share(self, cursor, current_oids, True)
 
         with lock_timeout(cursor, 0, self.commit_lock_timeout):
-            return AbstractLocker._lock_readCurrent_oids_for_share(self, cursor, current_oids)
+            return AbstractLocker._lock_readCurrent_oids_for_share(self, cursor, current_oids,
+                                                                   False)
 
     def release_commit_lock(self, cursor):
         "Auto-released by transaction end."

--- a/src/relstorage/adapters/mysql/oidallocator.py
+++ b/src/relstorage/adapters/mysql/oidallocator.py
@@ -18,9 +18,9 @@ IOIDAllocator implementations.
 
 from __future__ import absolute_import
 
-from perfmetrics import metricmethod
 from zope.interface import implementer
 
+from ..._compat import metricmethod
 from ..interfaces import IOIDAllocator
 from ..oidallocator import AbstractOIDAllocator
 from .locker import lock_timeout

--- a/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
@@ -15,6 +15,9 @@ BEGIN
        -- exclusive locks.)
        -- and then reraise the exception.
        SET @@innodb_lock_wait_timeout = prev_timeout;
+       -- The server depends on these error messages.
+       -- TODO: Write test cases that verify we rollback our shared locks if we
+       -- can't get the exclusive locks.
        IF prev_timeout IS NULL THEN
          SET @msg = 'Failed to get exclusive locks.';
        ELSE
@@ -98,6 +101,7 @@ BEGIN
   -- readCurrent conflicts first so we don't waste time resolving
   -- state conflicts if we are going to fail the transaction.
   -- Only need to return one of those.
+  -- TODO: Break if we get a row; don't even bother taking exclusive locks.
   SELECT * FROM (
     SELECT zoid, {CURRENT_OBJECT}.tid, NULL as prev_tid, NULL as state
     FROM {CURRENT_OBJECT}

--- a/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
@@ -5,6 +5,24 @@ CREATE PROCEDURE lock_objects_and_detect_conflicts(
 BEGIN
   DECLARE len INT;
   DECLARE i INT DEFAULT 0;
+  DECLARE prev_timeout INT;
+  DECLARE EXIT HANDLER FOR 1205, 1213
+     BEGIN
+       -- For 'lock_timeout' or deadlock errors, restore the old timeout
+       -- (if it was a shared lock that failed),
+       -- completely rollback the transaction to drop any locks we do have,
+       -- (important if we had already taken shared locks then timed out on
+       -- exclusive locks.)
+       -- and then reraise the exception.
+       SET @@innodb_lock_wait_timeout = prev_timeout;
+       IF prev_timeout IS NULL THEN
+         SET @msg = 'Failed to get exclusive locks.';
+       ELSE
+         SET @msg = 'Failed to get shared locks.';
+       END IF;
+       ROLLBACK;
+       RESIGNAL SET MESSAGE_TEXT = @msg;
+     END;
 
   -- We have to force the server to materialize the results, otherwise
   -- not all rows actually get locked. Also, it is critically
@@ -17,25 +35,20 @@ BEGIN
     zoid BIGINT PRIMARY KEY
   );
 
-  DELETE FROM temp_locked_zoid;
 
-  INSERT INTO temp_locked_zoid
-  SELECT zoid
-  FROM {CURRENT_OBJECT}
-  WHERE zoid IN (
-      SELECT zoid
-      FROM temp_store
-  )
-  ORDER BY zoid
-  FOR UPDATE;
 
+  -- TODO: Do the temp table creation in the mover.py
+  -- TODO: Investigate these plans. I was seeing them both use filesort and
+  -- temporary table. That can't be right. Or good.
 
   -- lock in share should NOWAIT
   -- or have a minimum lock timeout.
   -- We detect the MySQL version when we install the
   -- procedure and choose the appropriate statements.
-
+  SET prev_timeout = @@innodb_lock_wait_timeout;
   IF read_current_oids_tids IS NOT NULL THEN
+    -- We don't make the server do a round-trip to put this data
+    -- into a temp table because we're specifically trying to limit round trips.
     SET len = JSON_LENGTH(read_current_oids_tids);
     WHILE i < len DO
       INSERT INTO temp_read_current (zoid, tid)
@@ -44,6 +57,10 @@ BEGIN
       SET i = i + 1;
     END WHILE;
 
+    -- SIGNAL SQLSTATE 'HY000' SET  MYSQL_ERRNO = 1205;
+
+    -- The timeout only goes to 1; this procedure seems to always take roughtly 2s
+    -- to actually detect a lock timeout problem, however.
     {SET_LOCK_TIMEOUT}
 
     DELETE FROM temp_locked_zoid;
@@ -58,15 +75,36 @@ BEGIN
     ORDER BY zoid
     {FOR_SHARE};
 
+    SET @@innodb_lock_wait_timeout = prev_timeout;
+
   END IF;
+  SET prev_timeout = NULL;
+
+  DELETE FROM temp_locked_zoid;
+
+  INSERT INTO temp_locked_zoid
+  SELECT zoid
+  FROM {CURRENT_OBJECT}
+  WHERE zoid IN (
+      SELECT zoid
+      FROM temp_store
+  )
+  ORDER BY zoid
+  FOR UPDATE;
+
+
+
 
   -- readCurrent conflicts first so we don't waste time resolving
   -- state conflicts if we are going to fail the transaction.
-
-  SELECT zoid, {CURRENT_OBJECT}.tid, NULL, NULL
-  FROM {CURRENT_OBJECT}
-  INNER JOIN temp_read_current USING (zoid)
-  WHERE temp_read_current.tid <> {CURRENT_OBJECT}.tid
+  -- Only need to return one of those.
+  SELECT * FROM (
+    SELECT zoid, {CURRENT_OBJECT}.tid, NULL as prev_tid, NULL as state
+    FROM {CURRENT_OBJECT}
+    INNER JOIN temp_read_current USING (zoid)
+    WHERE temp_read_current.tid <> {CURRENT_OBJECT}.tid
+    LIMIT 1
+  ) lt
   UNION ALL
   SELECT cur.zoid, cur.tid, temp_store.prev_tid, {OBJECT_STATE_NAME}.state
   FROM {CURRENT_OBJECT} cur

--- a/src/relstorage/adapters/oracle/connmanager.py
+++ b/src/relstorage/adapters/oracle/connmanager.py
@@ -16,8 +16,7 @@ from __future__ import absolute_import
 
 import logging
 
-from perfmetrics import metricmethod
-
+from ..._compat import metricmethod
 from ..connmanager import AbstractConnectionManager
 from ..interfaces import ReplicaClosedException
 

--- a/src/relstorage/adapters/oracle/locker.py
+++ b/src/relstorage/adapters/oracle/locker.py
@@ -17,9 +17,9 @@ Locker implementations.
 
 from __future__ import absolute_import
 
-from perfmetrics import metricmethod
 from zope.interface import implementer
 
+from ..._compat import metricmethod
 from ..interfaces import ILocker
 from ..interfaces import UnableToAcquireCommitLockError
 from ..interfaces import UnableToAcquirePackUndoLockError

--- a/src/relstorage/adapters/oracle/oidallocator.py
+++ b/src/relstorage/adapters/oracle/oidallocator.py
@@ -17,9 +17,9 @@ IOIDAllocator implementations.
 
 from __future__ import absolute_import
 
-from perfmetrics import metricmethod
 from zope.interface import implementer
 
+from ..._compat import metricmethod
 from ..interfaces import IOIDAllocator
 from ..oidallocator import AbstractOIDAllocator
 

--- a/src/relstorage/adapters/oracle/tests/test_adapter.py
+++ b/src/relstorage/adapters/oracle/tests/test_adapter.py
@@ -16,18 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from zope.interface import alsoProvides
 
-from hamcrest import assert_that
-from nti.testing.matchers import validly_provides
-
-
-from relstorage.tests import TestCase
 from relstorage.tests import MockDriver
-
 from ..adapter import OracleAdapter as BaseAdapter
 
 from ... import interfaces
-
+from ...tests import test_adapter
 
 class Adapter(BaseAdapter):
     # We don't usually have cx_oracle installed, so
@@ -41,13 +36,11 @@ class Adapter(BaseAdapter):
         d.BINARY = None
         d.STRING = None
         d.Binary = None
+        d.use_replica_exceptions = ()
+        alsoProvides(d, interfaces.IDBDriver)
         return d
 
-class TestAdapter(TestCase):
+class TestAdapter(test_adapter.AdapterTestBase):
 
     def _makeOne(self):
         return Adapter()
-
-    def test_implements(self):
-        adapter = self._makeOne()
-        assert_that(adapter, validly_provides(interfaces.IRelStorageAdapter))

--- a/src/relstorage/adapters/oracle/tests/test_adapter.py
+++ b/src/relstorage/adapters/oracle/tests/test_adapter.py
@@ -37,6 +37,9 @@ class Adapter(BaseAdapter):
         d.STRING = None
         d.Binary = None
         d.use_replica_exceptions = ()
+        d.binary_column_as_state_type = lambda b: b
+        d.binary_column_as_bytes = lambda b: b
+        d.__name__ = 'cx_Oracle'
         alsoProvides(d, interfaces.IDBDriver)
         return d
 

--- a/src/relstorage/adapters/packundo.py
+++ b/src/relstorage/adapters/packundo.py
@@ -18,11 +18,11 @@ from __future__ import absolute_import
 import logging
 import time
 
-from perfmetrics import metricmethod
 from ZODB.POSException import UndoError
 from ZODB.utils import u64
 from zope.interface import implementer
 
+from .._compat import metricmethod
 from ..iter import fetchmany
 from ..treemark import TreeMarker
 from .interfaces import IPackUndo

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -262,7 +262,7 @@ class PostgreSQLAdapter(AbstractAdapter):
         return tid_int, "-"
 
 
-    lock_objects_and_detect_conflicts_interleavable = False
+    DEFAULT_LOCK_OBJECTS_AND_DETECT_CONFLICTS_INTERLEAVABLE = False
 
     def _best_lock_objects_and_detect_conflicts(self, cursor, read_current_oids):
         read_current_oids_p = None

--- a/src/relstorage/adapters/postgresql/connmanager.py
+++ b/src/relstorage/adapters/postgresql/connmanager.py
@@ -16,8 +16,7 @@ from __future__ import absolute_import
 
 import logging
 
-from perfmetrics import metricmethod
-
+from ..._compat import metricmethod
 from ..connmanager import AbstractConnectionManager
 
 log = logging.getLogger(__name__)

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -42,8 +42,11 @@ class PostgreSQLLocker(AbstractLocker):
         # Maybe for timeout == 0, we should do SET LOCAL, which
         # is guaranteed not to persist?
         # Recall postgresql uses milliseconds, but our configuration is given
-        # in seconds.
-        self.driver.set_lock_timeout(cursor, timeout * 1000)
+        # in integer seconds.
+        # For tests, though, we accept floating point numbers
+        timeout_ms = int(timeout * 1000.0)
+        self.driver.set_lock_timeout(cursor, timeout_ms)
+
 
     def release_commit_lock(self, cursor):
         # no action needed, locks released with transaction.

--- a/src/relstorage/adapters/postgresql/oidallocator.py
+++ b/src/relstorage/adapters/postgresql/oidallocator.py
@@ -17,9 +17,9 @@ IOIDAllocator implementations.
 
 from __future__ import absolute_import
 
-from perfmetrics import metricmethod
 from zope.interface import implementer
 
+from ..._compat import metricmethod
 from ..interfaces import IOIDAllocator
 from ..oidallocator import AbstractOIDAllocator
 

--- a/src/relstorage/adapters/postgresql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/postgresql/procs/lock_objects_and_detect_conflicts.sql
@@ -13,6 +13,9 @@ BEGIN
     -- readCurrent conflicts first so we don't waste time resolving
     -- state conflicts if we are going to fail the transaction. We only need to return
     -- the first conflict; it will immediately raise an exception.
+    -- TODO: Does this actually stream to the client? I don't think so, so we
+    -- need to detect if we got any rows and if so, not bother taking the exclusive
+    -- locks.
 
     -- Doing this in a single query takes some effort to make sure
     -- that the required rows all get locked. The optimizer is smart

--- a/src/relstorage/adapters/postgresql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/postgresql/procs/lock_objects_and_detect_conflicts.sql
@@ -6,24 +6,13 @@ CREATE OR REPLACE FUNCTION lock_objects_and_detect_conflicts(
 AS
 $$
 BEGIN
-  -- Unlike MySQL, we can simply do the SELECT (with PERFORM) for its
-  -- side effects to lock the rows.
-
-  PERFORM {CURRENT_OBJECT}.zoid
-  FROM {CURRENT_OBJECT}
-  WHERE {CURRENT_OBJECT}.zoid IN (
-      SELECT temp_store.zoid
-      FROM temp_store
-  )
-  ORDER BY {CURRENT_OBJECT}.zoid
-  FOR UPDATE;
-
 
   -- lock in share should NOWAIT
 
   IF read_current_oids IS NOT NULL THEN
     -- readCurrent conflicts first so we don't waste time resolving
-    -- state conflicts if we are going to fail the transaction.
+    -- state conflicts if we are going to fail the transaction. We only need to return
+    -- the first conflict; it will immediately raise an exception.
 
     -- Doing this in a single query takes some effort to make sure
     -- that the required rows all get locked. The optimizer is smart
@@ -48,8 +37,21 @@ BEGIN
         FOR SHARE NOWAIT
       )
       SELECT locked.zoid, locked.tid, NULL::BIGINT, NULL::BYTEA
-      FROM locked WHERE locked.tid <> locked.desired;
+      FROM locked WHERE locked.tid <> locked.desired
+      LIMIT 1;
   END IF;
+
+  -- Unlike MySQL, we can simply do the SELECT (with PERFORM) for its
+  -- side effects to lock the rows.
+  -- This one will block.
+  PERFORM {CURRENT_OBJECT}.zoid
+  FROM {CURRENT_OBJECT}
+  WHERE {CURRENT_OBJECT}.zoid IN (
+      SELECT temp_store.zoid
+      FROM temp_store
+  )
+  ORDER BY {CURRENT_OBJECT}.zoid
+  FOR UPDATE;
 
 
   RETURN QUERY

--- a/src/relstorage/adapters/postgresql/tests/test_adapter.py
+++ b/src/relstorage/adapters/postgresql/tests/test_adapter.py
@@ -17,22 +17,11 @@ from __future__ import division
 from __future__ import print_function
 
 
-from hamcrest import assert_that
-from nti.testing.matchers import validly_provides
-
-
-from relstorage.tests import TestCase
-
 from ..adapter import PostgreSQLAdapter as Adapter
 
-from ... import interfaces
+from ...tests import test_adapter
 
-class TestAdapter(TestCase):
+class TestAdapter(test_adapter.AdapterTestBase):
 
     def _makeOne(self):
         return Adapter()
-
-    def test_implements(self):
-
-        adapter = self._makeOne()
-        assert_that(adapter, validly_provides(interfaces.IRelStorageAdapter))

--- a/src/relstorage/adapters/replica.py
+++ b/src/relstorage/adapters/replica.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 import os
 import time
 
-from perfmetrics import metricmethod
 from zope.interface import implementer
 
+from .._compat import metricmethod
 from .interfaces import IReplicaSelector
 
 

--- a/src/relstorage/adapters/stats.py
+++ b/src/relstorage/adapters/stats.py
@@ -16,11 +16,14 @@
 
 import abc
 
+from zope.interface import implementer
+
 from .._compat import ABC
+from .interfaces import IDBStats
 from ._util import query_property
 from ._util import DatabaseHelpersMixin
 
-
+@implementer(IDBStats)
 class AbstractStats(DatabaseHelpersMixin, ABC):
 
     def __init__(self, connmanager, keep_history):

--- a/src/relstorage/adapters/tests/test_adapter.py
+++ b/src/relstorage/adapters/tests/test_adapter.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 from hamcrest import assert_that
 from nti.testing.matchers import validly_provides
+from zope.schema.interfaces import IObject
 
 from relstorage.tests import TestCase
 
@@ -31,6 +32,30 @@ class AdapterTestBase(TestCase):
     def test_implements(self):
         adapter = self._makeOne()
         assert_that(adapter, validly_provides(interfaces.IRelStorageAdapter))
+
+        # pylint:disable=no-value-for-parameter
+        for attr_name, field in interfaces.IRelStorageAdapter.namesAndDescriptions():
+            if IObject.providedBy(field):
+                attr_iface = field.schema
+                attr_val = getattr(adapter, attr_name)
+                # Look for functions/methods in its dict and check for __wrapped__ attributes;
+                # these come from perfmetrics @metricmethod and that breaks validation.
+                for k in dir(type(attr_val)):
+                    if k not in attr_iface:
+                        continue
+                    v = getattr(attr_val, k)
+                    if callable(v) and hasattr(v, '__wrapped__'):
+                        orig = v.__wrapped__
+                        if hasattr(orig, '__get__'):
+                            # Must be Python 3, we got the raw unbound function, we need to bind it
+                            # and add the self parameter.
+                            orig = orig.__get__(type(attr_val), attr_val)
+                        try:
+                            setattr(attr_val, k, orig)
+                        except AttributeError:
+                            # Must be slotted.
+                            continue
+                assert_that(attr_val, validly_provides(attr_iface))
 
 
 def test_suite():

--- a/src/relstorage/adapters/tests/test_adapter.py
+++ b/src/relstorage/adapters/tests/test_adapter.py
@@ -16,10 +16,24 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from ..adapter import MySQLAdapter as Adapter
-from ...tests import test_adapter
+from hamcrest import assert_that
+from nti.testing.matchers import validly_provides
 
-class TestAdapter(test_adapter.AdapterTestBase):
+from relstorage.tests import TestCase
+
+from .. import interfaces
+
+class AdapterTestBase(TestCase):
 
     def _makeOne(self):
-        return Adapter()
+        raise NotImplementedError
+
+    def test_implements(self):
+        adapter = self._makeOne()
+        assert_that(adapter, validly_provides(interfaces.IRelStorageAdapter))
+
+
+def test_suite():
+    # Nothing to see here.
+    import unittest
+    return unittest.TestSuite()

--- a/src/relstorage/storage/__init__.py
+++ b/src/relstorage/storage/__init__.py
@@ -25,7 +25,6 @@ import weakref
 
 import ZODB.interfaces
 
-from perfmetrics import metricmethod
 
 from ZODB import ConflictResolution
 
@@ -48,6 +47,7 @@ from ..adapters.connections import LoadConnection
 from ..adapters.connections import StoreConnection
 from ..adapters.connections import ClosedConnection
 from .._compat import clear_frames
+from .._compat import metricmethod
 from .._util import int64_to_8bytes
 from .._util import bytes8_to_int64
 

--- a/src/relstorage/storage/load.py
+++ b/src/relstorage/storage/load.py
@@ -21,9 +21,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from perfmetrics import Metric
-from perfmetrics import metricmethod
-
 from ZODB.POSException import POSKeyError
 
 from ZODB.utils import p64 as int64_to_8bytes
@@ -31,6 +28,8 @@ from ZODB.utils import u64 as bytes8_to_int64
 from ZODB.utils import maxtid
 
 from relstorage.cache.interfaces import CacheConsistencyError
+from .._compat import metricmethod
+from .._compat import metricmethod_sampled
 from .util import storage_method
 from .util import stale_aware
 
@@ -106,7 +105,7 @@ class Loader(object):
 
     @stale_aware
     @storage_method
-    @Metric(method=True, rate=0.1)
+    @metricmethod_sampled
     def load(self, oid, version=''):
         # pylint:disable=unused-argument
         oid_int = bytes8_to_int64(oid)
@@ -152,7 +151,7 @@ class Loader(object):
 
     # This is *NOT* stale aware for some reason (why?)
     @storage_method
-    @Metric(method=True, rate=0.1)
+    @metricmethod_sampled
     def loadSerial(self, oid, serial):
         """Load a specific revision of an object"""
         oid_int = bytes8_to_int64(oid)
@@ -192,7 +191,7 @@ class Loader(object):
 
     @stale_aware
     @storage_method
-    @Metric(method=True, rate=0.1)
+    @metricmethod_sampled
     def loadBefore(self, oid, tid):
         """
         Return the most recent revision of oid before tid committed.

--- a/src/relstorage/storage/pack.py
+++ b/src/relstorage/storage/pack.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 
 import time
 
-from perfmetrics import metricmethod
 from persistent.timestamp import TimeStamp
 
 from ZODB.utils import p64 as int64_to_8bytes
@@ -31,6 +30,7 @@ from ZODB.utils import u64 as bytes8_to_int64
 
 from relstorage._compat import OID_SET_TYPE
 from relstorage._compat import MAX_TID
+from relstorage._compat import metricmethod
 from .util import writable_storage_method
 
 logger = __import__('logging').getLogger(__name__)

--- a/src/relstorage/storage/store.py
+++ b/src/relstorage/storage/store.py
@@ -21,9 +21,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from perfmetrics import Metric
-from perfmetrics import metricmethod
 
+from .._compat import metricmethod
+from .._compat import metricmethod_sampled
 from .util import writable_storage_method
 from .util import phase_dependent_aborts_early
 
@@ -35,7 +35,7 @@ class Storer(object):
 
     @phase_dependent_aborts_early
     @writable_storage_method
-    @Metric(method=True, rate=0.1)
+    @metricmethod_sampled
     def store(self, tpc_phase, oid, previous_tid, data, version, transaction):
         # Called by Connection.commit(), after tpc_begin has been called.
         assert not version, "Versions aren't supported"

--- a/src/relstorage/storage/util.py
+++ b/src/relstorage/storage/util.py
@@ -128,7 +128,7 @@ class stale_aware(object):
         # and because we want to limit the overhead of additional
         # function calls (these methods are commonly used),
         # we derive a new class whose __call__ is exactly the bound
-        # method's __call__.  For this reason, its important to access
+        # method's __call__.  For this reason, it's important to access
         # these methods only once and cache them (which is what copy_storage_methods
         # does).
 
@@ -146,6 +146,7 @@ class stale_aware(object):
         # stale_aware_class = functools.wraps(bound)(stale_aware_class)
         return stale_aware_class(bound)
 
+
 def _make_phase_dependent(storage, method):
     aborts_early = getattr(method, 'aborts_early', False)
     if aborts_early:
@@ -160,12 +161,14 @@ def _make_phase_dependent(storage, method):
         @functools.wraps(method)
         def state(*args, **kwargs):
             return method(storage._tpc_phase, *args, **kwargs)
+    state.__wrapped__ = method # For Py2
     return state
 
 def _make_cannot_write(method):
     @functools.wraps(method)
     def read_only(*args, **kwargs):
         raise ReadOnlyError
+    read_only.__wrapped__ = method
     return read_only
 
 def copy_storage_methods(storage, delegate):

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -1,6 +1,7 @@
 """relstorage.tests package"""
 
 import abc
+import contextlib
 import os
 import unittest
 
@@ -19,6 +20,10 @@ except ImportError: # Python 2
     import mock
 
 mock = mock
+
+@contextlib.contextmanager
+def _fakeSubTest(*_args, **_kwargs):
+    yield
 
 class TestCase(unittest.TestCase):
     """
@@ -41,6 +46,13 @@ class TestCase(unittest.TestCase):
         'assertRegex',
         None
     ) or getattr(unittest.TestCase, 'assertRegexpMatches')
+
+    # 2.7 doesn't have subtest.
+    subTest = getattr(
+        unittest.TestCase,
+        'subTest',
+        None
+    ) or _fakeSubTest
 
     def setUp(self):
         super(TestCase, self).setUp()

--- a/src/relstorage/tests/locking.py
+++ b/src/relstorage/tests/locking.py
@@ -174,7 +174,9 @@ class TestLocking(TestCase):
         from relstorage.adapters.interfaces import UnableToLockRowsToModifyError
 
         # Use a very small commit lock timeout.
-        commit_lock_timeout = 0.1
+        # TODO: We can actually go much smaller for PostgreSQL, just not MySQL.
+        # We need a way to identify that.
+        commit_lock_timeout = 1
         duration_blocking = self.__do_check_error_with_conflicting_concurrent_read_current(
             UnableToLockRowsToModifyError,
             commit_lock_timeout=commit_lock_timeout,

--- a/src/relstorage/tests/locking.py
+++ b/src/relstorage/tests/locking.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""
+Test mixin dealing with different locking scenarios.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import threading
+import time
+
+from functools import partial
+from functools import update_wrapper
+
+import transaction
+
+from ZODB.DB import DB
+from ZODB.Connection import TransactionMetaData
+
+from ZODB.tests.MinPO import MinPO
+
+from . import TestCase
+
+def WithAndWithoutInterleaving(func):
+    # Expands a test case into two tests, for those that can run
+    # both with the stored procs and without it.
+    def _interleaved(self):
+        adapter = self._storage._adapter
+        if not adapter.DEFAULT_LOCK_OBJECTS_AND_DETECT_CONFLICTS_INTERLEAVABLE:
+            adapter.force_lock_objects_and_detect_conflicts_interleavable = True
+
+        func(self)
+        if 'force_lock_objects_and_detect_conflicts_interleavable' in adapter.__dict__:
+            del adapter.force_lock_objects_and_detect_conflicts_interleavable
+
+    def _stored_proc(self):
+        adapter = self._storage._adapter
+        if adapter.DEFAULT_LOCK_OBJECTS_AND_DETECT_CONFLICTS_INTERLEAVABLE:
+            # No stored proc version.
+            return
+        func(self)
+
+    def test(self):
+        # Sadly using self.subTest()
+        # causes zope-testrunner to lose the exception reports.
+        _stored_proc(self)
+        _interleaved(self)
+
+    return update_wrapper(test, func)
+
+
+class TestLocking(TestCase):
+    # pylint:disable=abstract-method
+
+    _storage = None
+
+    def make_storage(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+    def __store_two_for_read_current_error(self):
+        db = self._closing(DB(self._storage))
+        conn = db.open()
+        root = conn.root()
+        root['object1'] = MinPO('object1')
+        root['object2'] = MinPO('object2')
+        transaction.commit()
+
+        obj1_oid = root['object1']._p_oid
+        obj2_oid = root['object2']._p_oid
+        obj1_tid = root['object1']._p_serial
+        assert obj1_tid == root['object2']._p_serial
+
+        conn.close()
+        # We can't close the DB, that will close the storage that we
+        # still need.
+        return obj1_oid, obj2_oid, obj1_tid
+
+    def __read_current_and_lock(self, storage, read_current_oid, lock_oid, tid):
+        tx = TransactionMetaData()
+        storage.tpc_begin(tx)
+        storage.checkCurrentSerialInTransaction(read_current_oid, tid, tx)
+        storage.store(lock_oid, tid, b'bad pickle2', '', tx)
+        storage.tpc_vote(tx)
+        return tx
+
+    def __do_check_error_with_conflicting_concurrent_read_current(
+            self,
+            exception_in_b,
+            commit_lock_timeout=None,
+            storageA=None,
+            storageB=None,
+            identical_pattern_a_b=False,
+            copy_interleave=('A', 'B'),
+            abort=True
+    ):
+        root_adapter = self._storage._adapter
+        if commit_lock_timeout:
+            root_adapter.locker.commit_lock_timeout = commit_lock_timeout
+            self._storage._options.commit_lock_timeout = commit_lock_timeout
+
+        if storageA is None:
+            storageA = self._closing(self._storage.new_instance())
+        if storageB is None:
+            storageB = self._closing(self._storage.new_instance())
+
+        should_ileave = root_adapter.force_lock_objects_and_detect_conflicts_interleavable
+        if 'A' in copy_interleave:
+            storageA._adapter.force_lock_objects_and_detect_conflicts_interleavable = should_ileave
+        if 'B' in copy_interleave:
+            storageB._adapter.force_lock_objects_and_detect_conflicts_interleavable = should_ileave
+
+        # First, store the two objects in an accessible location.
+        obj1_oid, obj2_oid, tid = self.__store_two_for_read_current_error()
+
+        # Now transaction A readCurrent 1 and modify 2
+        # up through the vote phase
+        txa = self.__read_current_and_lock(storageA, obj1_oid, obj2_oid, tid)
+
+        if not identical_pattern_a_b:
+            # Second transaction does exactly the opposite, and blocks,
+            # raising an exception (usually)
+            lock_b = partial(
+                self.__read_current_and_lock,
+                storageB,
+                obj2_oid,
+                obj1_oid,
+                tid
+            )
+        else:
+            lock_b = partial(
+                self.__read_current_and_lock,
+                storageB,
+                obj1_oid,
+                obj2_oid,
+                tid
+            )
+
+        txb = None
+        before = time.time()
+        if exception_in_b:
+            with self.assertRaises(exception_in_b):
+                lock_b()
+        else:
+            txb = lock_b()
+        after = time.time()
+        duration_blocking = after - before
+
+        if abort:
+            storageA.tpc_abort(txa)
+            storageB.tpc_abort(txb)
+
+        return duration_blocking
+
+    @WithAndWithoutInterleaving
+    def checkTL_ConflictingReadCurrent(self):
+        # Given two objects 1 and 2, if transaction A does readCurrent(1)
+        # and modifies 2 up through the voting phase, and then transaction
+        # B does precisely the same thing,
+        # we get an error after ``commit_lock_timeout``  and not a deadlock.
+        from relstorage.adapters.interfaces import UnableToLockRowsToModifyError
+
+        # Use a very small commit lock timeout.
+        commit_lock_timeout = 0.1
+        duration_blocking = self.__do_check_error_with_conflicting_concurrent_read_current(
+            UnableToLockRowsToModifyError,
+            commit_lock_timeout=commit_lock_timeout,
+            identical_pattern_a_b=True
+        )
+
+        self.assertLessEqual(duration_blocking, commit_lock_timeout * 3)
+
+    @WithAndWithoutInterleaving
+    def checkTL_OverlappedReadCurrent_SharedLocksFirst(self):
+        # Starting with two objects 1 and 2, if transaction A modifies 1 and
+        # does readCurrent of 2, up through the voting phase, and transaction B does
+        # exactly the opposite, transaction B is immediately killed with a read conflict
+        # error. (We use the same two objects instead of a new object in transaction B to prove
+        # shared locks are taken first.)
+        from relstorage.adapters.interfaces import UnableToLockRowsToReadCurrentError
+        commit_lock_timeout = 1
+        duration_blocking = self.__do_check_error_with_conflicting_concurrent_read_current(
+            UnableToLockRowsToReadCurrentError,
+            commit_lock_timeout=commit_lock_timeout,
+        )
+        # The NOWAIT lock should be very quick to fire.
+        if self._storage._adapter.locker.supports_row_lock_nowait:
+            self.assertLessEqual(duration_blocking, commit_lock_timeout)
+        else:
+            # Sigh. Old MySQL. Very slow. This takes around 4.5s to run both iterations.
+            self.assertLessEqual(duration_blocking, commit_lock_timeout * 2.5)
+
+
+    def __lock_rows_being_modified_only(self, storage, cursor, _current_oids, _share_blocks):
+        # A monkey-patch for Locker.lock_current_objects to only take the exclusive
+        # locks.
+        storage._adapter.locker._lock_rows_being_modified(cursor)
+
+    def __assert_small_blocking_duration(self, storage, duration_blocking):
+        # Even though we just went with the default commit_lock_timeout,
+        # which is large...
+        self.assertGreaterEqual(storage._options.commit_lock_timeout, 10)
+        # ...the lock violation happened very quickly
+        self.assertLessEqual(duration_blocking, 3)
+
+    def checkTL_InterleavedConflictingReadCurrent(self):
+        # Similar to
+        # ``checkTL_ConflictingReadCurrent``
+        # except that we pause the process immediately after txA takes
+        # its exclusive locks to let txB take *its* exclusive locks.
+        # Then txB can go for the shared locks, which will block if
+        # we're not in ``NOWAIT`` mode for shared locks. This tests
+        # that we don't block, we report a retryable error. Note that
+        # we don't adjust the commit_lock_timeout; it doesn't apply.
+        #
+        # If we're using a stored procedure, this test will break
+        # because we won't be able to force the interleaving, so we make it
+        # use the old version.
+
+        from relstorage.adapters.interfaces import UnableToLockRowsToReadCurrentError
+        storageA = self._closing(self._storage.new_instance())
+        # This turns off stored procs and lets us control that phase.
+        storageA._adapter.force_lock_objects_and_detect_conflicts_interleavable = True
+
+        storageA._adapter.locker.lock_current_objects = partial(
+            self.__lock_rows_being_modified_only,
+            storageA)
+
+        duration_blocking = self.__do_check_error_with_conflicting_concurrent_read_current(
+            UnableToLockRowsToReadCurrentError,
+            storageA=storageA,
+            copy_interleave=()
+        )
+
+        self.__assert_small_blocking_duration(storageA, duration_blocking)
+
+    def checkTL_InterleavedConflictingReadCurrentDeadlock(self):
+        # Like
+        # ``checkTL_InterleavedConflictingReadCurrent``
+        # except that we interleave both txA and txB: txA takes modify
+        # lock, txB takes modify lock, txA attempts shared lock, txB
+        # attempts shared lock. This results in a database deadlock, which is reported as
+        # a retryable error.
+        #
+        # We have to use a thread to do the shared locks because it blocks.
+        from relstorage.adapters.interfaces import UnableToLockRowsToReadCurrentError
+
+        storageA = self._closing(self._storage.new_instance())
+        storageB = self._closing(self._storage.new_instance())
+        storageA.last_error = storageB.last_error = None
+
+        storageA._adapter.locker.lock_current_objects = partial(
+            self.__lock_rows_being_modified_only,
+            storageA)
+        storageB._adapter.locker.lock_current_objects = partial(
+            self.__lock_rows_being_modified_only,
+            storageB)
+
+        # This turns off stored procs for locking.
+        storageA._adapter.force_lock_readCurrent_for_share_blocking = True
+        storageB._adapter.force_lock_readCurrent_for_share_blocking = True
+
+        # This won't actually block, we haven't conflicted yet.
+        self.__do_check_error_with_conflicting_concurrent_read_current(
+            None,
+            storageA=storageA,
+            storageB=storageB,
+            abort=False
+        )
+
+        cond = threading.Condition()
+        cond.acquire()
+        def lock_shared(storage, notify=True):
+            cursor = storage._store_connection.cursor
+            read_current_oids = storage._tpc_phase.required_tids.keys()
+            if notify:
+                cond.acquire(5)
+                cond.notifyAll()
+                cond.release()
+
+            try:
+                storage._adapter.locker._lock_readCurrent_oids_for_share(
+                    cursor,
+                    read_current_oids,
+                    True
+                )
+            except UnableToLockRowsToReadCurrentError as ex:
+                storage.last_error = ex
+            finally:
+                if notify:
+                    cond.acquire(5)
+                    cond.notifyAll()
+                    cond.release()
+
+
+        thread_locking_a = threading.Thread(
+            target=lock_shared,
+            args=(storageA,)
+        )
+        thread_locking_a.start()
+
+        # wait for the background thread to get ready to lock.
+        cond.acquire(5)
+        cond.wait(5)
+        cond.release()
+
+        begin = time.time()
+
+        lock_shared(storageB, notify=False)
+
+        # Wait for background thread to finish.
+        cond.acquire(5)
+        cond.wait(5)
+        cond.release()
+
+        end = time.time()
+        duration_blocking = end - begin
+
+        # Now, one or the other storage got killed by the deadlock
+        # detector, but not both. Which one depends on the database.
+        # PostgreSQL likes to kill the foreground thread (storageB),
+        # MySQL likes to kill the background thread (storageA)
+        self.assertTrue(storageA.last_error or storageB.last_error)
+        self.assertFalse(storageA.last_error and storageB.last_error)
+
+        last_error = storageA.last_error or storageB.last_error
+
+        self.assertIn('deadlock', str(last_error).lower())
+
+        self.__assert_small_blocking_duration(storageA, duration_blocking)
+        self.__assert_small_blocking_duration(storageB, duration_blocking)

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -26,7 +26,6 @@ import tempfile
 import time
 import threading
 import unittest
-from functools import partial
 
 import transaction
 from persistent import Persistent
@@ -62,6 +61,7 @@ from . import mock
 from . import TestCase
 from . import StorageCreatingMixin
 from .persistentcache import PersistentCacheStorageTests
+from .locking import TestLocking
 from .test_zodbconvert import FSZODBConvertTests
 
 class RelStorageTestBase(StorageCreatingMixin,
@@ -245,6 +245,7 @@ class GenericRelStorageTests(
         UsesThreadsOnASingleStorageMixin,
         RelStorageTestBase,
         PersistentCacheStorageTests,
+        TestLocking,
         BasicStorage.BasicStorage,
         PackableStorage.PackableStorage,
         Synchronization.SynchronizedStorage,
@@ -1337,225 +1338,6 @@ class GenericRelStorageTests(
 
         storage1.close()
         storage2.close()
-
-    def __store_two_for_read_current_error(self):
-        db = self._closing(DB(self._storage))
-        conn = db.open()
-        root = conn.root()
-        root['object1'] = MinPO('object1')
-        root['object2'] = MinPO('object2')
-        transaction.commit()
-
-        obj1_oid = root['object1']._p_oid
-        obj2_oid = root['object2']._p_oid
-        obj1_tid = root['object1']._p_serial
-        assert obj1_tid == root['object2']._p_serial
-
-        conn.close()
-        # We can't close the DB, that will close the storage that we
-        # still need.
-        return obj1_oid, obj2_oid, obj1_tid
-
-    def __read_current_and_lock(self, storage, read_current_oid, lock_oid, tid):
-        tx = TransactionMetaData()
-        storage.tpc_begin(tx)
-        storage.checkCurrentSerialInTransaction(read_current_oid, tid, tx)
-        storage.store(lock_oid, tid, b'bad pickle2', '', tx)
-        storage.tpc_vote(tx)
-        return tx
-
-    def __do_check_error_with_conflicting_concurrent_read_current(
-            self,
-            exception_in_b,
-            commit_lock_timeout=None,
-            storageA=None,
-            storageB=None
-    ):
-        if commit_lock_timeout:
-            self._storage._adapter.locker.commit_lock_timeout = commit_lock_timeout
-            self._storage._options.commit_lock_timeout = commit_lock_timeout
-
-        if storageA is None:
-            storageA = self._closing(self._storage.new_instance())
-        if storageB is None:
-            storageB = self._closing(self._storage.new_instance())
-        # First, store the two objects in an accessible location.
-        obj1_oid, obj2_oid, tid = self.__store_two_for_read_current_error()
-
-        # Now transaction A readCurrent 2 and modify 1
-        # up through the vote phase
-        self.__read_current_and_lock(storageA, obj1_oid, obj2_oid, tid)
-
-        # Second transaction does exactly the opposite, and blocks,
-        # raising an exception (usually)
-        lock_b = partial(
-            self.__read_current_and_lock,
-            storageB,
-            obj2_oid,
-            obj1_oid,
-            tid
-        )
-        before = time.time()
-        if exception_in_b:
-            with self.assertRaises(exception_in_b):
-                lock_b()
-        else:
-            lock_b()
-        after = time.time()
-        duration_blocking = after - before
-
-        return duration_blocking
-
-    def checkProperErrorWithConflictingConcurrentReadCurrent(self):
-        # Given two objects 1 and 2, if transaction A does readCurrent(1)
-        # and modifies 2 up through the voting phase, and then transaction
-        # B does readCurrent(2) and modifies 1 up through the voting phase,
-        # we get an error after ``commit_lock_timeout``  and not a deadlock.
-        from relstorage.adapters.interfaces import UnableToLockRowsToModifyError
-
-        # Use a very small commit lock timeout.
-        commit_lock_timeout = 1
-        duration_blocking = self.__do_check_error_with_conflicting_concurrent_read_current(
-            UnableToLockRowsToModifyError,
-            commit_lock_timeout=commit_lock_timeout
-        )
-
-        self.assertLessEqual(duration_blocking, commit_lock_timeout * 3)
-
-    def __lock_rows_being_modified_only(self, storage, cursor, _current_oids, _share_blocks):
-        # A monkey-patch for Locker.lock_current_objects to only take the exclusive
-        # locks.
-        storage._adapter.locker._lock_rows_being_modified(cursor)
-
-    def __assert_small_blocking_duration(self, storage, duration_blocking):
-        # Even though we just went with the default commit_lock_timeout,
-        # which is large...
-        self.assertGreaterEqual(storage._options.commit_lock_timeout, 10)
-        # ...the lock violation happened very quickly
-        self.assertLessEqual(duration_blocking, 3)
-
-    def checkProperErrorWithInterleavedConflictingConcurrentReadCurrent(self):
-        # Similar to
-        # ``checkProperErrorWithConflictingConcurrentReadCurrent``
-        # except that we pause the process immediately after txA takes
-        # its exclusive locks to let txB take *its* exclusive locks.
-        # Then txB can go for the shared locks, which will block if
-        # we're not in ``NOWAIT`` mode for shared locks. This tests
-        # that we don't block, we report a retryable error. Note that
-        # we don't adjust the commit_lock_timeout; it doesn't apply.
-        #
-        # If we're using a stored procedure, this test will break
-        # because we won't be able to force the interleaving, so we make it
-        # use the old version.
-
-        from relstorage.adapters.interfaces import UnableToLockRowsToReadCurrentError
-        storageA = self._closing(self._storage.new_instance())
-        storageA._adapter.force_lock_objects_and_detect_conflicts_interleavable = True
-
-        storageA._adapter.locker.lock_current_objects = partial(
-            self.__lock_rows_being_modified_only,
-            storageA)
-
-        duration_blocking = self.__do_check_error_with_conflicting_concurrent_read_current(
-            UnableToLockRowsToReadCurrentError,
-            storageA=storageA
-        )
-
-        self.__assert_small_blocking_duration(storageA, duration_blocking)
-
-    def checkProperErrorWithInterleavedConflictingConcurrentReadCurrentDeadlock(self):
-        # Like
-        # ``checkProperErrorWithInterleavedConflictingConcurrentReadCurrent``
-        # except that we interleave both txA and txB: txA takes modify
-        # lock, txB takes modify lock, txA attempts shared lock, txB
-        # attempts shared lock. This results in a database deadlock, which is reported as
-        # a retryable error.
-        #
-        # We have to use a thread to do the shared locks because it blocks.
-        from relstorage.adapters.interfaces import UnableToLockRowsToReadCurrentError
-
-        storageA = self._closing(self._storage.new_instance())
-        storageB = self._closing(self._storage.new_instance())
-        storageA.last_error = storageB.last_error = None
-
-        storageA._adapter.locker.lock_current_objects = partial(
-            self.__lock_rows_being_modified_only,
-            storageA)
-        storageB._adapter.locker.lock_current_objects = partial(
-            self.__lock_rows_being_modified_only,
-            storageB)
-
-        storageA._adapter.force_lock_readCurrent_for_share_blocking = True
-        storageB._adapter.force_lock_readCurrent_for_share_blocking = True
-
-        # This won't actually block, we haven't conflicted yet.
-        self.__do_check_error_with_conflicting_concurrent_read_current(
-            None,
-            storageA=storageA,
-            storageB=storageB
-        )
-
-        cond = threading.Condition()
-        cond.acquire()
-        def lock_shared(storage, notify=True):
-            cursor = storage._store_connection.cursor
-            read_current_oids = storage._tpc_phase.required_tids.keys()
-            if notify:
-                cond.acquire()
-                cond.notifyAll()
-                cond.release()
-
-            try:
-                storage._adapter.locker._lock_readCurrent_oids_for_share(
-                    cursor,
-                    read_current_oids,
-                    True
-                )
-            except UnableToLockRowsToReadCurrentError as ex:
-                storage.last_error = ex
-            finally:
-                if notify:
-                    cond.acquire()
-                    cond.notifyAll()
-                    cond.release()
-
-
-        thread_locking_a = threading.Thread(
-            target=lock_shared,
-            args=(storageA,)
-        )
-        thread_locking_a.start()
-
-        # wait for the background thread to get ready to lock.
-        cond.acquire()
-        cond.wait()
-        cond.release()
-
-        begin = time.time()
-
-        lock_shared(storageB, notify=False)
-
-        # Wait for background thread to finish.
-        cond.acquire()
-        cond.wait()
-        cond.release()
-
-        end = time.time()
-        duration_blocking = end - begin
-
-        # Now, one or the other storage got killed by the deadlock
-        # detector, but not both. Which one depends on the database.
-        # PostgreSQL likes to kill the foreground thread (storageB),
-        # MySQL likes to kill the background thread (storageA)
-        self.assertTrue(storageA.last_error or storageB.last_error)
-        self.assertFalse(storageA.last_error and storageB.last_error)
-
-        last_error = storageA.last_error or storageB.last_error
-
-        self.assertIn('deadlock', str(last_error).lower())
-
-        self.__assert_small_blocking_duration(storageA, duration_blocking)
-        self.__assert_small_blocking_duration(storageB, duration_blocking)
 
 class AbstractRSZodbConvertTests(StorageCreatingMixin,
                                  FSZODBConvertTests,


### PR DESCRIPTION
Addresses part of #310. New tests were added for this. There's a [big documentation block](https://github.com/zodb/relstorage/blob/c40bd9bd957aca29f55819679662250d33eba66f/src/relstorage/adapters/interfaces.py#L1296) explaining why I believe this is a correct change.

Make MySQL clean up its locks by rolling back the transaction in the stored proc. This fixes #313. I didn't specifically test this, but I will.

Part of the process involved some changes to interfaces and I wanted to have that unit tested, which lead down a rabbit hole of being able to verify signatures for `metricsmethod`, so there's some noise.