### PR TITLE
Fix several race conditions when packing history-free storages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,10 @@
   Reported in :issue:`325` by krissik with initial PR by Andreas
   Gabriel.
 
+- Make ``zodbpack`` pass RelStorage specific options like
+  ``--prepack`` and ``--use-prepack-state`` to the RelStorage, even
+  when it has been wrapped in a ``zc.zlibstorage``.
+
 3.0a10 (2019-09-04)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,11 @@
   Python 2. This is used to determine when to shrink the disk cache.
   See :issue:`317`.
 
+- Fix several race conditions when packing history-free storages
+  through a combination of changes in ordering and more strongly
+  consistent (``READ ONLY REPEATABLE READ``) transactions.
+  Reported in :issue:`325` by krissik with initial PR by Andreas
+  Gabriel.
 
 3.0a10 (2019-09-04)
 ===================

--- a/docs/zodbpack.rst
+++ b/docs/zodbpack.rst
@@ -19,18 +19,19 @@ the storages to pack, in ZConfig format. An example configuration file::
 Options for ``zodbpack``
 ========================
 
-  ``--days`` or ``-d``
-    Specifies how many days of historical data to keep. Defaults to 0,
-    meaning no history is kept. This is meaningful even for
-    history-free storages, since unreferenced objects are not removed
-    from the database until the specified number of days have passed.
+``--days`` or ``-d``
+    Specifies how many days of historical data to
+    keep. Defaults to 1, meaning all objects newer than 1 day are
+    considered reachable. This is meaningful even for history-free
+    storages, since unreferenced objects are not removed from the
+    database until the specified number of days have passed.
 
-  ``--prepack``
+``--prepack``
     Instructs the storage to only run the pre-pack phase of the pack but not
     actually delete anything.  This is equivalent to specifying
     ``pack-prepack-only true`` in the storage options.
 
-  ``--use-prepack-state``
+``--use-prepack-state``
     Instructs the storage to only run the deletion (packing) phase, skipping
     the pre-pack analysis phase. This is equivalent to specifying
     ``pack-skip-prepack true`` in the storage options.

--- a/src/relstorage/_util.py
+++ b/src/relstorage/_util.py
@@ -337,7 +337,7 @@ def get_memory_usage():
 
 def byte_display(size):
     """
-    Returns a size with the correct unit (KB, MB), given the size in bytes.
+    Returns a string with the correct unit (KB, MB), given the size in bytes.
     """
     if size == 0:
         return '0 KB'
@@ -346,7 +346,6 @@ def byte_display(size):
     if size > 1048576:
         return '%0.02f MB' % (size / 1048576.0)
     return '%0.02f KB' % (size / 1024.0)
-
 
 class Lazy(object):
     "Property-like descriptor that calls func only once per instance."

--- a/src/relstorage/adapters/mysql/packundo.py
+++ b/src/relstorage/adapters/mysql/packundo.py
@@ -110,10 +110,4 @@ class MySQLHistoryPreservingPackUndo(_LockStmt, HistoryPreservingPackUndo):
         """
 
 class MySQLHistoryFreePackUndo(_LockStmt, HistoryFreePackUndo):
-
-    _script_create_temp_pack_visit = """
-        CREATE TEMPORARY TABLE temp_pack_visit (
-            zoid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
-            keep_tid BIGINT UNSIGNED NOT NULL
-        );
-        """
+    pass

--- a/src/relstorage/storage/pack.py
+++ b/src/relstorage/storage/pack.py
@@ -192,10 +192,11 @@ class Pack(object):
         if prepack_only and skip_prepack:
             raise ValueError('Pick either prepack_only or skip_prepack.')
 
-        # Use a private connection (lock_conn and lock_cursor) to
-        # hold the pack lock.  Have the adapter open temporary
-        # connections to do the actual work, allowing the adapter
-        # to use special transaction modes for packing.
+        # Use a private connection (lock_conn and lock_cursor) to hold
+        # the pack lock. Have the adapter open temporary connections
+        # to do the actual work, allowing the adapter to use special
+        # transaction modes for packing, and to commit at will without
+        # losing the lock.
         lock_conn, lock_cursor = self.connmanager.open()
         try:
             self.locker.hold_pack_lock(lock_cursor)

--- a/src/relstorage/tests/packundo.py
+++ b/src/relstorage/tests/packundo.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""
+Test mixin dealing with packing, especially concurrently.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+from persistent.mapping import PersistentMapping
+import transaction
+from ZODB.DB import DB
+from ZODB.serialize import referencesf
+
+from .reltestbase import RelStorageTestBase
+
+
+class TestPackBase(RelStorageTestBase):
+    # pylint:disable=abstract-method
+
+    def setUp(self):
+        super(TestPackBase, self).setUp()
+        self.main_db = self._closing(DB(self._storage))
+
+    def tearDown(self):
+        self.main_db.close()
+        self.main_db = None
+        super(TestPackBase, self).tearDown()
+
+    def _create_initial_state(self):
+        txm = transaction.TransactionManager(explicit=True)
+        conn = self.main_db.open(txm)
+        txm.begin()
+
+        A = conn.root.A = PersistentMapping()
+        B = A['B'] = PersistentMapping()
+        C = B['C'] = PersistentMapping()
+
+        txm.commit()
+        oids = {
+            'A': A._p_oid,
+            'B': B._p_oid,
+            'C': C._p_oid,
+        }
+        conn.close()
+
+        return oids
+
+    def _inject_changes_after_object_refs_added_and_check_objects_present(
+            self,
+            initial_oids, # type: Dict[str, bytes]
+            inject_changes,
+            delta=1,
+    ):
+        # We expect inject_changes to mutate *initial_oids* by *delta*
+        len_initial_oids = len(initial_oids)
+
+        adapter = self._storage._adapter
+        adapter.packundo.on_filling_object_refs_added = inject_changes
+
+        # Pack to the current TID (RelStorage extension)
+        packtime = None
+        self._storage.pack(packtime, referencesf)
+
+        # "The on_filling_object_refs_added hook should have been called once"
+        self.assertEqual(len(initial_oids),
+                         len_initial_oids + delta,
+                         initial_oids)
+
+        # All children should still exist.
+        for name, oid in initial_oids.items():
+            __traceback_info__ = name, oid
+            state, _tid = self._storage.load(oid, '')
+            self.assertIsNotNone(state)
+
+    def test_pack_when_object_ref_moved_during_prepack(self):
+        # Given a set of referencing objects present at the beginning
+        # of the pre pack:
+        #
+        #   T1: root -> A -> B -> C
+        #
+        # If a new transaction is committed after we gather the initial list of
+        # objects but before we start examining their state such that
+        # the graph now becomes:
+        #
+        #  T2: root -> A
+        #          \-> B -> D -> C
+        #
+        # That is, C is no longer referenced from B but a new object D, B is referenced
+        # not from A but from the root.
+        #
+        # Then when we pack with GC, no objects are removed.
+        expect_oids = self._create_initial_state()
+
+        def inject_changes(**_kwargs):
+            txm = transaction.TransactionManager(explicit=True)
+            conn = self.main_db.open(txm)
+            txm.begin()
+
+            A = conn.root.A
+            B = A['B']
+            del A['B']
+            D = B['D'] = PersistentMapping()
+            C = B['C']
+            del B['C']
+            D['C'] = C
+
+            txm.commit()
+
+            expect_oids['D'] = D._p_oid
+            conn.close()
+
+        self._inject_changes_after_object_refs_added_and_check_objects_present(expect_oids,
+                                                                               inject_changes)
+
+    # https://ci.appveyor.com/project/jamadden/relstorage/build/1.0.19/job/a1vq619n84ss1s9a
+    def test_pack_when_referring_object_mutates_during_prepack(self):
+        # Packing should not remove objects referenced by an object
+        # that changes during packing. In this case, we're adding a
+        # new object (which should be untouched because it's not
+        # visible as-of the pack-TID) and mutating an existing object
+        # to refer to the new object as well as the new object. add
+        # some data to be packed
+
+        expect_oids = self._create_initial_state()
+
+        def inject_changes(**_kwargs):
+            # Change the database just after the list of objects
+            # to analyze has been determined.
+            txm = transaction.TransactionManager(explicit=True)
+            conn = self.main_db.open(txm)
+            txm.begin()
+            Added = conn.root.ADDED = PersistentMapping()
+            txm.commit()
+            expect_oids['Added'] = Added._p_oid
+            conn.close()
+
+        self._inject_changes_after_object_refs_added_and_check_objects_present(expect_oids,
+                                                                               inject_changes)
+
+class HistoryFreeTestPack(TestPackBase):
+    # pylint:disable=abstract-method
+    keep_history = False
+
+    @unittest.expectedFailure
+    def test_pack_when_object_ref_moved_during_prepack(self):
+        TestPackBase.test_pack_when_object_ref_moved_during_prepack(self)
+
+
+class HistoryPreservingTestPack(TestPackBase):
+    # pylint:disable=abstract-method
+    keep_history = True

--- a/src/relstorage/tests/packundo.py
+++ b/src/relstorage/tests/packundo.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import functools
-import unittest
+
 
 from persistent.mapping import PersistentMapping
 import transaction
@@ -109,6 +109,7 @@ class TestPackBase(RelStorageTestBase):
             hook='on_filling_object_refs_added'
     ):
         # We expect inject_changes to mutate *initial_oids* by *delta*
+        # (see _mutate_state)
         len_initial_oids = len(initial_oids)
 
         adapter = self._storage._adapter
@@ -118,7 +119,7 @@ class TestPackBase(RelStorageTestBase):
         packtime = None
         self._storage.pack(packtime, referencesf)
 
-        # "The on_filling_object_refs_added hook should have been called once"
+        # The on_filling_object_refs_added hook should have been called once
         self.assertEqual(len(initial_oids),
                          len_initial_oids + delta,
                          initial_oids)
@@ -134,7 +135,6 @@ class TestPackBase(RelStorageTestBase):
                 self.assertIsNotNone(state)
 
         self.assertEmpty(missing)
-
 
     def test_pack_when_object_ref_moved_during_prepack(self):
         # If we mutate after we gather the initial list of
@@ -179,13 +179,6 @@ class HistoryFreeTestPack(TestPackBase):
     # pylint:disable=abstract-method
     keep_history = False
 
-    @unittest.expectedFailure
-    def test_pack_when_object_ref_moved_during_prepack(self):
-        # This currently fails because we're in different transactions
-        # and can't see the new reference to the object.
-        TestPackBase.test_pack_when_object_ref_moved_during_prepack(self)
-
-    @unittest.expectedFailure
     def test_pack_when_object_ref_moved_after_ref_finding_first_batch(self):
         # If we mutate after gather the initial list of objects, and after
         # finding references in the first batch (of all objects), we should not
@@ -213,7 +206,6 @@ class HistoryFreeTestPack(TestPackBase):
 
         self.assertIn('D', expect_oids) # hook was called.
 
-    @unittest.expectedFailure
     def test_pack_when_object_ref_moved_just_before_examine_prev_reference(self):
         # We mutate just before we examine the state for the B object.
         expect_oids = self._create_initial_state()

--- a/src/relstorage/tests/packundo.py
+++ b/src/relstorage/tests/packundo.py
@@ -192,7 +192,7 @@ class HistoryFreeTestPack(TestPackBase):
 
         def inject_changes(oid_batch, refs_found):
             # We're examining the root and the first three objects
-            self.assertEqual(oid_batch, list(self.OID_INITIAL_SET))
+            self.assertEqual(sorted(oid_batch), sorted(self.OID_INITIAL_SET))
             self.assertEqual(len(refs_found), 3)
             # We're only called once: a single batch
             self.assertNotIn('D', expect_oids)
@@ -229,7 +229,7 @@ class HistoryFreeTestPack(TestPackBase):
                 hook='on_fill_object_ref_batch',
             )
         finally:
-            self.assertEqual(seen_oids, list(self.OID_INITIAL_SET))
+            self.assertEqual(sorted(seen_oids), sorted(self.OID_INITIAL_SET))
             self.assertIn('D', expect_oids) # hook was called.
 
 

--- a/src/relstorage/tests/test_zodbpack.py
+++ b/src/relstorage/tests/test_zodbpack.py
@@ -41,7 +41,7 @@ class ZODBPackScriptTests(unittest.TestCase):
         if os.path.exists(self.cfg_fn):
             os.remove(self.cfg_fn)
 
-    def test_pack_defaults(self):
+    def test_pack_with_0_day(self):
         from ZODB.DB import DB
         from ZODB.FileStorage import FileStorage
         from ZODB.POSException import POSKeyError
@@ -64,14 +64,14 @@ class ZODBPackScriptTests(unittest.TestCase):
         db.close()
         storage = None
 
-        main(['', self.cfg_fn])
+        main(['', '--days=0', self.cfg_fn])
 
         # packing should have removed the old state.
         storage = FileStorage(self.db_fn)
         self.assertRaises(POSKeyError, storage.loadSerial, oid, serial)
         storage.close()
 
-    def test_pack_with_1_day(self):
+    def test_pack_defaults(self):
         from ZODB.DB import DB
         from ZODB.FileStorage import FileStorage
         import time

--- a/src/relstorage/tests/testmysql.py
+++ b/src/relstorage/tests/testmysql.py
@@ -196,17 +196,16 @@ class MySQLTestSuiteBuilder(AbstractTestSuiteBuilder):
         # both values default to 1MB. So keep it small.)
         return Options().blob_chunk_size
 
-    def _make_check_class_HistoryFreeRelStorageTests(self, bases, name):
+    def _make_check_class_HistoryFreeRelStorageTests(self, bases, name, klass_dict=None):
         bases = (GenericMySQLTestsMixin, ) + bases
 
-        klass_dict = {
-        }
+        klass_dict = {}
 
         return self._default_make_check_class(bases, name, klass_dict=klass_dict)
 
     # pylint:disable=line-too-long
-    def _make_check_class_HistoryPreservingRelStorageTests(self, bases, name):
-        return self._make_check_class_HistoryFreeRelStorageTests(bases, name)
+    def _make_check_class_HistoryPreservingRelStorageTests(self, bases, name, klass_dict=None):
+        return self._make_check_class_HistoryFreeRelStorageTests(bases, name, klass_dict)
 
 
 class GenericMySQLTestsMixin(object):

--- a/src/relstorage/zodbconvert.py
+++ b/src/relstorage/zodbconvert.py
@@ -106,7 +106,8 @@ def main(argv=None):
 
     logging.basicConfig(
         level=logging.INFO,
-        format="%(asctime)s [%(name)s] %(levelname)s %(message)s")
+        format="%(asctime)s [%(name)s] %(levelname)s %(message)s"
+    )
 
     source, destination = open_storages(options)
 


### PR DESCRIPTION
Fixes #325 and incorporates and fixes #336.

Add several tests that originally failed in different ways, depending on where in the process changes happened.

Use a combination of changes in ordering and more strongly consistent (``READ ONLY REPEATABLE READ``) transactions.

The longer running load connection is not expected to be a problem; we've run a test with an active load connection loading objects for 8 hours while the database was being written to without any problems in a 60 million object database.

Some logging adjustments; it appears to take a native driver ~4GB to buffer 30 million OIDs, and then when that's brought into CPython we need a total of ~5GB. There's room for improvement there.

Make `zodbpack --prepack` compatible with zc.zlibstorage (the large database I test with are compressed that way so that's why it's included here.)