### PR TITLE
Faster vacuuming and setting of cache items.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@
 
 - Avoid attempting to lock objects being created. See :issue:`329`.
 
+- Make cache vacuuming faster.
+
 3.0a10 (2019-09-04)
 ===================
 

--- a/src/relstorage/cache/interfaces.py
+++ b/src/relstorage/cache/interfaces.py
@@ -298,20 +298,13 @@ class ILRUCache(Interface):
     # Cache-specific operations.
     ###
 
-    def get_from_key_or_backup_key(pref_key, backup_key):
+    def replace_or_remove_smaller_value(key, value):
         """
-        Get a value stored at either *pref_key* or, failing that,
-        *backup_key*.
+        Given a key that's already present, either removes it
+        if *value* is none, or changes its stored value to be *value*.
 
-        *backup_key* may be None if there is no second key.
-
-        If a value is found at *backup_key*, then it is
-        moved to be stored at *pref_key*, while retaining its
-        frequency information.
-
-        Counts as  a hit on whichever key matches.
-
-        This is used to implement ``IStateCache.__call__``.
+        Does this without counting as a hit or otherwise changing the MRU
+        status of key.
         """
 
     def peek(key):

--- a/src/relstorage/cache/tests/test_local_client.py
+++ b/src/relstorage/cache/tests/test_local_client.py
@@ -301,7 +301,7 @@ class LocalClientOIDTests(AbstractStateCacheTests):
 
     def test_set_and_get_object_too_large(self):
         c = self._makeOne(cache_local_compression='none')
-        c[self.key] = (b'abcdefgh' * 10000, 1)
+        c[self.key] = (b'abcdefgh' * 10000, self.key_tid)
         self.assertEqual(c[self.key], None)
 
     def test_set_with_zero_space(self):

--- a/src/relstorage/cache/tests/test_lru_cffiring.py
+++ b/src/relstorage/cache/tests/test_lru_cffiring.py
@@ -200,29 +200,6 @@ class GenericLRUCacheTests(TestCase):
         self.assertIsNone(cache[(1, 0)])
         self.assertEqual(list(cache), [])
 
-    def test_get_backup_not_found(self):
-        c = self._makeOne(100)
-        r = c.get_from_key_or_backup_key((1, 0), None)
-        self.assertIsNone(r)
-
-    def test_get_backup_at_pref(self):
-        c = self._makeOne(100)
-        c[(1, 0)] = (b'1', 0)
-        c[(1, 1)] = (b'2', 0)
-
-        result = c.get_from_key_or_backup_key((1, 0), None)
-        self.assertEqual(result, (b'1', 0))
-
-    def test_get_backup_at_backup(self):
-        c = self._makeOne(100)
-        c[(1, 1)] = (b'2', 0)
-
-        result = c.get_from_key_or_backup_key((1, 0), (1, 1))
-        self.assertEqual(result, (b'2', 0))
-        self.assertEqual(len(c), 1)
-        self.assertIn((1, 0), c)
-        self.assertNotIn((1, 1), c)
-
     def test_entries(self):
         cache = self._makeOne(20)
         cache[(1, 0)] = (b'abc', 0)


### PR DESCRIPTION
Through bulk calls that avoid shuffling MRU status when not needed.