### PR TITLE
Workaround bug in MySQL that caused TIDs to suddenly jump.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Nothing changed yet.
 
+- Due to a bug in MySQL (incorrectly rounding the 'minute' value of a
+  timestamp up), TIDs generated in the last half second of a minute
+  would suddenly jump ahead by 4,266,903,756 integers (a full minute).
 
 3.0a8 (2019-08-13)
 ==================

--- a/src/relstorage/adapters/mysql/procs/make_tid_for_epoch.sql
+++ b/src/relstorage/adapters/mysql/procs/make_tid_for_epoch.sql
@@ -18,9 +18,20 @@ BEGIN
    */
 
   DECLARE ts TIMESTAMP;
-  DECLARE year, month, day, hour, minute INT;
+  DECLARE year, month, day, hour INT;
+  -- MySQL 5.7 and probably 8 has a bug: it wants to get the minute
+  -- value from a timestamp by *rounding* it following its usual
+  -- rules, instead of truncating it (truncation is correct: it
+  -- represents "the number of whole minutes past the hour, 0 - 59").
+  -- So instead of getting 29 for XX:29:59, we get 30. Needless to say
+  -- that messes up computations that happen in the last 0.5 seconds
+  -- of the minute (they jump ahead by 60 seconds, aka 4,294,967,296
+  -- in the generated int). Therefore we have to manually adjust for
+  -- this. (No combination of datatypes for the field, EXTRACT() vs
+  -- MINUTE() made a difference.)
+  DECLARE tm_min INT;
   DECLARE a1, a, b BIGINT;
-  DECLARE b1, second REAL;
+  DECLARE b1, tm_sec REAL;
 
   SET ts = FROM_UNIXTIME(unix_ts) + 0.0;
 
@@ -28,17 +39,21 @@ BEGIN
       month  = EXTRACT(MONTH from ts),
       day    = EXTRACT(DAY from ts),
       hour   = EXTRACT(hour from ts),
-      minute = EXTRACT(minute from ts),
-      second = unix_ts % 60;
+      tm_min = EXTRACT(MINUTE from ts),
+      tm_sec = MOD(unix_ts, 60.0);
 
+  IF tm_sec >= 59.5 THEN
+    SET tm_min = tm_min - 1;
+  END IF;
 
   SET a1 = (((year - 1900) * 12 + month - 1) * 31 + day - 1);
-  SET a = (a1 * 24 + hour) *60 + minute;
+  SET a = (a1 * 24 + hour) *60 + tm_min;
   -- This is a magic constant; see _timestamp.c
-  SET b1 = second / 1.3969838619232178e-08;
+  SET b1 = tm_sec / 1.3969838619232178e-08;
   -- CAST(AS INTEGER) rounds, but the C and Python TimeStamp
   -- simply truncate, and we must match them.
   SET b = TRUNCATE(b1, 0);
 
   SET tid_64 = (a << 32) + b;
+
 END;


### PR DESCRIPTION
MySQL incorrectly rounds the 'minute' value of a timestamp up when the
'seconds' value is greater than 59.5, but the spec says minute should
be whole minutes, not rounded. Thus, TIDs generated in the last half
second of a minute would suddenly jump ahead by 4,266,903,756
integers (a full minute).