### PR TITLE
Make loading the persistent cache explicitly check invalidations like older versions did

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,12 @@
 3.0a10 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Fix a bug where the persistent cache might not properly detect
+  object invalidations if the MVCC index pulled too far ahead at save
+  time. Now it explicitly checks for invalidations at load time, as
+  earlier versions did.
 
+- Require perfmetrics 3.0.
 
 3.0a9 (2019-08-28)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     ],
     install_requires=[
         'cffi',
-        'perfmetrics',
+        'perfmetrics >= 3.0.0',
         'zope.interface',
         'zope.dottedname',
         'zc.lockfile',

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -148,12 +148,7 @@ else:
             replacement.__wrapped__ = self._orig
             return replacement
 
-    from perfmetrics import Metric as _PMetric
-    class Metric(_PMetric):
-        def __call__(self, f):
-            new_f = _PMetric.__call__(self, f)
-            new_f.__wrapped__ = f
-            return new_f
+    from perfmetrics import Metric
 
     metricmethod = Metric(method=True)
 

--- a/src/relstorage/cache/local_client.py
+++ b/src/relstorage/cache/local_client.py
@@ -378,6 +378,9 @@ class LocalClient(object):
             else:
                 yield (oid, value[1])
 
+    def keys(self):
+        return self._cache.data.keys()
+
     def _decompress(self, data):
         pfx = data[:2]
         if pfx not in self._decompression_functions:
@@ -442,10 +445,12 @@ class LocalClient(object):
         count_removed = 0
         conn = '(no oids to remove)'
         if bad_oids:
+            self.invalidate_all(bad_oids)
             conn = sqlite_connect(options, self.prefix, close_async=False)
             with closing(conn):
                 db = Database.from_connection(conn)
                 count_removed = db.remove_invalid_persistent_oids(bad_oids)
+
         logger.debug("Removed %d invalid OIDs from %s", count_removed, conn)
 
     def zap_all(self):

--- a/src/relstorage/cache/storage_cache.py
+++ b/src/relstorage/cache/storage_cache.py
@@ -268,7 +268,7 @@ class StorageCache(DetachableMVCCDatabaseViewer):
         # We must only restore into an empty cache.
         state = self.polling_state
         assert not len(self.local_client) # pylint:disable=len-as-condition
-        state.restore(self.local_client)
+        state.restore(self.adapter, self.local_client)
 
     def _reset(self, message=None):
         """

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -125,13 +125,14 @@ class TestCase(unittest.TestCase):
         finally:
             super(TestCase, self).tearDown()
 
-    def assertIsEmpty(self, container):
-        self.assertLength(container, 0)
+    def assertIsEmpty(self, container, msg=None):
+        self.assertLength(container, 0, msg)
 
     assertEmpty = assertIsEmpty
 
-    def assertLength(self, container, length):
-        self.assertEqual(len(container), length, container)
+    def assertLength(self, container, length, msg=None):
+        self.assertEqual(len(container), length,
+                         '%s -- %s' % (msg, container) if msg else container)
 
 class StorageCreatingMixin(ABC):
 


### PR DESCRIPTION
This fixes a bug where the MVCC logic could 'miss' an invalidation at save time under certain circumstances.

Added two test cases, one that passed before this change and a second one that failed before this change.