### PR TITLE
Get Oracle tests passing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@
   must deploy ZEO, even if all processes are on a single machine. See
   :pr:`362`.
 
+- Fix and test Oracle. The minimum required cx_oracle is now 6.0.
+
 3.0a12 (2019-10-09)
 ===================
 

--- a/docs/db-specific-options.rst
+++ b/docs/db-specific-options.rst
@@ -238,6 +238,9 @@ driver
     Other than "auto" the only supported value is "cx_Oracle".
 
     .. caution::
+        (This is a historical note. Only version 6.0 and above of
+        cx_Oracle is supported in RelStorage 3.)
+
         If you use cx_Oracle 5.2.1 or 5.3 (in general, any version >=
         5.2 but < 6.0) you must be sure that it is compiled against a
         version of the Oracle client that is compatible with the

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ module; no extra library is required. The underlying SQLite database
 must be at least version 3.8.3.
 
 On CPython2, install psycopg2 2.8+, mysqlclient 1.4+, or cx_Oracle
-5.2+ (but use caution with 5.2.1+); PyMySQL 0.7, MySQL
+6.0+; PyMySQL 0.7, MySQL
 Connector/Python 8.0.16 is also tested to work as is pg8000.
 
 .. note:: umysql support was removed in RelStorage 3.0. Use 'gevent

--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,13 @@ setup(
             'psycopg2cffi >= 2.8.1',
         ],
         'oracle': [
-            'cx_Oracle>=5.0.0'
+            # 5.2 added support for LOBs larger than 4GB.
+            # 6.0 lets lobs be used across DB fetches, uses
+            # temp lob caching.
+            # 6.2 lets lobs be bound directly to a cursor, and
+            # 7.0 lets lobs be set directly from bytes, without an intermediate
+            # temporary lob.
+            'cx_Oracle>=6.0'
         ],
         'memcache': memcache_require,
         'test': tests_require,

--- a/src/relstorage/adapters/batch.py
+++ b/src/relstorage/adapters/batch.py
@@ -118,7 +118,8 @@ class RowBatcher(object):
         Handles a query of the ``WHERE col IN (?, ?,)`` type.
 
         The keyword arguments should be of length 1, containing
-        an iterable of the values to check.
+        an iterable of the values to check: ``col=(1, 2)`` or
+        in the dynamic case ``**{indirect_var: [1, 2]}``.
 
         Returns a iterator of matching rows.
         """
@@ -185,10 +186,13 @@ class RowBatcher(object):
         params = list(itertools.chain.from_iterable(params))
         return params
 
+    def _make_placeholder_list_of_length(self, count):
+        return ','.join([self.delete_placeholder] * count)
+
     def _make_single_column_query(self, command, table,
                                   filter_column, filter_value,
                                   rows_need_flattened):
-        placeholder_str = ','.join([self.delete_placeholder] * len(filter_value))
+        placeholder_str = self._make_placeholder_list_of_length(len(filter_value))
         stmt = "%s FROM %s WHERE %s IN (%s)" % (
             command, table, filter_column, placeholder_str
         )

--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -236,7 +236,6 @@ class AbstractLocker(DatabaseHelpersMixin,
             # Bug in our code
             raise
         except self.lock_exceptions:
-            import traceback; traceback.print_exc()
             self.reraise_commit_lock_error(
                 cursor,
                 stmt,

--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -236,6 +236,7 @@ class AbstractLocker(DatabaseHelpersMixin,
             # Bug in our code
             raise
         except self.lock_exceptions:
+            import traceback; traceback.print_exc()
             self.reraise_commit_lock_error(
                 cursor,
                 stmt,

--- a/src/relstorage/adapters/mysql/mover.py
+++ b/src/relstorage/adapters/mysql/mover.py
@@ -162,13 +162,11 @@ class MySQLObjectMover(AbstractObjectMover):
     """
 
     # UPSERT for current_object: no need for separate update.
-    _update_current_insert_query = """
-        INSERT INTO current_object (zoid, tid)
-            SELECT zoid, tid FROM object_state
-            WHERE tid = %s
-            ORDER BY zoid
+    _update_current_insert_query = (
+        AbstractObjectMover._upsert_current_insert_base
+        + """
         ON DUPLICATE KEY UPDATE
             tid = VALUES(tid)
-    """
-
+        """
+    )
     _update_current_update_query = None

--- a/src/relstorage/adapters/mysql/packundo.py
+++ b/src/relstorage/adapters/mysql/packundo.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 
 from ..packundo import HistoryFreePackUndo
 from ..packundo import HistoryPreservingPackUndo
+from ..schema import Schema
 
 class _LockStmt(object):
     # 8.0 supports 'FOR SHARE' but before that we have
@@ -102,12 +103,14 @@ class MySQLHistoryPreservingPackUndo(_LockStmt, HistoryPreservingPackUndo):
         );
     """
 
-    _script_delete_empty_transactions_batch = """
-        DELETE FROM transaction
-        WHERE packed = %(TRUE)s
-          AND is_empty = %(TRUE)s
-        LIMIT 1000
-        """
+    # pylint:disable=singleton-comparison
+    _delete_empty_transactions_batch_query = Schema.transaction.delete(
+    ).where(
+        Schema.transaction.c.packed == True
+    ).and_(
+        Schema.transaction.c.is_empty == True
+    ).limit(1000)
+
 
 class MySQLHistoryFreePackUndo(_LockStmt, HistoryFreePackUndo):
     pass

--- a/src/relstorage/adapters/oracle/adapter.py
+++ b/src/relstorage/adapters/oracle/adapter.py
@@ -78,6 +78,9 @@ class OracleAdapter(AbstractAdapter):
         options = self.options
         dsn = self._dsn
 
+        batcher_factory = lambda cursor, row_limit=None: OracleRowBatcher(
+            cursor, inputsizes, row_limit
+        )
         self.connmanager = CXOracleConnectionManager(
             driver,
             user=user,
@@ -91,6 +94,7 @@ class OracleAdapter(AbstractAdapter):
             options=self.options,
             driver=driver,
             inputsize_NUMBER=driver.NUMBER,
+            batcher_factory=batcher_factory,
         )
         self.schema = OracleSchemaInstaller(
             connmanager=self.connmanager,
@@ -110,15 +114,13 @@ class OracleAdapter(AbstractAdapter):
             driver,
             options=options,
             runner=self.runner,
-            batcher_factory=lambda cursor, row_limit: OracleRowBatcher(
-                cursor, inputsizes, row_limit),
+            batcher_factory=batcher_factory,
         )
         self.mover.inputsizes = inputsizes
         self.connmanager.add_on_store_opened(self.mover.on_store_opened)
         self.oidallocator = OracleOIDAllocator(
             connmanager=self.connmanager,
         )
-
 
         self.poller = Poller(
             self.driver,

--- a/src/relstorage/adapters/oracle/batch.py
+++ b/src/relstorage/adapters/oracle/batch.py
@@ -32,6 +32,11 @@ class OracleRowBatcher(RowBatcher):
     Expects :name parameters and a dictionary for each row.
     """
 
+    insert_placeholder = delete_placeholder = ':1'
+
+    # ORA-01795: maximum number of expressions in a list is 1000
+    row_limit = 999
+
     def __init__(self, cursor, inputsizes, row_limit=None):
         super(OracleRowBatcher, self).__init__(cursor, row_limit)
         self.inputsizes = inputsizes
@@ -110,3 +115,10 @@ class OracleRowBatcher(RowBatcher):
             for i, column in enumerate(zip(*r)):
                 params.append(self.cursor.arrayvar(datatypes[i], list(column)))
             self.cursor.execute(operation, tuple(params))
+
+    # TODO: Can we override _make_single_column_query() to pass
+    # an array to the database for use in a sql statement?
+    # We'd need the TABLE operator, probably. How far back is that supported?
+
+    def _make_placeholder_list_of_length(self, count):
+        return ','.join((':%d' % i for i in range(count)))

--- a/src/relstorage/adapters/oracle/drivers.py
+++ b/src/relstorage/adapters/oracle/drivers.py
@@ -52,16 +52,13 @@ class cx_OracleDriver(AbstractModuleDriver):
         self.DatabaseError = cx_Oracle.DatabaseError
         self.NUMBER = cx_Oracle.NUMBER
         self.BLOB = cx_Oracle.BLOB
+        self.CLOB = cx_Oracle.CLOB
         self.LOB = cx_Oracle.LOB
         self.LONG_BINARY = cx_Oracle.LONG_BINARY
+        self.LONG_STRING = cx_Oracle.LONG_STRING
         self.BINARY = cx_Oracle.BINARY
         self.STRING = cx_Oracle.STRING
         self.version = cx_Oracle.version
-
-    def binary_column_as_state_type(self, data):
-        # cx_Oracle likes to give us an object
-        # with .read(), look for that.
-        return self.binary_column_as_state_type(data.read())
 
 
 implement_db_driver_options(

--- a/src/relstorage/adapters/oracle/mover.py
+++ b/src/relstorage/adapters/oracle/mover.py
@@ -103,6 +103,8 @@ class OracleObjectMover(AbstractObjectMover):
         if size <= 2000:
             # Send data inline for speed.  Oracle docs say maximum size
             # of a RAW is 2000 bytes.
+            # XXX: Revisit this. cx_Oracle docs suggest that blobs up to 1GB can
+            # be sent inline very fast.
             if self.keep_history:
                 stmt = "BEGIN relstorage_op.restore(:1, :2, :3, :4); END;"
                 batcher.add_array_op(

--- a/src/relstorage/adapters/oracle/schema.py
+++ b/src/relstorage/adapters/oracle/schema.py
@@ -246,39 +246,6 @@ class OracleSchemaInstaller(AbstractSchemaInstaller):
         """
         self.runner.run_script(cursor, stmt)
 
-    # def _create_object_state(self, cursor):
-    #     if self.keep_history:
-    #         stmt = """
-    #         CREATE TABLE object_state (
-    #             zoid        NUMBER(20) NOT NULL,
-    #             tid         NUMBER(20) NOT NULL REFERENCES transaction,
-    #                         PRIMARY KEY (zoid, tid),
-    #                         CONSTRAINT tid_min CHECK (tid > 0),
-    #             prev_tid    NUMBER(20) NOT NULL REFERENCES transaction,
-    #             md5         CHAR(32),
-    #             state_size  NUMBER(20) NOT NULL,
-    #                         CONSTRAINT state_size_min CHECK (state_size >= 0),
-    #             state       BLOB
-    #         );
-    #         CREATE INDEX object_state_tid ON object_state (tid);
-    #         CREATE INDEX object_state_prev_tid ON object_state (prev_tid);
-
-    #         """
-    #     else:
-    #         stmt = """
-    #         CREATE TABLE object_state (
-    #             zoid        NUMBER(20) NOT NULL PRIMARY KEY,
-    #             tid         NUMBER(20) NOT NULL,
-    #                         CONSTRAINT tid_min CHECK (tid > 0),
-    #             state_size  NUMBER(20) NOT NULL,
-    #                         CONSTRAINT state_size_min CHECK (state_size >= 0),
-    #             state       BLOB
-    #         );
-    #         CREATE INDEX object_state_tid ON object_state (tid);
-    #         """
-
-    #     self.runner.run_script(cursor, stmt)
-
     def _create_blob_chunk(self, cursor):
         if self.keep_history:
             stmt = """
@@ -312,19 +279,6 @@ class OracleSchemaInstaller(AbstractSchemaInstaller):
             """
 
         self.runner.run_script(cursor, stmt)
-
-
-    # def _create_pack_object(self, cursor):
-    #     stmt = """
-    #     CREATE TABLE pack_object (
-    #         zoid        NUMBER(20) NOT NULL PRIMARY KEY,
-    #         keep        CHAR NOT NULL CHECK (keep IN ('N', 'Y')),
-    #         keep_tid    NUMBER(20) NOT NULL,
-    #         visited     CHAR DEFAULT 'N' NOT NULL CHECK (visited IN ('N', 'Y'))
-    #     );
-    #     CREATE INDEX pack_object_keep_zoid ON pack_object (keep, zoid);
-    #     """
-    #     self.runner.run_script(cursor, stmt)
 
     def _create_pack_state(self, cursor):
         if self.keep_history:

--- a/src/relstorage/adapters/postgresql/mover.py
+++ b/src/relstorage/adapters/postgresql/mover.py
@@ -38,14 +38,13 @@ class PostgreSQLObjectMover(AbstractObjectMover):
             state = excluded.state
     """
 
-    _update_current_insert_query = """
-        INSERT INTO current_object (zoid, tid)
-            SELECT zoid, tid FROM object_state
-            WHERE tid = %s
-            ORDER BY zoid
+    _update_current_insert_query = (
+        AbstractObjectMover._upsert_current_insert_base
+        + """
         ON CONFLICT (zoid) DO UPDATE SET
             tid = excluded.tid
-    """
+        """
+    )
     _update_current_update_query = None
 
 

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -536,7 +536,8 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         object.
         """
         self._create_pack_object_query.execute(cursor)
-        self.runner.run_script_stmt(cursor, self.CREATE_PACK_OBJECT_IX_TMPL)
+        # Some databases (pg) have multiple statements
+        self.runner.run_script(cursor, self.CREATE_PACK_OBJECT_IX_TMPL)
 
     CREATE_PACK_STATE_TMPL = """
     CREATE TABLE pack_state (

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -137,9 +137,22 @@ class Schema(object):
         Column('tid', TID)
     )
 
+    pack_object = Table(
+        'pack_object',
+        Column('zoid', OID, primary_key=True),
+        Column('keep', Boolean, nullable=False),
+        Column('keep_tid', TID, nullable=False),
+        Column('visited', Boolean, nullable=False, default=False)
+    )
+
 
 class AbstractSchemaInstaller(DatabaseHelpersMixin,
                               ABC):
+
+    # Names of schema objects: Wherever we write them, they should be
+    # in lower case, even if the database internally changes the case.
+    # (In general, they should be written to match the output of
+    # :meth:`_normalize_schema_object_names`.)
 
     # Keep this list in the same order as the schema scripts,
     # for dependency (Foreign Key) purposes.
@@ -153,7 +166,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         'commit_row_lock',
         'pack_lock',
         'transaction',
-        'new_oid',
+        'new_oid', # If you use a sequence, remove this
         'object_state',
         'blob_chunk',
         'current_object',
@@ -167,6 +180,8 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         'temp_pack_visit',
         'temp_undo',
     )
+
+    all_sequences = ()
 
     # Tables that might exist, but which are unused and obsolete.
     # These can/should be dropped, and names shouldn't be reused.
@@ -197,6 +212,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
             blob_chunk_num_type=self.COLTYPE_BLOB_CHUNK_NUM,
             md5_type=self.COLTYPE_MD5,
             state_type=self.COLTYPE_STATE,
+            state_size_type=self.COLTYPE_STATE_SIZE,
             transactional_suffix=self.TRANSACTIONAL_TABLE_SUFFIX,
         )
 
@@ -310,6 +326,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
     #: Our default is appropriate for PostgreSQL.
     COLTYPE_BINARY_STRING = 'BYTEA'
     COLTYPE_STATE = COLTYPE_BINARY_STRING
+    COLTYPE_STATE_SIZE = 'BIGINT'
     #: The type of the column used to number blob chunks.
     COLTYPE_BLOB_CHUNK_NUM = 'BIGINT'
     #: The type of the column used to store blob chunks.
@@ -332,16 +349,6 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         """
         self._create_transaction_query.execute(cursor)
 
-    @abc.abstractmethod
-    def _create_new_oid(self, cursor):
-        """
-        Create the incrementing sequence for new OIDs.
-
-        This should be the same for history free and preserving
-        schemas.
-        """
-        raise NotImplementedError()
-
     # NOTE: Prior to MySQL 8.0.16, CHECK constraints
     # are ignored at creation time and dropped. Thus if you upgrade
     # an existing 5.7 schema to 8, constraints will not be enforced,
@@ -357,7 +364,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
             prev_tid    {tid_type} NOT NULL
                            REFERENCES "transaction",
             md5         {md5_type},
-            state_size  BIGINT NOT NULL,
+            state_size  {state_size_type} NOT NULL,
             state       {state_type},
             CONSTRAINT object_state_pk
                 PRIMARY KEY (zoid, tid),
@@ -371,7 +378,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         CREATE TABLE object_state (
             zoid        {oid_type} NOT NULL PRIMARY KEY,
             tid         {tid_type} NOT NULL,
-            state_size  BIGINT NOT NULL,
+            state_size  {state_size_type} NOT NULL,
             state       {state_type} NOT NULL,
             CHECK (tid > 0),
             CHECK (state_size >= 0)
@@ -513,19 +520,13 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         """
         self.runner.run_script(cursor, self.CREATE_OBJECT_REFS_ADDED_TMPL)
 
-    CREATE_PACK_OBJECT_TMPL = """
-    CREATE TABLE pack_object (
-        zoid        {oid_type} NOT NULL PRIMARY KEY,
-        keep        BOOLEAN NOT NULL,
-        keep_tid    {oid_type} NOT NULL,
-        visited     BOOLEAN NOT NULL DEFAULT FALSE
-    ) {transactional_suffix};
+
+    # Oracle doesn't accept a line break before ON
+    CREATE_PACK_OBJECT_IX_TMPL = """
+    CREATE INDEX pack_object_keep_zoid ON pack_object (keep, zoid);
     """
 
-    CREATE_PACK_OBJECT_IX_TMPL = """
-    CREATE INDEX pack_object_keep_zoid
-    ON pack_object (keep, zoid);
-    """
+    _create_pack_object_query = Schema.pack_object.create()
 
     def _create_pack_object(self, cursor):
         """
@@ -535,10 +536,8 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         visited. The keep_tid field specifies the current revision of the
         object.
         """
-        self.runner.run_script(
-            cursor,
-            self.CREATE_PACK_OBJECT_TMPL + self.CREATE_PACK_OBJECT_IX_TMPL,
-        )
+        self._create_pack_object_query.execute(cursor)
+        self.runner.run_script_stmt(cursor, self.CREATE_PACK_OBJECT_IX_TMPL)
 
     CREATE_PACK_STATE_TMPL = """
     CREATE TABLE pack_state (
@@ -623,7 +622,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
             ).bind(self).compiled()
             stmt.execute(
                 cursor,
-                (0, 'system', 'special transaction for object creation')
+                (0, b'system', b'special transaction for object creation')
             )
 
         stmt = """
@@ -636,12 +635,24 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
     def _reset_oid(self, cursor):
         raise NotImplementedError()
 
+    def _normalize_schema_object_names(self, names):
+        return [n.lower() for n in names]
+
+    def _create_schema_objects(self, cursor, all_object_names, existing_object_names):
+        # Normalize names
+        existing_object_names = set(self._normalize_schema_object_names(existing_object_names))
+        todo = set(all_object_names) - existing_object_names
+        # Preserve order
+        todo = [t for t in all_object_names if t in todo]
+        __traceback_info__ = todo, existing_object_names, all_object_names
+        for table in todo:
+            meth = getattr(self, '_create_' + table)
+            meth(cursor)
+        return todo, existing_object_names
+
     def create_tables(self, cursor, existing_tables=()):
         """Create the database tables."""
-        for table in self.all_tables:
-            if table not in existing_tables:
-                meth = getattr(self, '_create_' + table)
-                meth(cursor)
+        _, existing_tables = self._create_schema_objects(cursor, self.all_tables, existing_tables)
 
         if self.keep_history and 'transaction' not in existing_tables:
             self._init_after_create(cursor)
@@ -658,6 +669,12 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
     def create_triggers(self, cursor):
         "Subclasses should override"
 
+    def create_sequences(self, cursor):
+        "Subclasses should override."
+        self._create_schema_objects(cursor,
+                                    self.all_sequences,
+                                    self.list_sequences(cursor))
+
     def _prepare_with_connection(self, conn, cursor): # pylint:disable=unused-argument
         # XXX: We can generalize this to handle triggers, procs, etc,
         # to make subclasses have easier time.
@@ -665,9 +682,10 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         __traceback_info__ = existing_tables
         all_tables = self.create_tables(cursor, existing_tables)
         __traceback_info__ = existing_tables, all_tables
-        if 'transaction' in existing_tables:
+        if 'transaction' in self._normalize_schema_object_names(existing_tables):
             self.update_schema(cursor, existing_tables)
 
+        self.create_sequences(cursor)
         self.create_procedures(cursor)
         self.create_triggers(cursor)
 
@@ -682,6 +700,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         self.check_compatibility(cursor, tables)
 
     def check_compatibility(self, cursor, tables): # pylint:disable=unused-argument
+        tables = self._normalize_schema_object_names(tables)
         if self.keep_history:
             if 'transaction' not in tables and 'current_object' not in tables:
                 raise StorageError(
@@ -718,18 +737,23 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         if self._needs_transaction_empty_update(cursor):
             cursor.execute(self._rename_transaction_empty_stmt)
 
+    _blank_transaction_query = Schema.transaction.select(
+        '*'
+    ).where(Schema.transaction.c.tid < 0)
+
     def _needs_transaction_empty_update(self, cursor):
         # Get a description of the table, but don't actually return
         # any rows.
         if not self.keep_history:
             return False
 
-        cursor.execute('SELECT * FROM "transaction" WHERE tid < 0')
+        self._blank_transaction_query.execute(cursor)
         columns = self._column_descriptions(cursor)
         # Make sure to read the (empty) result, some drivers (CMySQLConnector)
         # are picky about that and won't let you close a cursor without reading
         # everything.
         cursor.fetchall()
+
         for column_descr in columns:
             if column_descr.name.lower() == 'is_empty':
                 # Yay, nothing to do.
@@ -758,17 +782,22 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
 
         def zap_all(_conn, cursor):
             existent = set(self.list_tables(cursor))
-            todo = list(self.all_tables)
-            todo.reverse() # using reversed()  doesn't print nicely
-            logger.debug("Checking tables: %r", todo)
+            to_zap = {} # {normalized_name: recorded_name}
             self._before_zap_all_tables(cursor, existent, slow)
-            for table in todo:
-                logger.debug("Considering table %s", table)
-                if table.startswith('temp_'):
+            for possible_table in existent:
+                norm_table = self._normalize_schema_object_names([possible_table])[0]
+                if norm_table.startswith('temp_'):
                     continue
-                if table in existent:
-                    table_stmt = stmt % table
+                if norm_table in self.all_tables:
+                    to_zap[norm_table] = possible_table
+
+            # Do in reverse order because that's how Foreign Key
+            # constraints are set up.
+            for possible_table in reversed(self.all_tables):
+                if possible_table in to_zap:
+                    table_stmt = stmt % to_zap[possible_table]
                     logger.debug(table_stmt)
+                    __traceback_info__ = table_stmt
                     cursor.execute(table_stmt)
             logger.debug("Done deleting from tables.")
 

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -379,7 +379,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
             zoid        {oid_type} NOT NULL PRIMARY KEY,
             tid         {tid_type} NOT NULL,
             state_size  {state_size_type} NOT NULL,
-            state       {state_type} NOT NULL,
+            state       {state_type},
             CHECK (tid > 0),
             CHECK (state_size >= 0)
         ) {transactional_suffix};
@@ -521,9 +521,8 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
         self.runner.run_script(cursor, self.CREATE_OBJECT_REFS_ADDED_TMPL)
 
 
-    # Oracle doesn't accept a line break before ON
     CREATE_PACK_OBJECT_IX_TMPL = """
-    CREATE INDEX pack_object_keep_zoid ON pack_object (keep, zoid);
+    CREATE INDEX pack_object_keep_zoid ON pack_object (keep, zoid)
     """
 
     _create_pack_object_query = Schema.pack_object.create()

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -203,6 +203,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
 
     def __init__(self, connmanager, runner, keep_history):
         self.connmanager = connmanager
+        self.driver = connmanager.driver
         self.keep_history = keep_history
         self.runner = runner.with_format_vars(
             tid_type=self.COLTYPE_OID_TID,
@@ -622,7 +623,9 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
             ).bind(self).compiled()
             stmt.execute(
                 cursor,
-                (0, b'system', b'special transaction for object creation')
+                (0,
+                 self.driver.Binary(b'system'),
+                 self.driver.Binary(b'special transaction for object creation'))
             )
 
         stmt = """

--- a/src/relstorage/adapters/scriptrunner.py
+++ b/src/relstorage/adapters/scriptrunner.py
@@ -47,6 +47,7 @@ class ScriptRunner(object):
         'self_tid':     '%(self_tid)s',
         'min_tid':      '%(min_tid)s',
         'max_tid':      '%(max_tid)s',
+        'INNER_ORDER_BY': 'ORDER BY zoid',
     }
 
     format_vars = {
@@ -72,8 +73,9 @@ class ScriptRunner(object):
         """
         __traceback_info__ = generic_stmt, self.format_vars
         stmt = generic_stmt.format(**self.format_vars)
-        __traceback_info__ = stmt, self.script_vars
-        stmt = stmt % self.script_vars
+        if '%(' in stmt and ')s' in stmt:
+            __traceback_info__ = stmt, self.script_vars
+            stmt = stmt % self.script_vars
         __traceback_info__ = stmt
         try:
             cursor.execute(stmt, generic_params)

--- a/src/relstorage/adapters/sql/_util.py
+++ b/src/relstorage/adapters/sql/_util.py
@@ -56,6 +56,9 @@ class Columns(object):
             name
         ))
 
+    def has_column(self, name):
+        return hasattr(self, name)
+
     def __getitem__(self, ix):
         return self._columns[ix]
 
@@ -112,10 +115,12 @@ class Columns(object):
         """
         seen_combining = set()
         columns = []
+
         for c in self._columns + other._columns:
-            if c.name in combining and c.name not in seen_combining:
-                columns.append(c)
-                seen_combining.add(c.name)
+            if c.name in combining:
+                if c.name not in seen_combining:
+                    columns.append(c)
+                    seen_combining.add(c.name)
             else:
                 columns.append(c)
         return type(self)(columns)

--- a/src/relstorage/adapters/sql/insert.py
+++ b/src/relstorage/adapters/sql/insert.py
@@ -97,16 +97,24 @@ class Insertable(object):
 
 class Delete(Query, WhereMixin):
 
+    _limit = None
+
     def __init__(self, table):
         super(Delete, self).__init__()
         self.table = table
         self._where = None
+
+    def limit(self, literal):
+        s = copy(self)
+        s._limit = literal
+        return s
 
     def __compile_visit__(self, compiler):
         compiler.emit_keyword('DELETE FROM')
         compiler.visit(self.table)
         if self._where:
             compiler.visit(self._where)
+        compiler.visit_limit(self._limit)
 
 class Truncate(Query):
 

--- a/src/relstorage/adapters/sql/query.py
+++ b/src/relstorage/adapters/sql/query.py
@@ -17,13 +17,12 @@ from .dialect import DialectAware
 
 from .expressions import ParamMixin
 from .expressions import And
+from .expressions import EmptyExpression
 
 class Clause(DialectAware):
     """
     A portion of a SQL statement.
     """
-
-
 
 class ColumnList(Columns):
     """
@@ -45,8 +44,9 @@ class WhereClause(Clause):
         return new
 
     def __compile_visit__(self, compiler):
-        compiler.emit_keyword(' WHERE')
-        compiler.visit_grouped(self.expression)
+        compiler.emit_keyword('WHERE')
+        #compiler.visit_grouped(self.expression)
+        compiler.visit(self.expression)
 
 class OrderBy(Clause):
 
@@ -55,7 +55,7 @@ class OrderBy(Clause):
         self.dir = dir
 
     def __compile_visit__(self, compiler):
-        compiler.emit(' ORDER BY ')
+        compiler.emit_keyword('ORDER BY')
         compiler.visit(self.expression)
         if self.dir:
             compiler.emit(' ' + self.dir)
@@ -65,6 +65,20 @@ def where(expression):
     if expression:
         return WhereClause(expression)
 
+class WhereMixin(object):
+    _where = EmptyExpression()
+
+    def where(self, expression):
+        expression = expression.resolve_against(self.table)
+        s = copy(self)
+        s._where = where(expression)
+        return s
+
+    def and_(self, expression):
+        expression = expression.resolve_against(self.table)
+        s = copy(self)
+        s._where = self._where.and_(expression)
+        return s
 
 class Query(ParamMixin,
             Clause):

--- a/src/relstorage/adapters/sql/query.py
+++ b/src/relstorage/adapters/sql/query.py
@@ -45,8 +45,8 @@ class WhereClause(Clause):
 
     def __compile_visit__(self, compiler):
         compiler.emit_keyword('WHERE')
-        #compiler.visit_grouped(self.expression)
-        compiler.visit(self.expression)
+        compiler.visit_grouped(self.expression)
+
 
 class OrderBy(Clause):
 

--- a/src/relstorage/tests/blob/blob_packing.py
+++ b/src/relstorage/tests/blob/blob_packing.py
@@ -121,7 +121,6 @@ class TestBlobPackHistoryPreservingMixin(TestBlobMixin):
         del root['blob']
         transaction.commit()
         conn.close()
-
         self._pack_at_time_index(None, count_not_exist=5)
         self.assertFalse(os.path.exists(dir_name))
 

--- a/src/relstorage/tests/blob/blob_transaction.py
+++ b/src/relstorage/tests/blob/blob_transaction.py
@@ -63,11 +63,17 @@ class TestBlobTransactionMixin(TestBlobMixin):
         blob1 = self._make_blob()
         conn = self.database.open()
         root1 = conn.root()
+        self.assertNotIn('blob1', root1)
         root1['blob1'] = blob1
         self.assertIn('blob1', root1)
-
+        self.assertEqual(root1._p_status, 'changed')
         # Aborting a blob add leaves the blob unchanged:
+
         transaction.abort()
+        # Note that debugging with something like pudb that automatically
+        # displays local variables will invalidate this: it will already
+        # have been loaded again.
+        self.assertEqual(root1._p_status, 'ghost')
         self.assertNotIn('blob1', root1)
 
         self.assertIsNone(blob1._p_oid)

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -1168,7 +1168,8 @@ class GenericRelStorageTests(
         replica_conf = ''
         if util.DEFAULT_DATABASE_SERVER_HOST == util.STANDARD_DATABASE_SERVER_HOST:
             replica_fn = self.get_adapter_zconfig_replica_conf()
-            replica_conf = 'replica-conf ' + self.get_adapter_zconfig_replica_conf()
+            if replica_fn:
+                replica_conf = 'replica-conf ' + self.get_adapter_zconfig_replica_conf()
 
         conf = u"""
         %import relstorage

--- a/src/relstorage/tests/testoracle.py
+++ b/src/relstorage/tests/testoracle.py
@@ -23,10 +23,6 @@ from .util import AbstractTestSuiteBuilder
 
 class OracleAdapterMixin(object):
 
-    keep_history = False
-    base_dbname = None
-    driver_name = None
-
     def make_adapter(self, options, db=None):
         dsn = os.environ.get('ORACLE_TEST_DSN', 'XE')
         if db is None:
@@ -78,13 +74,14 @@ class OracleAdapterMixin(object):
         self.assertEqual(adapter._twophase, False)
 
     def get_adapter_zconfig_replica_conf(self):
-        import tempfile
-        dsn = self.__get_adapter_zconfig_dsn()
-        fd, replica_conf = tempfile.mkstemp('.conf', 'rstest_oracle_replica')
-        self.addCleanup(os.remove, replica_conf)
-        os.write(fd, dsn.encode("ascii"))
-        os.close(fd)
-        return replica_conf
+        # import tempfile
+        # dsn = self.__get_adapter_zconfig_dsn()
+        # fd, replica_conf = tempfile.mkstemp('.conf', 'rstest_oracle_replica')
+        # self.addCleanup(os.remove, replica_conf)
+        # os.write(fd, dsn.encode("ascii"))
+        # os.close(fd)
+        # return replica_conf
+        return None
 
 
 class OracleTestSuiteBuilder(AbstractTestSuiteBuilder):
@@ -100,13 +97,7 @@ class OracleTestSuiteBuilder(AbstractTestSuiteBuilder):
 
     def _compute_large_blob_size(self, use_small_blobs):
         if use_small_blobs:
-            # cx_Oracle blob support can only address up to sys.maxint on
-            # 32-bit systems, 4GB otherwise. This takes a great deal of time, however,
-            # so allow tuning it down.
-            from relstorage.adapters.oracle.mover import OracleObjectMover as ObjectMover
-            assert hasattr(ObjectMover, 'oracle_blob_chunk_maxsize')
-            ObjectMover.oracle_blob_chunk_maxsize = 1024 * 1024 * 10
-            large_blob_size = ObjectMover.oracle_blob_chunk_maxsize * 2
+            large_blob_size = 1024 * 1024 * 10
         else:
             large_blob_size = min(sys.maxsize, 1<<32)
         return large_blob_size

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -153,6 +153,7 @@ class _Availability(object):
         try:
             adapter.connmanager.open_and_call(self.__check_db_access_cb)
         except (TypeError, AttributeError):
+            import traceback; traceback.print_exc()
             raise
         except Exception as e:  # pylint:disable=broad-except
             self._available = False


### PR DESCRIPTION
Fixes #340 and fixes #361 

- Remove a fair amount of special purpose code from the oracle driver in favor of the new sql abstractions. Required some additions to the abstraction layer.
- Bump min cx_Oracle to 6.0 for better blob handling.
- Tested with same version of Oracle as RelStorage 2 was tested.