### PR TITLE
Ensure we don't try to take exclusive locks if we already identified …

### DIFF
--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -142,7 +142,8 @@ class AbstractLocker(DatabaseHelpersMixin,
         )
 
     @metricmethod
-    def lock_current_objects(self, cursor, read_current_oid_ints, shared_locks_block):
+    def lock_current_objects(self, cursor, read_current_oid_ints, shared_locks_block,
+                             after_lock_share=lambda: None):
         # We need to be sure to take the locks in a deterministic
         # order; the easiest way to do that is to order them by OID.
         # But we have two separate sets of OIDs we need to lock: the
@@ -187,6 +188,7 @@ class AbstractLocker(DatabaseHelpersMixin,
         if read_current_oid_ints:
             self._lock_readCurrent_oids_for_share(cursor, read_current_oid_ints,
                                                   shared_locks_block)
+            after_lock_share()
 
 
         # Then lock the rows we need exclusive access to.

--- a/src/relstorage/adapters/mysql/adapter.py
+++ b/src/relstorage/adapters/mysql/adapter.py
@@ -312,7 +312,7 @@ class MySQLAdapter(AbstractAdapter):
 
         # There's always a useless last result, the result of the stored procedure itself.
         proc_result = multi_results.pop()
-        assert proc_result == ()
+        assert not proc_result, proc_result
 
         # With read_current_oids, the proc returns one or two results,
         # either of which may be empty. If it returns one, that's

--- a/src/relstorage/adapters/mysql/adapter.py
+++ b/src/relstorage/adapters/mysql/adapter.py
@@ -332,12 +332,12 @@ class MySQLAdapter(AbstractAdapter):
                 assert read_conflicts[0][-1] is None, multi_results
                 conflicts = read_conflicts
             else:
-                assert len(multi_results) == 2
-                assert not multi_results[0]
+                assert len(multi_results) == 2, multi_results
+                assert not multi_results[0], multi_results
                 conflicts = multi_results[1]
         else:
             # Only conflicts were checked and returned.
-            assert len(multi_results) == 1
+            assert len(multi_results) == 1, multi_results
             conflicts = multi_results[0]
 
         return conflicts

--- a/src/relstorage/adapters/mysql/drivers/__init__.py
+++ b/src/relstorage/adapters/mysql/drivers/__init__.py
@@ -91,12 +91,17 @@ class AbstractMySQLDriver(AbstractModuleDriver):
         returns multiple results, and they don't all use the standard
         way to retrieve them, so use this.
 
-        Returns a list of lists of rows: [ [[row in first], ...],
-        [[row in second], ...], ... ]
+        Returns a list of lists of rows, one list for each result set::
+
+            [
+              [(row in first),  ...],
+              [(row in second), ...],
+              ...
+            ]
 
         Note that, because 'CALL' potentially returns multiple result
         sets, there is potentially at least one extra database round
-        trip involved when we call `cursor.nextset()`. If the
+        trip involved when we call ``cursor.nextset()``. If the
         procedure being called is very short or returns only a single
         very small result, this may add substantial overhead.
 
@@ -104,7 +109,7 @@ class AbstractMySQLDriver(AbstractModuleDriver):
         (mysqlclient) 1.4.2 using libmysqlclient.21.so (from mysql8)
         or libmysqlclient.20 (mysql 5.7), all the drivers use the
         flags from the server to detect that there are no more results
-        and turn nextset() into a simple flag check. So if the CALL
+        and turn ``nextset()`` into a simple flag check. So if the CALL
         only returns one result set (because the CALLed object doesn't
         return any of its own, i.e., it only has side-effects) there
         shouldn't be any penalty.

--- a/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
@@ -186,6 +186,8 @@ class PyMySQLConnectorDriver(AbstractMySQLDriver):
                 multi_results.append(resultset.fetchall())
             except self.driver_module.InterfaceError:
                 # This gets raised on the empty set at the end, for some reason.
+                # Ensure we put one there to be like the others
+                multi_results.append(())
                 break
         return multi_results
 

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -29,12 +29,10 @@ class PostgreSQLLocker(AbstractLocker):
 
     def _on_store_opened_set_row_lock_timeout(self, cursor, restart=False):
         # This only lasts beyond the current transaction if it
-        # commits.
-        if not restart:
-            # We never change our lock timeout setting; the lock_and_choose_tid
-            # functions have it as part of their function definition, and
-            # we have NOWAIT for when we need a 0 timeout.
-            self._set_row_lock_timeout(cursor, self.commit_lock_timeout)
+        # commits. If we have a rollback, then our effect is lost. Thus,
+        # we can't be sure if it actually has taken effect, so even on a restart
+        # we need to perform it.
+        self._set_row_lock_timeout(cursor, self.commit_lock_timeout)
 
     def _set_row_lock_timeout(self, cursor, timeout):
         # This will rollback if the transaction rolls back,

--- a/src/relstorage/storage/interfaces.py
+++ b/src/relstorage/storage/interfaces.py
@@ -28,6 +28,7 @@ from zope.interface import Interface
 
 from transaction.interfaces import TransientError
 from ZODB.POSException import StorageTransactionError
+from ZODB.POSException import ReadConflictError
 
 # pylint:disable=inherit-non-class,no-self-argument,no-method-argument
 # pylint:disable=too-many-ancestors
@@ -60,3 +61,9 @@ class IStaleAware(Interface):
 
         :return: Another `IStaleAware`.
         """
+
+class VoteReadConflictError(ReadConflictError):
+    """
+    A read conflict (from Connection.readCurrent()) that wasn't
+    detected until the storage voted.
+    """

--- a/src/relstorage/storage/tpc/vote.py
+++ b/src/relstorage/storage/tpc/vote.py
@@ -22,14 +22,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from ZODB.POSException import ConflictError
-from ZODB.POSException import ReadConflictError
 from ZODB.POSException import StorageTransactionError
 from ZODB.utils import p64 as int64_to_8bytes
 from ZODB.utils import u64 as bytes8_to_int64
 
+from ..interfaces import VoteReadConflictError
+
 from . import LOCK_EARLY
 from . import AbstractTPCState
 from .finish import Finish
+
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -261,7 +263,7 @@ class AbstractVote(AbstractTPCState):
                 # A readCurrent entry. Did it conflict?
                 expect_tid_int = required_tids[oid_int]
                 if committed_tid_int != expect_tid_int:
-                    raise ReadConflictError(
+                    raise VoteReadConflictError(
                         oid=int64_to_8bytes(oid_int),
                         serials=(int64_to_8bytes(committed_tid_int),
                                  int64_to_8bytes(expect_tid_int)))


### PR DESCRIPTION
…a shared lock ReadConflict.

And raise a place-specific exception for that. Turns out our implementation of readCurrent() immediately makes a database call and raises ReadConflictError right there if it finds a change. So the test was getting a false positive for awhile.

Fixes #310.