### PR TITLE
Use CAST(state AS BLOB) to get the correct length of the states.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,11 @@
   query like ``?read_only=12345&cache_local_mb=yes`` would have been
   interpreted as ``True`` and ``1``, respectively. Now it produces errors.
 
+- Fix the calculation of the persistent cache size, especially on
+  Python 2. This is used to determine when to shrink the disk cache.
+  See :issue:`317`.
+
+
 3.0a10 (2019-09-04)
 ===================
 

--- a/src/relstorage/cache/persistence.py
+++ b/src/relstorage/cache/persistence.py
@@ -52,6 +52,7 @@ SQ3_SUPPORTS_CTE = sqlite3.sqlite_version_info >= (3, 8, 3) # 2014-02-03
 # Because we use a CTE in our default queries. In principle,
 # we could probably re-write queries and run on 3.7.11; 3.7.0 was the
 # oldest to support WAL mode, and 3.7.11 added multiple VALUE syntax.
+# Prior to 3.7.6, you can't use LENGTH() on a BLOB column.
 SQ3_MIN_VERSION = (3, 8, 3)
 SQ3_IS_MIN_VERSION = sqlite3.sqlite_version_info >= SQ3_MIN_VERSION
 


### PR DESCRIPTION
Fixes #317