### PR TITLE
Add experimental option to make the gevent driver stop switching (som…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
 script:
 # coverage slows PyPy down from 2minutes to 12+.
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --rcfile=.pylintrc relstorage -f parseable -r n; fi
-  - python -m gevent.monkey `which zope-testrunner` --test-path=src --color -vvv -t BlobCache --layer gevent
+  - RELSTORAGE_GEVENT_NO_SWITCH_WHEN_LOCKED=true python -m gevent.monkey `which zope-testrunner` --test-path=src --color -vvv -t BlobCache --layer gevent
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then python $RS_TEST_CMD; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run $RS_TEST_CMD; fi
 after_success:

--- a/src/relstorage/adapters/mysql/drivers/_mysqldb_gevent.py
+++ b/src/relstorage/adapters/mysql/drivers/_mysqldb_gevent.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2009 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from gevent import socket
+from gevent import get_hub
+from gevent import sleep as gevent_sleep
+wait = socket.wait # pylint:disable=no-member
+
+
+# pylint:disable=wrong-import-position,no-name-in-module,import-error
+from MySQLdb.connections import Connection as BaseConnection
+from MySQLdb.cursors import SSCursor as BaseCursor
+
+
+class Cursor(BaseCursor):
+    # Internally this calls mysql_use_result(). The source
+    # code for that function has this comment: "There
+    # shouldn't be much processing per row because mysql
+    # server shouldn't have to wait for the client (and
+    # will not wait more than 30 sec/packet)." Empirically
+    # that doesn't seem to be true.
+
+    def _noop(self):
+        """Does nothing."""
+
+    sleep = staticmethod(gevent_sleep)
+
+    def _fetch_row(self, size=1):
+        # Somewhat surprisingly, if we just wait on read,
+        # we end up blocking forever. This is because of the buffers
+        # maintained inside the MySQL library: we might already have the
+        # rows that we need buffered.
+
+        # Blocking on write is pointless: by definition
+        # we're here to read results so we can always
+        # write. That just forces us to take a trip around
+        # the event loop for no good reason.
+
+        # Therefore, our best option to periodically yield
+        # is to explicitly invoke gevent.sleep(). Without
+        # any time given, it will yield to other ready
+        # greenlets; only sometimes will it force a trip
+        # around the event loop.
+
+        # TODO: But if we're actually going to need to read data,
+        # we want to wait until it arrives. Can we get that info
+        # somehow? Can we develop a heuristic?
+
+        # Somewhat amusingly, the low-levels of libmysqlclient use
+        # kevent to do waiting: mysql_real_query -> cli_read_query_result ->
+        # my_net_read -> net_read_packet -> via_read_buff -> vio_read
+        # -> vio_io_wait -> kevent
+        self.sleep()
+        return BaseCursor._fetch_row(self, size)
+
+    def fetchall(self):
+        result = []
+        fetch = self.fetchmany
+        while 1:
+            # Even if self.rowcount is 0 we must still call
+            # or we get the connection out of sync.
+            rows = fetch()
+            if not rows:
+                break
+            result.extend(rows)
+            if self.rownumber == self.rowcount:
+                # Avoid a useless extra trip at the end.
+                break
+        return result
+
+    def __iter__(self):
+        fetch = self.fetchmany
+        batch = fetch()
+        while batch:
+            for row in batch:
+                yield row
+            batch = fetch()
+
+    def enter_critical_phase_until_transaction_end(self):
+        # May make multiple enters.
+        if 'sleep' not in self.__dict__:
+            self.sleep = self._noop
+            self.connection.enter_critical_phase_until_transaction_end(self)
+
+    def exit_critical_phase_at_transaction_end(self):
+        del self.sleep
+
+
+# Prior to mysqlclient 1.4, there was a 'waiter' Connection
+# argument that could be used to do this, but it was removed.
+# So we implement it ourself.
+class Connection(BaseConnection):
+    default_cursor = Cursor
+    gevent_read_watcher = None
+    gevent_write_watcher = None
+    gevent_hub = None
+    cursor_in_critical = None
+
+    # pylint:disable=method-hidden
+
+    def enter_critical_phase_until_transaction_end(self, cursor):
+        assert self.cursor_in_critical is None
+        self.cursor_in_critical = cursor
+        # The queries need to go through and allow switches without blocking.
+        # Otherwise we can deadlock.
+        self.commit = self._critical_commit
+        self.rollback = self._critical_rollback
+
+    def exit_critical_phase_at_transaction_end(self):
+        del self.rollback
+        del self.commit
+        cur = self.cursor_in_critical
+        del self.cursor_in_critical
+        cur.exit_critical_phase_at_transaction_end()
+        assert self.cursor_in_critical is None
+
+    def check_watchers(self):
+        # We can be used from more than one thread in a sequential
+        # fashion.
+        hub = get_hub()
+        if hub is not self.gevent_hub:
+            self.__close_watchers()
+
+            fileno = self.fileno()
+            hub = self.gevent_hub = get_hub()
+            self.gevent_read_watcher = hub.loop.io(fileno, 1)
+            self.gevent_write_watcher = hub.loop.io(fileno, 2)
+
+    def __close_watchers(self):
+        if self.gevent_read_watcher is not None:
+            self.gevent_read_watcher.close()
+            self.gevent_write_watcher.close()
+            self.gevent_hub = None
+
+    def query(self, query):
+        # From the mysqlclient implementation:
+        # "Since _mysql releases the GIL while querying, we need immutable buffer"
+        if isinstance(query, bytearray):
+            query = bytes(query)
+
+        self.check_watchers()
+
+        wait(self.gevent_write_watcher, hub=self.gevent_hub)
+        self.send_query(query)
+
+        wait(self.gevent_read_watcher, hub=self.gevent_hub)
+        self.read_query_result()
+
+    # The default implementations of 'rollback' and
+    # 'commit' use only C API functions `mysql_rollback`
+    # and `mysql_commit`; it doesn't touch any internal
+    # state. Those in turn simply call
+    # `mysql_real_query("rollback")` and
+    # `mysql_real_query("commit")`. That's a synchronous
+    # function that waits for the result to be ready. We
+    # don't want to block like that (commit could
+    # potentially take some time.)
+
+    def _critical_rollback(self):
+        try:
+            BaseConnection.rollback(self)
+        finally:
+            self.exit_critical_phase_at_transaction_end()
+
+    def rollback(self):
+        self.query('rollback')
+
+    def _critical_commit(self):
+        try:
+            BaseConnection.commit(self)
+        finally:
+            self.exit_critical_phase_at_transaction_end()
+
+    def commit(self):
+        self.query('commit')
+
+    def close(self):
+        self.__close_watchers()
+        BaseConnection.close(self)
+
+    def __delattr__(self, name):
+        # BaseConnection has a delattr that forbids
+        # all deletion. Not helpful.
+        if name in self.__dict__:
+            self.__dict__.pop(name)
+        else:
+            BaseConnection.__delattr__(self, name)

--- a/src/relstorage/cache/storage_cache.py
+++ b/src/relstorage/cache/storage_cache.py
@@ -892,6 +892,7 @@ class StorageCache(object):
             change_to,
             delta_size
         )
+        # XXX: Make this atomic.
         old_value = self.cache.get_checkpoints()
         if old_value and old_value != expect:
             log.debug(

--- a/src/relstorage/storage/tpc/vote.py
+++ b/src/relstorage/storage/tpc/vote.py
@@ -273,9 +273,9 @@ class AbstractVote(AbstractTPCState):
             oid = int64_to_8bytes(oid_int)
             prev_tid = int64_to_8bytes(committed_tid_int)
             serial = int64_to_8bytes(tid_this_txn_saw_int)
-
             resolved_state = tryToResolveConflict(oid, prev_tid, serial,
                                                   state_from_this_txn, committed_state)
+
             if resolved_state is None:
                 # unresolvable; kill the whole transaction
                 raise ConflictError(

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -151,6 +151,8 @@ class _Availability(object):
         adapter = adapter_maker.make_adapter(options, db_name)
         try:
             adapter.connmanager.open_and_call(self.__check_db_access_cb)
+        except (TypeError, AttributeError):
+            raise
         except Exception as e:  # pylint:disable=broad-except
             self._available = False
             self._msg = "%s: Failed to connect: %r %s" % (self._msg, type(e), e)


### PR DESCRIPTION
…e) once it takes locks.

This defaults to off, but can be turned on with env var `RELSTORAGE_GEVENT_NO_SWITCH_WHEN_LOCKED` or by setting an attribute on the driver class.

This should actually return the level of switching (during the cricital phase) back to what it was before #321.