### PR TITLE
More safety for reading/writing the persistent cache.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@
 3.0a8 (unreleased)
 ==================
 
+- Improve the safety of the persistent local cache in high-concurrency
+  environments using older versions of SQLite. Perform a quick
+  integrity check on startup and refuse to use the cache files if they
+  are reported corrupt.
+
 - Switch the order in which object locks are taken: try shared locks
   first and only then attempt exclusive locks. Shared locks do not
   have to block, so a quick lock timeout here means that a

--- a/src/relstorage/cache/storage_cache.py
+++ b/src/relstorage/cache/storage_cache.py
@@ -902,6 +902,9 @@ class _PersistentRowFilter(object):
         self.delta_after1 = delta_type()
         self.polled_invalid_oids = OID_SET_TYPE()
 
+    def __str__(self):
+        return "<PersistentRowFilter>"
+
     def __call__(self, checkpoints, row_iter):
         if not checkpoints:
             # Nothing to do except put in correct format, no transforms are possible.

--- a/src/relstorage/cache/tests/test_local_client.py
+++ b/src/relstorage/cache/tests/test_local_client.py
@@ -387,7 +387,12 @@ class LocalClientOIDTests(AbstractStateCacheTests):
 
         # But it gets removed based on having seen it and knowing
         # it's there.
-        c.write_to_sqlite(conn)
+        conn._rs_has_closed = True # Prevent closing by the write method
+        try:
+            c.write_to_sqlite(conn)
+        finally:
+            conn._rs_has_closed = False
+
         self.assertEmpty(db.oid_to_tid)
 
     def test_ctor(self):

--- a/src/relstorage/cache/tests/test_local_database.py
+++ b/src/relstorage/cache/tests/test_local_database.py
@@ -20,7 +20,6 @@ class UpdateTests(TestCase):
     # UPSERTS or multi-column updates aren't available.
 
     USE_UPSERT = False
-    USE_PAREN_UPDATE = False
 
     def setUp(self):
         self.options = MockOptionsWithMemoryDB()
@@ -38,7 +37,6 @@ class UpdateTests(TestCase):
         return Database.from_connection(
             self.connection,
             use_upsert=self.USE_UPSERT,
-            use_paren_update=self.USE_PAREN_UPDATE
         )
 
     def test_set_checkpoints(self):
@@ -185,12 +183,6 @@ class UpdateTests(TestCase):
                  "Requires upserts")
 class UpsertUpdateTests(UpdateTests):
     USE_UPSERT = True
-
-
-@unittest.skipIf(not local_database.SUPPORTS_PAREN_UPDATE,
-                 "Requires paren updates")
-class ParenUpdateTests(UpdateTests):
-    USE_PAREN_UPDATE = True
 
 
 class MultiConnectionTests(TestCase):


### PR DESCRIPTION
Perform a quick verify before trying to read from it.

Use a simpler query for updates on old versions of SQLite; the old more complicated 'correlated-subqueries-with-cte' might have been a bit buggy.

Also some logging and speed improvements.

Note that appveyor PRs will be broken for 3.6 and 3.7 because mysqlclient released a new version and hasn't put out updated Windows wheels yet. I'm hoping they do soon so I'm not disabling or adjusting it yet.