### PR TITLE
Checkpoint for issue 311

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,36 @@
   commits on MySQL. This could lead to ``tpc_vote`` blocking longer
   than desired. See :issue:`331`.
 
+- Fix ``undo`` to purge the objects whose transaction was revoked from
+  the cache.
+
+- History-free databases remove objects from the local cache when they
+  are replaced by a newer revision. This helps the cache size stay
+  in check. This partly rolls back the conflict resolution
+  enhancements in 3.0a7 when the updater and the conflicting updater
+  are in the same process. That will be improved.
+
+- Make new connections automatically stay up-to-date with the most
+  recent polling that's been done. In environments with a large amount
+  of write activity, this makes them much more useful immediately,
+  without having to perform large polls. Older connections, though,
+  continue to need large polls if they're used again for the first
+  time in a long time. That is expected to be improved. For now,
+  reducing the ZODB connection pool size, or enabling its idle
+  timeout, may help.
+
+- Only one connection at a time for a given database will ever perform
+  a "Using new checkpoints" poll query, which can be very expensive
+  given large cache-delta-size values. Other connections will use the
+  results of this query and make minor updates as needed.
+
+- Stop storing the current checkpoints in memcache, if one is
+  configured. Memcache integration has been discouraged since the
+  introduction of RelStorage persistent caches, which are much
+  improved in 3.0. Having checkpoint data come from there is
+  inconsistent with several of the new features that let the local
+  cache be smarter and more efficient.
+
 3.0a8 (2019-08-13)
 ==================
 

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -101,6 +101,12 @@ else:
 
 metricmethod_sampled = Metric(method=True, rate=0.1)
 
+if 'zope-testrunner' in sys.argv[0] and MAC:
+    # If we're running under the testrunner,
+    # don't apply the metricmethod stuff. It makes
+    # backtraces ugly and makes stepping in the
+    # debugger annoying.
+    metricmethod = metricmethod_sampled = lambda f: f
 
 try:
     from abc import ABC

--- a/src/relstorage/adapters/connections.py
+++ b/src/relstorage/adapters/connections.py
@@ -206,7 +206,7 @@ class AbstractManagedConnection(object):
             set this to false.
         """
         fresh_connection = False
-        if not self:
+        if self.connection is None or self._cursor is None:
             # We're closed or disconnected. Start a new connection entirely.
             self.drop()
             self._open_connection()

--- a/src/relstorage/adapters/connections.py
+++ b/src/relstorage/adapters/connections.py
@@ -240,9 +240,10 @@ class AbstractManagedConnection(object):
             self.connmanager.rollback_and_close(conn, cursor)
 
     def __repr__(self):
-        return "<%s at 0x%x conn=%r cur=%r>" % (
+        return "<%s at 0x%x active=%s, conn=%r cur=%r>" % (
             self.__class__.__name__,
             id(self),
+            self.active,
             self.connection,
             self._cursor
         )

--- a/src/relstorage/adapters/connmanager.py
+++ b/src/relstorage/adapters/connmanager.py
@@ -213,6 +213,8 @@ class AbstractConnectionManager(object):
     def rollback_quietly(self, conn, cursor):
         return self.__rollback(conn, cursor, True, None)
 
+    rollback_store_quietly = rollback_quietly
+
     def commit(self, conn, cursor=None, force=False):
         if self._may_need_commit(conn) or force:
             self._do_commit(conn, cursor)

--- a/src/relstorage/adapters/packundo.py
+++ b/src/relstorage/adapters/packundo.py
@@ -330,9 +330,13 @@ class HistoryPreservingPackUndo(PackUndo):
             raise UndoError("Transaction not found or packed")
 
         # Rule: we can undo an object if the object's state in the
-        # transaction to undo matches the object's current state.
-        # If any object in the transaction does not fit that rule,
-        # refuse to undo.
+        # transaction to undo matches the object's current state. If
+        # any object in the transaction does not fit that rule, refuse
+        # to undo. In theory this means arbitrary transactions can be
+        # undone (because we actually match the state); in practice it
+        # means that it must be the most recent transaction those
+        # objects were involved in.
+
         # (Note that this prevents conflict-resolving undo as described
         # by ZODB.tests.ConflictResolution.ConflictResolvingTransUndoStorage.
         # Do people need that? If so, we can probably support it, but it

--- a/src/relstorage/adapters/poller.py
+++ b/src/relstorage/adapters/poller.py
@@ -154,6 +154,10 @@ class Poller(object):
         """
         See ``IPoller``.
         """
+        if after_tid == last_tid:
+            # small optimization in case we're asked for the same.
+            # there can be no changes where change > X and change <= X
+            return ()
         params = {'min_tid': after_tid, 'max_tid': last_tid}
         self._list_changes_range_query.execute(cursor, params)
         # Return the cursor: let it be its own iterable. This could be a

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -29,10 +29,10 @@ class PostgreSQLLocker(AbstractLocker):
 
     def _on_store_opened_set_row_lock_timeout(self, cursor, restart=False):
         # This only lasts beyond the current transaction if it
-        # commits. If we have a rollback, then our effect is lost. Thus,
-        # we can't be sure if it actually has taken effect, so even on a restart
-        # we need to perform it.
+        # commits. If we have a rollback, then our effect is lost.
+        # Luckily, right here is a fine time to commit.
         self._set_row_lock_timeout(cursor, self.commit_lock_timeout)
+        cursor.connection.commit()
 
     def _set_row_lock_timeout(self, cursor, timeout):
         # This will rollback if the transaction rolls back,

--- a/src/relstorage/adapters/tests/test_connections.py
+++ b/src/relstorage/adapters/tests/test_connections.py
@@ -120,7 +120,7 @@ class TestConnection(TestConnectionCommon):
             if not fresh:
                 raise manager.connmanager.driver.disconnected_exceptions[0]
 
-        manager.call(f, True)
+        manager.call(f, can_reconnect=True)
 
         self.assertEqual(called, [False, True])
 

--- a/src/relstorage/cache/_statecache_wrappers.py
+++ b/src/relstorage/cache/_statecache_wrappers.py
@@ -99,6 +99,10 @@ class MultiStateCache(object):
         self.l.set_all_for_tid(tid_int, state_oid_iter)
         self.g.set_all_for_tid(tid_int, state_oid_iter)
 
+    def invalidate_all(self, oids):
+        self.l.invalidate_all(oids)
+        self.g.invalidate_all(oids)
+
     # Unlike everything else, checkpoints are on the global
     # client first and then the local one.
 

--- a/src/relstorage/cache/interfaces.py
+++ b/src/relstorage/cache/interfaces.py
@@ -144,6 +144,11 @@ class IStateCache(Interface):
         Clear cached data.
         """
 
+    def invalidate_all(oids):
+        """
+        Remove all cached data for each of the oid integers in *oids*.
+        """
+
     ##
     # Methods that are here to assist with tracing.
     ##

--- a/src/relstorage/cache/interfaces.py
+++ b/src/relstorage/cache/interfaces.py
@@ -121,6 +121,22 @@ class IStateCache(Interface):
     def close():
         """
         Release external resources held by this object.
+
+        This object may not be usable after this.
+        """
+
+    def new_instance():
+        """
+        Create an object sharing the same underlying data, but
+        capable of operating independently, such as in a new thread.
+
+        This may return the same object.
+        """
+
+    def release():
+        """
+        Like close, but intended to be called on child objects
+        created for MVCC using a ``new_instance`` method.
         """
 
     def flush_all():

--- a/src/relstorage/cache/local_client.py
+++ b/src/relstorage/cache/local_client.py
@@ -314,6 +314,11 @@ class LocalClient(object):
     def close(self):
         pass
 
+    release = close
+
+    def new_instance(self):
+        return self
+
     def items(self):
         return self.__bucket.items()
 

--- a/src/relstorage/cache/memcache_client.py
+++ b/src/relstorage/cache/memcache_client.py
@@ -103,6 +103,12 @@ class MemcacheStateCache(object):
     def __delitem__(self, oid_tid):
         self.client.delete(self.__oid_tid_to_key(*oid_tid))
 
+    def invalidate_all(self, oids): # pylint:disable=unused-argument
+        """
+        Implemented by flushing everything.
+        """
+        self.flush_all()
+
     def _set_multi(self, keys_and_values):
         formatted = {
             '%s:state:%d:%d' % (self.prefix, tid, oid): (p64(actual_tid) + (state or b''))

--- a/src/relstorage/cache/storage_cache.py
+++ b/src/relstorage/cache/storage_cache.py
@@ -1735,7 +1735,7 @@ class _TemporaryStorage(object):
             # only on MySQL. Not sure why.
             raise KeyError("No oid %d stored in %s" % (
                 oid_int,
-                dict(self._queue_contents)
+                list(self._queue_contents)
             ))
         return self._read_temp_state(startpos, endpos)
 

--- a/src/relstorage/cache/storage_cache.py
+++ b/src/relstorage/cache/storage_cache.py
@@ -123,7 +123,12 @@ class _PollingState(_InvalidationMixin):
     delta_map_type = OID_TID_MAP_TYPE
 
     def __init__(self):
-        self._lock = threading.Lock()
+        # Use this lock when we're doing normal poll updates
+        # or need to read consistent metadata.
+        self._da0_lock = threading.Lock()
+        # acquire this lock when we intend to replace
+        # checkpoints and delta maps.
+        self._checkpoint_lock = threading.Lock()
         self.checkpoints = None
         self.current_tid = None
         self.delta_after0 = self.delta_map_type()
@@ -136,7 +141,8 @@ class _PollingState(_InvalidationMixin):
         pass
 
     def close(self):
-        self._lock = None
+        self._da0_lock = None
+        self._checkpoint_lock = None
         self.checkpoints = None
         self.current_tid = None
         self.delta_after0 = None
@@ -184,7 +190,7 @@ class _PollingState(_InvalidationMixin):
 
         :return: A tuple ``(checkpoints, tid, da0, da1)``
         """
-        with self._lock:
+        with self._da0_lock:
             return (
                 self.checkpoints,
                 self.current_tid,
@@ -192,18 +198,289 @@ class _PollingState(_InvalidationMixin):
                 self.delta_map_type(self.delta_after1)
             )
 
-    def after_poll(self, cache): # type: StorageCache -> None
+    def after_normal_poll(self, cache): # type: StorageCache -> None
         """
-        The *cache* calls this after it has completed all actions in its
-        `StorageCache.after_poll` method to update the global polling state.
+        Update the current TID and the ``delta_after0`` map when we
+        have incorporated changes from the database (this implies that
+        the cache's checkpoints match ours). This should be
+        the common case.
+
+        The *cache* calls this after it has completed all actions in
+        its `StorageCache.after_poll` method to update the global
+        polling state.
         """
+        with self._da0_lock:
+            if self.current_tid is not None:
+                if cache.current_tid == self.current_tid:
+                    # No changes, fairly common, at least in tests,
+                    # since each implicit transaction polls twice, I think.
+                    return
+                if cache.current_tid < self.current_tid:
+                    # No new information, for some reason they're behind us. Possibly
+                    # the poll look a long time, and transactions completed and polled
+                    # during that interval. Or possibly threads ran "out of order" on the
+                    # Python side:
+                    #
+                    # 1. Thread A polls to get TID1
+                    # 2. Somewhere the database changes to TID 2; this
+                    #    could even be happening as Thread A is running.
+                    # 3. Thread B polls to get TID2
+                    # 4. Thread B calls our after_poll.
+                    # 5. Thread A calls our after_poll.
+                    #
+                    # TODO: Signal that they should restart the load and poll again?
+                    # If the database is changing fast enough, they'll never catch up.
+                    print("Cache instance", cache, "with tid", cache.current_tid,
+                          "is behind", self.current_tid)
+                    logger.debug("Cache instance %s with polled TID %s is behind current tid %s",
+                                 cache, cache.current_tid, self.current_tid)
+                    return
+
+            self.current_tid = cache.current_tid
+            self.delta_after0.update(cache.delta_after0)
+
+    def after_tpc_finish(self, tid, oids):
+        """
+        Record the objects as being changed in the transaction, if needed.
+
+        Does *not* increment the current TID; that only happens on polls
+        because we're not the authoritative source for current TIDs.
+        """
+        with self._da0_lock:
+            get = self.delta_after0.get
+            da0 = self.delta_after0
+            for oid in oids:
+                if get(oid, 0) < tid:
+                    da0[oid] = tid
+
+    def __poll_into(self, cache, cursor, cp0, cp1, new_tid_int, da0, da1):
+        da0_size = len(da0)
+        da1_size = len(da1)
+        # poller.list_changes(low, high) provides an iterator of
+        # (oid, tid) where tid > cp1 and tid <= new_tid_int. It is guaranteed
+        # that each oid shows up only once.
+        change_list = cache.adapter.poller.list_changes(
+            cursor, cp1, new_tid_int)
+
+        # Put the changes in new_delta_after*.
+        # Let the backing cache know about this (this is only done
+        # for tracing).
+        updating_0 = cache.cache.updating_delta_map(da0)
+        updating_1 = cache.cache.updating_delta_map(da1)
+        try:
+            for oid_int, tid_int in change_list:
+                if tid_int <= cp1 or tid_int > new_tid_int:
+                    cache._reset(
+                        "Requested changes %d < tid <= %d "
+                        "but change %d for OID %d out of range." % (
+                            cp1, new_tid_int,
+                            tid_int, oid_int
+                        )
+                    )
+
+                d = updating_0 if tid_int > cp0 else updating_1
+                d[oid_int] = tid_int
+        except:
+            consume(change_list)
+            raise
+
+        # Everybody has a home (we didn't get duplicate entries
+        # or multiple entries for the same OID with different TID)
+        # This is guaranteed by the IPoller interface, so we don't waste
+        # time tracking it here.
+
+        # Usually, delta_after0 will be quite small. If it's large, it means
+        # we had an open connection sitting (idle?) for a long time since its
+        # last poll.
+        logger.debug(
+            "%s from cp1 %s to current_tid %s of sizes %d (0) and %d (1)",
+            "Built new deltas" if not da0_size else "Updated existing deltas",
+            cp1, new_tid_int,
+            len(da0) - da0_size, len(da1) - da1_size
+        )
+
+    def __return_empty_delta(self, cp, new_tid_int, current_tid, checkpoints):
+        logger.debug(
+            "Trying to set new checkpoints %s with tid %s "
+            "but current tid is already %s and checkpoints %s",
+            cp, new_tid_int, current_tid, checkpoints
+        )
+        return (new_tid_int, new_tid_int), self.delta_map_type(), self.delta_map_type()
+
+    def __poll_and_update(self, cache, cursor, new_checkpoints, current_tid, new_tid_int, da0, da1):
+        # current_tid, da0, da1 are snapshots.
+        # Poll into a pair of new maps so we can do this without holding a lock.
+        # This should be a very small, usual poll, so we don't hold a poll lock either.
+        new_da0 = self.delta_map_type()
+        new_da1 = self.delta_map_type()
+
+        self.__poll_into(cache, cursor, new_checkpoints[0], current_tid, new_tid_int,
+                         new_da0, new_da1)
+
+        assert not new_da1 # Nothing to add after the tid we just polled, that's impossible.
+        original_new_da0 = self.delta_map_type(new_da0) # we mutate it.
+
+        with self._da0_lock:
+            # Ok, time has marched on.
+            # We just need to merge anything we've got, letting other updates take precedence.
+            # (Our data might be old)
+            self.current_tid = max(new_tid_int, self.current_tid)
+            new_da0.update(self.delta_after0)
+            self.delta_after0 = new_da0
+
+            if self.current_tid <= new_tid_int:
+                # Cool, everything is good to return.
+                return (
+                    new_checkpoints,
+                    self.delta_map_type(self.delta_after0),
+                    self.delta_map_type(self.delta_after1)
+                )
+
+            # The current data could contain info that's out of range for us,
+            # so we can't use it.
+            # But we can update our older snapshot and return that.
+            original_new_da0.update(da0)
+            return new_checkpoints, da0, da1
+
+
+    def after_poll_with_changed_checkpoints(self, cache, cursor, new_checkpoints, new_tid_int):
+        """
+        Called when the cache has detected that it needs to change its
+        checkpoints and rebuild its delta maps.
+
+        This returns the checkpoints, delta0 map, and delta1 map.
+
+        There are three cases to handle:
+
+        - The ``new_checkpoints`` are both equal to the ``new_tid_int``.
+
+          This means the instance saw checkpoints from the future.
+
+          We simply return empty maps and hope it catches up and polls again soon.
+
+        - Our current checkpoints match the desired new checkpoints.
+
+          If *new_tid_int* is greater or equal to our current tid,
+          we list the changes necessary to catch up to ``new_tid_int``, incorporate them
+          locally, and return the desired data.
+
+          If new_tid_int is in the past, meaning other local connections have committed
+          or polled more recently,  then we treat it like the very first case:
+          give it empty maps and hope it catches up soon.
+
+        - Our current checkpoints do *not* match the desired new checkpoints.
+
+          If the desired checkpoints are in the past, the caller is very out of date.
+          We treat this like the very first case, where ``new_checkpoints`` are both
+          equal to the ``new_tid_int``.
+
+          All that's left is for them to be in the future. We execute a poll query
+          and build new maps. A lock is held while this is done so that it only has to
+          happen once.
+        """
+        # pylint:disable=too-many-return-statements
+        cp0, cp1 = new_checkpoints
+        if cp0 == cp1 == new_tid_int:
+            return self.__return_empty_delta(new_checkpoints, new_tid_int, "<unknown>", "<unknown>")
+
+        lock = [self._da0_lock]
+        def release():
+            if lock[0] is not None:
+                lock[0].release()
+                lock[0] = None
+
+        lock[0].acquire()
+        checkpoints = self.checkpoints
+        current_tid = self.current_tid
+        try:
+            if checkpoints == new_checkpoints:
+                if new_tid_int < current_tid:
+                    # We just return empty maps and hope it catches up.
+                    # Note that we must return fake checkpoints so that it knows
+                    # to try checking again.
+
+                    return self.__return_empty_delta(new_checkpoints,
+                                                     new_tid_int, current_tid, checkpoints)
+
+                if new_tid_int == current_tid:
+                    # Cool, just need to snapshot the data.
+                    return (
+                        checkpoints,
+                        self.delta_map_type(self.delta_after0),
+                        self.delta_map_type(self.delta_after1)
+                    )
+
+                # It's greater. We need to catch up. But only between our
+                # tid and the new one.
+                # Discard the lock; it's not necessary to hold while we poll and update
+                # if we do it carefully.
+                da0 = self.delta_map_type(self.delta_after0)
+                da1 = self.delta_map_type(self.delta_after1)
+                release()
+
+                return self.__poll_and_update(cache, cursor, new_checkpoints,
+                                              current_tid, new_tid_int, da0, da1)
+
+            # Ok, they weren't equal. They could be in the future (best) or the past (boo!)
+            # though I'm not quite sure how they could be in the past.
+            if checkpoints is None or cp0 > checkpoints[0]:
+                release()
+
+                new_delta_after0 = self.delta_map_type()
+                new_delta_after1 = self.delta_map_type()
+                with self._checkpoint_lock:
+                    # If someone already changed the checkpoints,
+                    # do this whole thing again, don't poll.
+                    need_poll = True
+                    with self._da0_lock:
+                        if checkpoints is not self.checkpoints:
+                            need_poll = False
+                    if not need_poll:
+                        return self.after_poll_with_changed_checkpoints(
+                            cache, cursor,
+                            new_checkpoints, new_tid_int)
+
+                    self.__poll_into(cache, cursor, cp0, cp1, new_tid_int,
+                                     new_delta_after0, new_delta_after1)
+
+                # Could our TID have crept past the checkpoint already?
+                # If so, we need to do the extra poll and bring us back to current status;
+                # but that can't be visible to this caller; we have to snapshot these things
+                # anyway, so do it now. Because we're going to replace the maps,
+                # we HAVE to do this with the lock. It should be very small query.
+                da0 = self.delta_map_type(new_delta_after0)
+                da1 = self.delta_map_type(new_delta_after1)
+                with self._da0_lock:
+                    current_tid = self.current_tid or 0
+                    if current_tid > new_tid_int:
+                        self.__poll_into(cache, cursor, cp0, new_tid_int, current_tid,
+                                         new_delta_after0, new_delta_after1)
+
+                    # Merge, being careful not to go backwards.
+                    self.checkpoints = checkpoints = max(new_checkpoints,
+                                                         self.checkpoints or (0, 0))
+                    self.current_tid = max(new_tid_int, current_tid)
+                    # No, this isn't right, we'll be growing forever if we do this.
+                    # new_delta_after0.update(self.delta_after0)
+                    # new_delta_after1.update(self.delta_after1)
+
+                    self.delta_after0 = new_delta_after0
+                    self.delta_after1 = new_delta_after1
+
+                return checkpoints, da0, da1
+
+            # We asked for checkpoints in the past. Bad cache!
+            return self.__return_empty_delta(new_checkpoints, new_tid_int, current_tid, checkpoints)
+        finally:
+            release()
+
 
     def invalidate(self, oid_int, tid_int):
-        with self._lock:
+        with self._da0_lock:
             self._invalidate(oid_int, tid_int)
 
     def invalidate_all(self, oids):
-        with self._lock:
+        with self._da0_lock:
             self._invalidate_all(oids)
 
 @interface.implementer(IPersistentCache)
@@ -629,6 +906,18 @@ class StorageCache(_InvalidationMixin):
             tid2 = cp1
 
         preferred_key = (oid_int, cp0)
+        # This object will get cached under this key. Until the checkpoints change,
+        # we'll be able to find it. After checkpoints have shifted forward
+        # once (cp1 becomes cp0), if we request it again we'll find it under the secondary
+        # key and the cache will automatically move it forward to this key, where, when
+        # the checkpoints change once again, we'll still be able to find it. If we don't
+        # request it after that first checkpoint change, though, then on the second one
+        # we won't be able to find it, even if it's still in memory and we'll go through
+        # this all again.
+        #
+        # TODO: Why don't we just use a specific distinguished TID
+        # such as 0 for older objects so we don't have to go through
+        # this?
 
         # Query the cache. Query multiple keys simultaneously to
         # minimize latency. The client is responsible for moving
@@ -720,6 +1009,7 @@ class StorageCache(_InvalidationMixin):
         tid_int = u64(tid)
 
         self.cache.set_all_for_tid(tid_int, self.temp_objects)
+        self.polling_state.after_tpc_finish(tid_int, self.temp_objects.stored_oids)
         # We only do this because cache_trace_analysis uses us
         # in ways that aren't quite accurate. We'd prefer to call clear_temp()
         # at this point.
@@ -807,6 +1097,10 @@ class StorageCache(_InvalidationMixin):
             # checkpoint0 is in a future that this instance can't yet
             # see. Ignore the checkpoint change for now, continue
             # with our own.
+            logger.debug(
+                "Global checkpoints (%s) are ahead of polled tid %s",
+                global_checkpoints, new_tid_int
+            )
             global_checkpoints = self.checkpoints
             if not self.checkpoints:
                 # How nice, this was our first poll, but
@@ -816,12 +1110,44 @@ class StorageCache(_InvalidationMixin):
                 # cache is now stale).
                 global_checkpoints = (new_tid_int, new_tid_int)
 
-        # We want to keep the current checkpoints for speed, but we
-        # have to replace them (to avoid consistency violations)
-        # if certain conditions happen (like emptying the ZODB Connection cache
-        # which happens when `changes` is None).
-        if (global_checkpoints == self.checkpoints # In sync with the world
-                # Poller didn't give up, and there was data in the database
+        # We want to keep the current delta maps for speed, but we
+        # have to replace them (to avoid consistency violations) if
+        # certain conditions happen. These conditions are all
+        # external, in the database. If `changes` is None, and hence
+        # we return None, the entire ZODB Connection cache will be
+        # dropped.
+
+        if (
+                # We are in sync with the world. If we don't use the
+                # same checkpoints as everyone else, then when `load`
+                # has a cache miss and needs to store an older object
+                # that hasn't changed recently enough to be in the
+                # delta maps, it uses OID:CP0 as the key. So if we
+                # don't update our checkpoints when everyone else
+                # does, we'll be writing two separate sets of keys for
+                # older objects that haven't changed, bloating the
+                # cache. This shouldn't actually be a consistency
+                # issue, just a bloat issue. (Further, it is also this
+                # changing of checkpoints that signals us to drop our
+                # delta maps, which may or may not actually be full.)
+                #
+                # TODO: That's probably not a good use of cache. We
+                # should use a distinguished key such as -1 for these
+                # "frozen" objects.
+                #
+                # This also happens when the global checkpoints are in
+                # the future. We'll throw away our delta maps *now*,
+                # making it unlikely we'll get any cache hits. Next time we poll,
+                # hopefully we'll be caught up enough to use the global maps
+                # and will rebuild our maps then.
+                #
+                # TODO: Do we really need to throw them away now? Why can't we
+                # keep them for the transaction we're about to have?
+                global_checkpoints == self.checkpoints
+                # Poller didn't give up (which it would if this was
+                # our first poll; it won't list the entire database),
+                # and there was data in the database (if there's no
+                # data, new_tid_int will be 0).
                 and changes is not None
                 # The storage had polled before and gotten a response
                 # other than 0, meaning no data in the database.
@@ -839,31 +1165,40 @@ class StorageCache(_InvalidationMixin):
                 # (possibly we switched to a replica that's out of date)
                 # and the user configured `revert-when-stale` to be on.
                 # In that case, `changes` should also be None and we really shouldn't
-                # get here.
-                and new_tid_int >= my_prev_tid_int):
-
+                # get here. Note that it could be the same if there were no
+                # changes.
+                and new_tid_int >= my_prev_tid_int
+        ):
             # All the conditions for keeping the checkpoints were met,
             # so just update self.delta_after0 and self.current_tid.
-            try:
-                changes = self.__poll_update_delta0_from_changes(changes)
-            except:
-                consume(changes)
-                raise
+            changes = self.__poll_update_delta0_from_changes(changes)
+            self.polling_state.after_normal_poll(self)
         else:
             log.debug(
-                "Using new checkpoints: %s. Current cp: %s. "
-                "Too many changes? %s. prev_tid_int: %s. my_prev_tid_int: %s. "
-                "new_tid_int: %s",
+                "Replacing checkpoint deltas. {p=%s, current_cp=%s, "
+                "prev_tid_int=%s, my_prev_tid_int=%s, new_tid_int=%s} "
+                "(Cause: Suggested checkpoint change? %s. Too many changes? %s. "
+                "Had polled before? %s. Polls match? %s. "
+                "Transaction went back? %s)",
                 global_checkpoints, self.checkpoints,
-                changes is None, prev_tid_int, my_prev_tid_int,
-                new_tid_int
+                prev_tid_int, my_prev_tid_int, new_tid_int,
+                global_checkpoints != self.checkpoints, changes is None,
+                not bool(prev_tid_int), (my_prev_tid_int or -2) < (prev_tid_int or -1),
+                new_tid_int < my_prev_tid_int
             )
+            # If the TID went backwards, and we didn't have `revert-when-stale` on,
+            # we *must* get a ``changes`` of None in order to signal dropping
+            # the connection cache. (A backwards TID causes the poller to raise an
+            # exception without that setting.)
+            assert new_tid_int >= my_prev_tid_int or changes is None
             if changes is not None:
                 changes = OID_SET_TYPE([oid for oid, _tid in changes])
 
             self.__poll_replace_checkpoints(cursor, global_checkpoints, new_tid_int)
 
         if not global_checkpoints_in_future and self._should_suggest_shifted_checkpoints():
+            # Obviously we can't do this if we're currently behind what the checkpoints
+            # are already set to.
             self._suggest_shifted_checkpoints()
 
         return changes
@@ -953,67 +1288,35 @@ class StorageCache(_InvalidationMixin):
             changed_oids.add(oid_int)
             my_tid_int = m_get(oid_int, -1)
             if tid_int > my_tid_int:
+                # XXX: When would it be lower?
                 m[oid_int] = tid_int
         return changed_oids
 
     @metricmethod
     def __poll_replace_checkpoints(self, cursor, new_checkpoints, new_tid_int):
-        # We have to replace the checkpoints.
-        cp0, cp1 = new_checkpoints
+        # We were asked to replace our checkpoints, with the global
+        # checkpoints specified by the cache. To keep access to all
+        # our cache data, we rebuild our delta maps. The new
+        # checkpoints give us our rebuild boundaries.
 
-        # Use the checkpoints specified by the cache (or equal to new_tid_int,
-        # if the cache was in the future.)
-
-        # Rebuild delta_after0 and delta_after1, if we can.
-        # If we can't, because we don't actually have a range, do nothing.
-        # If the case that the checkpoints are (new_tid, new_tid),
-        # we'll do nothing and have no delta maps. This is because, hopefully,
-        # next time we poll we'll be able to use the global checkpoints and
-        # catch up then.
-        new_delta_after0 = self.polling_state.delta_map_type()
-        new_delta_after1 = self.polling_state.delta_map_type()
-        if cp1 < new_tid_int:
-            # poller.list_changes(cp1, new_tid_int) provides an iterator of
-            # (oid, tid) where tid > cp1 and tid <= new_tid_int. It is guaranteed
-            # that each oid shows up only once.
-            change_list = self.adapter.poller.list_changes(
-                cursor, cp1, new_tid_int)
-
-            # Put the changes in new_delta_after*.
-            # Let the backing cache know about this (this is only done
-            # for tracing).
-            updating_0 = self.cache.updating_delta_map(new_delta_after0)
-            updating_1 = self.cache.updating_delta_map(new_delta_after1)
-            try:
-                for oid_int, tid_int in change_list:
-                    if tid_int <= cp1 or tid_int > new_tid_int:
-                        self._reset(
-                            "Requested changes %d < tid <= %d "
-                            "but change %d for OID %d out of range." % (
-                                cp1, new_tid_int,
-                                tid_int, oid_int
-                            )
-                        )
-
-                    d = updating_0 if tid_int > cp0 else updating_1
-                    d[oid_int] = tid_int
-            except:
-                consume(change_list)
-                raise
-
-            # Everybody has a home (we didn't get duplicate entries
-            # or multiple entries for the same OID with different TID)
-            # This is guaranteed by the IPoller interface, so we don't waste
-            # time tracking it here.
-        logger.debug(
-            "Built new deltas from cp1 %s to current_tid %s of sizes %d (0) and %d (1)",
-            cp1, new_tid_int,
-            len(new_delta_after0), len(new_delta_after1)
+        # Note that those will both be equal to ``new_tid_int``, if
+        # the cache had checkpoints in the future. In that case, we
+        # just empty our delta maps and do nothing else (there's
+        # nothing to poll for that we could make use of). Hopefully,
+        # next time we poll we'll be able to use the global
+        # checkpoints; we'll notice that ours don't match and call this again
+        # to rebuild.
+        assert new_checkpoints is not None
+        cp, da0, da1 = self.polling_state.after_poll_with_changed_checkpoints(
+            self,
+            cursor,
+            new_checkpoints,
+            new_tid_int
         )
-
-        self.checkpoints = new_checkpoints
-        self.delta_after0 = new_delta_after0
-        self.delta_after1 = new_delta_after1
+        assert cp is not None
+        self.checkpoints = cp
+        self.delta_after0 = da0
+        self.delta_after1 = da1
 
     def _suggest_shifted_checkpoints(self):
         """Suggest that future polls use a new pair of checkpoints.

--- a/src/relstorage/cache/storage_cache.py
+++ b/src/relstorage/cache/storage_cache.py
@@ -1255,6 +1255,9 @@ class StorageCache(_InvalidationMixin):
             # so I get to. Note that this return of None will
             # drop anything already cached
             self.__poll_establish_global_checkpoints(new_tid_int)
+            if changes is not None:
+                consume(changes)
+
             return
 
         global_checkpoints_in_future = global_checkpoints[0] > new_tid_int

--- a/src/relstorage/cache/tests/cache_trace_analysis.rst
+++ b/src/relstorage/cache/tests/cache_trace_analysis.rst
@@ -24,6 +24,12 @@ Check to make sure the cache analysis scripts work.
     ...         history.append((b'l', oid, serial,
     ...                        b'x'*random.randint(200,2000)))
 
+    >>> def send_queue(self, tid):
+    ...    tid_int = u64(tid)
+    ...    self.cache.set_all_for_tid(tid_int, self.temp_objects)
+    ...    self.temp_objects.reset()
+
+
     >>> def cache_run(name, size):
     ...     serial = 1
     ...     random.seed(42)
@@ -50,14 +56,14 @@ Check to make sure the cache analysis scripts work.
     ...             cache.after_poll(None, cache.current_tid, serial, [(oid, serial)])
     ...             assert cache.current_tid == serial
     ...             cache.store_temp(oid, data)
-    ...             cache._send_queue(p64(serial))
+    ...             send_queue(cache, p64(serial))
     ...             cache.adapter.mover.data[oid] = (data, serial)
     ...         else:
     ...             new_cache.current_tid = serial
     ...             v = new_cache.load(None, oid)
     ...             if v[0] is None:
     ...                 new_cache.store_temp(oid, data)
-    ...                 new_cache._send_queue(p64(serial))
+    ...                 send_queue(new_cache, p64(serial))
     ...                 cache.adapter.mover.data[oid] = (data, serial)
     ...     cache.close(close_async=False)
 

--- a/src/relstorage/cache/tests/cache_trace_analysis.rst
+++ b/src/relstorage/cache/tests/cache_trace_analysis.rst
@@ -33,10 +33,12 @@ Check to make sure the cache analysis scripts work.
     ...     options.cache_local_mb = size*(1<<20)
     ...     options.cache_local_dir = '.'
     ...     options.cache_local_compression = 'zlib'
-    ...     options.share_local_cache = True
     ...     # We can interleave between instances
     ...     cache = relstorage.cache.StorageCache(MockAdapter(), options, name)
     ...     new_cache = cache.new_instance()
+    ...     assert hasattr(cache.cache, 'tracer'), cache.cache
+    ...     assert hasattr(new_cache.cache, 'tracer'), new_cache.cache
+    ...     assert new_cache.cache.tracer is cache.cache.tracer
     ...     cache.checkpoints = new_cache.checkpoints = cache.local_client.store_checkpoints(0, 0)
     ...     new_cache.tpc_begin()
     ...     cache.tpc_begin()

--- a/src/relstorage/cache/tests/test_memcache_client.py
+++ b/src/relstorage/cache/tests/test_memcache_client.py
@@ -94,3 +94,8 @@ class MemcacheClientTests(AbstractStateCacheTests):
     def getClass(self):
         from relstorage.cache.storage_cache import MemcacheStateCache
         return MemcacheStateCache.from_options
+
+    def test_new_instance_is_really_new(self):
+        inst = self._makeOne()
+        new = inst.new_instance()
+        self.assertIsNot(inst, new)

--- a/src/relstorage/cache/tests/test_storage_cache.py
+++ b/src/relstorage/cache/tests/test_storage_cache.py
@@ -620,6 +620,20 @@ class StorageCacheTests(TestCase):
         self.assertTrue(c._should_suggest_shifted_checkpoints(lambda: 0.89))
         self.assertFalse(c._should_suggest_shifted_checkpoints(lambda: 0.9))
 
+    def test_instances_know_master(self):
+        child = self._makeOne()
+        self.assertEqual(1, len(self._instances))
+        master = self._instances[0]
+        self.assertIs(master, child.master)
+
+        # This shouldn't actually happen...
+        grandchild = child.new_instance()
+        self.assertIs(master, grandchild.master)
+
+        # releasing drops the master
+        grandchild.release()
+        self.assertIsNone(grandchild.master)
+        self.assertIs(master, child.master)
 
 class PersistentRowFilterTests(TestCase):
 

--- a/src/relstorage/cache/tests/test_storage_cache.py
+++ b/src/relstorage/cache/tests/test_storage_cache.py
@@ -128,7 +128,7 @@ class StorageCacheTests(TestCase):
         if fname:
             self.assertTrue(os.path.exists(fname), fname)
 
-    def test_save(self):
+    def test_save_and_clear(self):
         c, oid, tid = self._setup_for_save()
         self.assertNoPersistentCache(c)
         c.save(overwrite=True, close_async=False)
@@ -149,10 +149,25 @@ class StorageCacheTests(TestCase):
         c.local_client.store_checkpoints(0, 0)
         c.save(close_async=False)
 
+        # Creating a new one loads the stored data.
         c2 = self._makeOne(cache_local_dir=c.options.cache_local_dir)
         self.assertEqual(1, len(c2))
         self.assertEqual(c2.checkpoints, (0, 0))
         self.assertEqual(dict(c2.delta_after0), {oid: tid})
+        self.assertIsEmpty(c2.delta_after1)
+
+        # Resetting also loads the stored data by default.
+        c2.clear()
+        self.assertEqual(1, len(c2))
+        self.assertEqual(c2.checkpoints, (0, 0))
+        self.assertEqual(dict(c2.delta_after0), {oid: tid})
+        self.assertIsEmpty(c2.delta_after1)
+
+        # But can be told to ignore it
+        c2.clear(load_persistent=False)
+        self.assertEqual(0, len(c2))
+        self.assertIsNone(c2.checkpoints)
+        self.assertIsEmpty(c2.delta_after0)
         self.assertIsEmpty(c2.delta_after1)
 
         c.options.cache_local_dir = None
@@ -195,7 +210,7 @@ class StorageCacheTests(TestCase):
         self.assertEmpty(c)
         self.assertNoPersistentCache(c)
 
-    def test_clear(self):
+    def test_clear_no_persistent_data(self):
         from relstorage.tests.fakecache import data
         data.clear()
         c = self._makeOne()
@@ -620,20 +635,22 @@ class StorageCacheTests(TestCase):
         self.assertTrue(c._should_suggest_shifted_checkpoints(lambda: 0.89))
         self.assertFalse(c._should_suggest_shifted_checkpoints(lambda: 0.9))
 
-    def test_instances_know_master(self):
+    def test_instances_share_polling_state(self):
         child = self._makeOne()
         self.assertEqual(1, len(self._instances))
         master = self._instances[0]
-        self.assertIs(master, child.master)
+        self.assertIs(master.polling_state, child.polling_state)
 
         # This shouldn't actually happen...
         grandchild = child.new_instance()
-        self.assertIs(master, grandchild.master)
+        self.assertIs(master.polling_state, grandchild.polling_state)
+        self.assertTrue(grandchild.polling_state)
 
         # releasing drops the master
         grandchild.release()
-        self.assertIsNone(grandchild.master)
-        self.assertIs(master, child.master)
+        self.assertFalse(grandchild.polling_state)
+        # Doesn't affect anything else.
+        self.assertIs(master.polling_state, child.polling_state)
 
 class PersistentRowFilterTests(TestCase):
 

--- a/src/relstorage/cache/tests/test_storage_cache.py
+++ b/src/relstorage/cache/tests/test_storage_cache.py
@@ -383,7 +383,7 @@ class StorageCacheTests(TestCase):
         c.store_temp(2, b'abc')
         c.store_temp(3, b'def')
         tid = p64(55)
-        c._send_queue(tid)
+        c.after_tpc_finish(tid)
         self.assertEqual(data, {
             'myprefix:state:55:2': tid + b'abc',
             'myprefix:state:55:3': tid + b'def',
@@ -399,7 +399,7 @@ class StorageCacheTests(TestCase):
         c.store_temp(2, b'abc')
         c.store_temp(3, b'def' * 100)
         tid = p64(55)
-        c._send_queue(tid)
+        c.after_tpc_finish(tid)
         self.assertEqual(data, {
             'myprefix:state:55:2': tid + b'abc',
             'myprefix:state:55:3': tid + (b'def' * 100),
@@ -410,7 +410,7 @@ class StorageCacheTests(TestCase):
         c = self._makeOne()
         c.tpc_begin()
         tid = p64(55)
-        c._send_queue(tid)
+        c.after_tpc_finish(tid)
         self.assertEqual(data, {})
 
     def test_after_tpc_finish(self):

--- a/src/relstorage/options.py
+++ b/src/relstorage/options.py
@@ -106,6 +106,7 @@ class Options(object):
     cache_local_dir = None
     #: Switch checkpoints after this many writes
     cache_delta_size_limit = 100000 if not PYPY else 50000
+
     #: Implementation of ILRUCache to use for local cache
     #: storage.
     cache_local_storage = None
@@ -119,12 +120,6 @@ class Options(object):
     create_schema = True
     #: Which database driver to use
     driver = 'auto'
-
-    # If share_local_cache is off, each storage instance has a private
-    # cache rather than a shared cache.  This option exists mainly for
-    # simulating disconnected caches in tests and can't be set from ZConfig.
-    share_local_cache = True
-
 
     # Deprecated things
     #: How many persistent cache files to keep

--- a/src/relstorage/storage/history.py
+++ b/src/relstorage/storage/history.py
@@ -47,6 +47,7 @@ class History(object):
     __slots__ = (
         'adapter',
         'load_connection',
+        '__dict__',
     )
 
     def __init__(self, adapter, load_connection):

--- a/src/relstorage/storage/pack.py
+++ b/src/relstorage/storage/pack.py
@@ -83,6 +83,11 @@ class Pack(object):
         if t > 275085010696509852:
             # Must be a TID.
 
+            # This magic number generates 'Value too large to be stored in data type' when
+            # given to time.gmtime() as used to originally generate TimeStamp values,
+            # though it can be converted back. It also happens to specify July 2019
+            # when this feature was implemented.
+
             # Turn it back into a time.time() for later logging
             ts = TimeStamp(int64_to_8bytes(t))
             logger.debug(

--- a/src/relstorage/storage/tpc/vote.py
+++ b/src/relstorage/storage/tpc/vote.py
@@ -286,7 +286,7 @@ class AbstractVote(AbstractTPCState):
         if count_conflicts:
             logger.debug("Attempting to resolve %d conflicts", count_conflicts)
 
-        __traceback_info__ = conflicts, invalidated_oid_ints
+        __traceback_info__ = conflicts, invalidated_oid_ints, cursor
 
         for conflict in conflicts:
             oid_int, committed_tid_int, tid_this_txn_saw_int, committed_state = conflict

--- a/src/relstorage/storage/tpc/vote.py
+++ b/src/relstorage/storage/tpc/vote.py
@@ -286,6 +286,8 @@ class AbstractVote(AbstractTPCState):
         if count_conflicts:
             logger.debug("Attempting to resolve %d conflicts", count_conflicts)
 
+        __traceback_info__ = conflicts, invalidated_oid_ints
+
         for conflict in conflicts:
             oid_int, committed_tid_int, tid_this_txn_saw_int, committed_state = conflict
             if tid_this_txn_saw_int is None:

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -290,6 +290,8 @@ class MockConnectionManager(object):
         if hasattr(conn, 'rollback'):
             conn.rollback()
 
+    rollback_store_quietly = rollback_quietly
+
     def rollback_and_close(self, conn, cursor):
         self.rollback_quietly(conn, cursor)
         if conn:

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -331,7 +331,7 @@ class MockQuery(object):
 class MockPoller(object):
 
     poll_query = MockQuery('SELECT MAX(tid) FROM object_state')
-
+    last_requested_range = None
     def __init__(self, driver=None):
         self.driver = driver or MockDriver()
         self.changes = []  # [(oid, tid)]
@@ -340,6 +340,7 @@ class MockPoller(object):
         # Return a list, because the caller is allowed
         # to assume a length. Return exactly the item in the list because
         # it may be a type other than a tuple
+        self.last_requested_range = (after_tid, last_tid)
         return [
             item
             for item in self.changes

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -480,16 +480,17 @@ class GenericRelStorageTests(
         oid = self._storage.new_oid()
 
         revid1 = self._dostoreNP(oid, data=zodb_pickle(obj))
-
         # These will both poll and get the state for (oid, revid1)
         # cached at that location, where it will be found during conflict
         # resolution.
         storage1 = self._storage.new_instance()
         storage1.load(oid, '')
+
         storage2 = self._storage.new_instance()
         storage2.load(oid, '')
-        # It's not there now, but root is. Clear those things
         # Remember that the cache stats are shared between instances.
+        # They were both able to get the data that the root storage put in the cache.
+
         self.assertEqual(storage1._cache.stats()['hits'], 2)
         storage1._cache.reset_stats()
         if clear_cache:
@@ -503,20 +504,31 @@ class GenericRelStorageTests(
         # revid1 that add two to _value.
         root_storage = self._storage
         try:
-            self._storage = self.__make_tryToResolveConflict_ignore_committedData(storage1)
+
+            def noConflict(*_args, **_kwargs):
+                self.fail("Should be no conflict.")
+            storage1.tryToResolveConflict = noConflict
+            self._storage = storage1
             _revid2 = self._dostoreNP(oid, revid=revid1, data=zodb_pickle(obj))
+
+            # This one had no conflicts and did no cache work
+            self.assertEqual(storage1._cache.stats()['hits'], 0)
+            self.assertEqual(storage1._cache.stats()['misses'], 0)
+
+            # This will conflict and  will have to use the cache and DB for loadSerial
             self._storage = self.__make_tryToResolveConflict_ignore_committedData(storage2)
             _revid3 = self._dostoreNP(oid, revid=revid1, data=zodb_pickle(obj))
 
-            # Both of them needed to resolve conflicts, and since we
-            # didn't pass any data up from the storage, both of them
-            # found the data in their cache (unless we cleared the
-            # cache; in which case, the first one resolved the state
-            # and saved it back to the database and cache, and the
-            # second one found it there)
+            # Since we didn't pass any data up from the storage, this
+            # would need to make two lookups, for committed data and
+            # previous data. If we're history free, we invalidated the
+            # object when the first one saved it, but we're lucky
+            # enough to find the committed data in our shared state.
+            # This happens to be the same thing as if we cleared the cache.
+
             cache_stats = storage1._cache.stats()
             __traceback_info__ = cache_stats, clear_cache
-            if clear_cache:
+            if clear_cache or not self.keep_history:
                 self.assertEqual(cache_stats['misses'], 2)
                 self.assertEqual(cache_stats['hits'], 1)
             else:
@@ -667,22 +679,32 @@ class GenericRelStorageTests(
             r1 = c1.root()
             # The root state and checkpoints should now be cached.
             # A commit count *might* be cached depending on the ZODB version.
-            self.assertTrue('zzz:checkpoints' in fakecache.data)
+            # (We stopped storing checkpoints in cache, they're too important.)
+            self.assertNotIn('zzz:checkpoints', fakecache.data)
+            self.assertIsNotNone(db.storage._cache.polling_state.checkpoints)
             self.assertEqual(sorted(fakecache.data.keys())[-1][:10],
                              'zzz:state:')
             r1['alpha'] = PersistentMapping()
             transaction.commit()
-            self.assertEqual(len(fakecache.data), 4)
+            if self.keep_history:
+                item_count = 3
+            else:
+                # The previous root state was automatically invalidated
+                item_count = 2
+            self.assertEqual(len(fakecache.data), item_count)
 
             oid = r1['alpha']._p_oid
             c1._storage.load(oid, '')
-            # another state should now be cached
-            self.assertEqual(len(fakecache.data), 4)
+            # Came out of the cache, nothing new
+            self.assertEqual(len(fakecache.data), item_count)
 
             # make a change
             r1['beta'] = 0
             transaction.commit()
-            self.assertEqual(len(fakecache.data), 5)
+            if self.keep_history:
+                # Once again, history free automatically invalidated.
+                item_count += 1
+            self.assertEqual(len(fakecache.data), item_count)
 
             c1._storage.load(oid, '')
 
@@ -1255,7 +1277,12 @@ class GenericRelStorageTests(
 
         transaction.commit()
 
-        self.assertEqual(3, len(self._storage._cache))
+        if self.keep_history:
+            item_count = 3
+        else:
+            # The new state for the root invalidated the old state.
+            item_count = 2
+        self.assertEqual(item_count, len(self._storage._cache))
         self._storage._cache.clear()
         self.assertEmpty(self._storage._cache)
 
@@ -1364,6 +1391,8 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
         <zlibstorage %s>
         <relstorage>
             %s
+            cache-prefix %s
+            cache-local-dir %s
         </relstorage>
         </zlibstorage>
         """ % (
@@ -1371,6 +1400,8 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
             self.filestorage_file,
             self.relstorage_name,
             self.get_adapter_zconfig(),
+            self.relstorage_name,
+            os.path.abspath('.'),
         )
         self._write_cfg(cfg)
 
@@ -1406,7 +1437,7 @@ class AbstractRSDestZodbConvertTests(AbstractRSZodbConvertTests):
         return self.srcfile
 
     def _create_dest_storage(self):
-        return self._closing(self.make_storage(zap=False))
+        return self._closing(self.make_storage(cache_prefix=self.relstorage_name, zap=False))
 
 class AbstractRSSrcZodbConvertTests(AbstractRSZodbConvertTests):
 
@@ -1418,7 +1449,7 @@ class AbstractRSSrcZodbConvertTests(AbstractRSZodbConvertTests):
         return self.destfile
 
     def _create_src_storage(self):
-        return self._closing(self.make_storage(zap=False))
+        return self._closing(self.make_storage(cache_prefix=self.relstorage_name, zap=False))
 
 class AbstractIDBOptionsTest(unittest.TestCase):
 

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -679,18 +679,21 @@ class GenericRelStorageTests(
             r1 = c1.root()
             # The root state and checkpoints should now be cached.
             # A commit count *might* be cached depending on the ZODB version.
-            # (We stopped storing checkpoints in cache, they're too important.)
-            self.assertNotIn('zzz:checkpoints', fakecache.data)
+            # (Checkpoints are stored in the cache for the sake of tests/monitoring,
+            # but aren't read.)
+            self.assertIn('zzz:checkpoints', fakecache.data)
             self.assertIsNotNone(db.storage._cache.polling_state.checkpoints)
             self.assertEqual(sorted(fakecache.data.keys())[-1][:10],
                              'zzz:state:')
             r1['alpha'] = PersistentMapping()
             transaction.commit()
+            cp_count = 1
             if self.keep_history:
                 item_count = 3
             else:
                 # The previous root state was automatically invalidated
                 item_count = 2
+            item_count += cp_count
             self.assertEqual(len(fakecache.data), item_count)
 
             oid = r1['alpha']._p_oid


### PR DESCRIPTION
This does a great deal for #311. You could probably say it fixes #311 (it definitely fixed a few random issues I discovered; every time the cache gets better, it seems like I find a new corner case. It's about 50/50 whether it's a genuine bug or just the tests previously getting lucky and working in one particular state of checkpoints). It introduces a shared `PollingState` object that handles deciding when checkpoints need to be rebuilt, and only doing that in one thread/connection, so we don't have this cascade effect where lots of connections decide they need to rebuild checkpoints and spend lots of time thrashing with each other on large queries. (Code gets interesting for `PollingState` starting around [here](https://github.com/zodb/relstorage/compare/master...issue311#diff-5c2ca3e44f9343bf7373eb767c0f4379R216).) There are still some rough edges and TODOs, but tests all pass as does some stress testing.

However, I think it's just a waypoint and I won't bother sanding down those edges (here). Centralizing control of polling and checkpoint (re)building got me thinking much more about #134, and I think we're not that far away from being able to implement that in a way that ought to get us away from checkpoints entirely, while being more efficient, especially on workloads that are adding/updating  but also reading older objects that don't change. I'm getting a start on that in [this branch](https://github.com/zodb/relstorage/tree/issue311-take2); it'll probably take a couple days.