### PR TITLE
Remove the distribution extra qualifiers from the zodburi entry points.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -56,11 +56,11 @@ disable=
 
 
 [IMPORTS]
-# It's common to have ZODB installed in the virtual environment
-# with us. That causes it to be recognized as first party, meaning
-# that it is suddenly sorted incorrectly compared to other third party
-# imports such as zope.
-known-third-party=ZODB
+# It's common to have ZODB and a few closely related dependencies
+# installed in the virtual environment with us. That causes it to be
+# recognized as first party, meaning that it is suddenly sorted
+# incorrectly compared to other third party imports such as zope.
+known-third-party=ZODB,transaction
 
 [FORMAT]
 # duplicated from setup.cfg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,19 @@
   exceptions besides just ``ReadConflictError`` so they don't
   propagate out to ``transaction.begin()``.
 
+- Make the zodburi resolver entry points not require a specific
+  RelStorage extra such as 'postgres', in case there is a desire to
+  use a different database driver than the default that's installed
+  with that extra. See :issue:`342`, reported by Éloi Rivard.
+
+- Make the zodburi resolvers accept the 'driver' query paramater to
+  allow selecting a specific driver to use. This functions the same as
+  in a ZConfig configuration.
+
+- Make the zodburi resolvers more strict on the distinction between
+  boolean arguments and arbitrary integer arguments. Previously, a
+  query like ``?read_only=12345&cache_local_mb=yes`` would have been
+  interpreted as ``True`` and ``1``, respectively. Now it produces errors.
 
 3.0a10 (2019-09-04)
 ===================

--- a/setup.py
+++ b/setup.py
@@ -209,10 +209,9 @@ setup(
             'zodbpack = relstorage.zodbpack:main',
         ],
         'zodburi.resolvers': [
-            ('postgres = '
-             'relstorage.zodburi_resolver:postgresql_resolver [postgresql]'),
-            'mysql = relstorage.zodburi_resolver:mysql_resolver [mysql]',
-            'oracle = relstorage.zodburi_resolver:oracle_resolver [oracle]'
+            'postgres = relstorage.zodburi_resolver:postgresql_resolver',
+            'mysql = relstorage.zodburi_resolver:mysql_resolver',
+            'oracle = relstorage.zodburi_resolver:oracle_resolver'
         ]
     },
 )

--- a/src/relstorage/options.py
+++ b/src/relstorage/options.py
@@ -180,7 +180,12 @@ class Options(object):
         )
 
     def __repr__(self):
-        return 'relstorage.options.Options(**' + repr(self.__dict__) + ')'
+        opts = []
+        for k, v in sorted(self.__dict__.items()):
+            opt = '%s=%r' % (k, v)
+            opts.append(opt)
+        opts = ', '.join(opts)
+        return 'relstorage.options.Options(%s)' % (opts,)
 
     def __eq__(self, other):
         if not isinstance(other, Options):

--- a/src/relstorage/storage/copy.py
+++ b/src/relstorage/storage/copy.py
@@ -46,7 +46,7 @@ class Copy(object):
         self.restore = restore
 
     def copyTransactionsFrom(self, other):
-        # pylint:disable=too-many-locals
+        # pylint:disable=too-many-locals,too-many-statements
         # adapted from ZODB.blob.BlobStorageMixin
         begin_time = time.time()
         txnum = 0


### PR DESCRIPTION
They're more trouble than they are worth.

Also simplify the option parsing to use the same primitives that are usef for our .conf files, and add support for selecting the driver.

Fixes #342.