### PR TITLE
Use UPSERTs for Oracle and SQLite. And fix an exception with large tx on SQLite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 3.0b1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make SQLite and Oracle both use UPSERT queries instead of multiple
+  database round trips.
+
+- Fix an exception with large transactions on SQLite.
 
 
 3.0a13 (2019-10-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
 
 - Fix an exception with large transactions on SQLite.
 
+- Fix compiling the C extension on very new versions of Microsoft
+  Visual Studio.
 
 3.0a13 (2019-10-21)
 ===================

--- a/src/relstorage/adapters/mysql/tests/test_dialect.py
+++ b/src/relstorage/adapters/mysql/tests/test_dialect.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from ...sql.tests import test_sql
+from ..drivers import MySQLDialect
+
+class TestMySQLDialect(test_sql.TestUpsert):
+    keep_history = False
+    dialect = MySQLDialect()
+
+    insert_or_replace = (
+        'INSERT INTO object_state(zoid, state, tid, state_size) '
+        'VALUES (%s, %s, %s, %s) '
+        'ON DUPLICATE KEY UPDATE '
+        'state = VALUES(state), tid = VALUES(tid), '
+        'state_size = VALUES(state_size)'
+    )
+
+    insert_or_replace_subquery = (
+        'INSERT INTO object_state(zoid, tid, state, state_size) '
+        'SELECT zoid, %s, state, COALESCE(LENGTH(state), 0) FROM temp_store '
+        'ORDER BY zoid '
+        'ON DUPLICATE KEY UPDATE '
+        'state = VALUES(state), tid = VALUES(tid), '
+        'state_size = VALUES(state_size)'
+    )
+
+    upsert_unconstrained_subquery = (
+        'INSERT INTO object_state(zoid, tid, state, state_size) '
+        'SELECT zoid, %s, state, COALESCE(LENGTH(state), 0) FROM temp_store '
+        'ON DUPLICATE KEY UPDATE state = VALUES(state), '
+        'tid = VALUES(tid), state_size = VALUES(state_size)'
+    )

--- a/src/relstorage/adapters/oracle/dialect.py
+++ b/src/relstorage/adapters/oracle/dialect.py
@@ -93,7 +93,6 @@ class OracleCompiler(Compiler):
         self.emit_keyword('WHEN NOT MATCHED THEN INSERT')
         self.visit_grouped(upsert.column_list)
         self.emit_keyword('VALUES')
-        # XXX: If the subquery has expression, they need to be given aliases.
         excluded_columns = Columns(_ExcludedColumn(c.name) for c in upsert.column_list)
         self.visit_grouped(excluded_columns)
 

--- a/src/relstorage/adapters/oracle/mover.py
+++ b/src/relstorage/adapters/oracle/mover.py
@@ -23,7 +23,6 @@ from zope.interface import implementer
 from ..interfaces import IObjectMover
 from ..mover import AbstractObjectMover
 from ..mover import metricmethod_sampled
-from ..sql._util import copy
 
 
 @implementer(IObjectMover)
@@ -58,8 +57,15 @@ class OracleObjectMover(AbstractObjectMover):
         pass
 
     @metricmethod_sampled
-    def store_temp(self, cursor, batcher, oid, prev_tid, data):
-        """Store an object in the temporary table."""
+    def store_temps(self, cursor, state_oid_tid_iter):
+        batcher = self.make_batcher(cursor) # Default row limit
+        store_temp = self._store_temp
+        for data, oid_int, tid_int in state_oid_tid_iter:
+            store_temp(batcher, oid_int, tid_int, data)
+        batcher.flush()
+
+    @metricmethod_sampled
+    def _store_temp(self, batcher, oid, prev_tid, data):
         md5sum = self._compute_md5sum(data)
 
         size = len(data)
@@ -188,10 +194,10 @@ class OracleObjectMover(AbstractObjectMover):
 
     # Oracle doesn't like 'ORDER BY' in a sub-select used in the IN clause.
     # It gives a confusing syntax error about missing a right paren.
-    _update_current_update_query = copy(AbstractObjectMover._update_current_update_query)
-    sub_select = _update_current_update_query._where.expression.rhs
-    _update_current_update_query._where.expression.rhs = sub_select.unordered()
-    del sub_select
+    # _update_current_update_query = copy(AbstractObjectMover._update_current_update_query)
+    # sub_select = _update_current_update_query._where.expression.rhs
+    # _update_current_update_query._where.expression.rhs = sub_select.unordered()
+    # del sub_select
 
     @metricmethod_sampled
     def download_blob(self, cursor, oid, tid, filename):

--- a/src/relstorage/adapters/oracle/mover.py
+++ b/src/relstorage/adapters/oracle/mover.py
@@ -58,11 +58,12 @@ class OracleObjectMover(AbstractObjectMover):
 
     @metricmethod_sampled
     def store_temps(self, cursor, state_oid_tid_iter):
-        batcher = self.make_batcher(cursor) # Default row limit
         store_temp = self._store_temp
+        batcher = self.make_batcher(cursor) # Default row limit
         for data, oid_int, tid_int in state_oid_tid_iter:
             store_temp(batcher, oid_int, tid_int, data)
         batcher.flush()
+
 
     @metricmethod_sampled
     def _store_temp(self, batcher, oid, prev_tid, data):
@@ -170,34 +171,6 @@ class OracleObjectMover(AbstractObjectMover):
                         rowkey=oid,
                         size=size,
                     )
-
-    @metricmethod_sampled
-    def replace_temp(self, cursor, oid, prev_tid, data):
-        """Replace an object in the temporary table.
-
-        This happens after conflict resolution.
-        """
-        md5sum = self._compute_md5sum(data)
-
-        stmt = """
-        UPDATE temp_store SET
-            prev_tid = :prev_tid,
-            md5 = :md5sum,
-            state = :blobdata
-        WHERE zoid = :oid
-        """
-        cursor.setinputsizes(blobdata=self.inputsizes['blobdata']) # pylint:disable=unsubscriptable-object
-        cursor.execute(stmt, oid=oid, prev_tid=prev_tid,
-                       md5sum=md5sum, blobdata=self.driver.Binary(data))
-
-
-
-    # Oracle doesn't like 'ORDER BY' in a sub-select used in the IN clause.
-    # It gives a confusing syntax error about missing a right paren.
-    # _update_current_update_query = copy(AbstractObjectMover._update_current_update_query)
-    # sub_select = _update_current_update_query._where.expression.rhs
-    # _update_current_update_query._where.expression.rhs = sub_select.unordered()
-    # del sub_select
 
     @metricmethod_sampled
     def download_blob(self, cursor, oid, tid, filename):

--- a/src/relstorage/adapters/postgresql/tests/test_mover.py
+++ b/src/relstorage/adapters/postgresql/tests/test_mover.py
@@ -94,7 +94,7 @@ class TestPostgreSQLObjectMover(TestCase):
     def test_prep_statements_hf(self):
         inst = self._makeOne(keep_history=False)
         self.assertTrue(
-            str(inst._move_from_temp_hf_insert_query).startswith(
+            str(inst._move_from_temp_hf_upsert_query).startswith(
                 'EXECUTE rs_prep_stmt'
             )
         )

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -39,6 +39,9 @@ from .sql import State
 from .sql import Boolean
 from .sql import BinaryString
 from .sql import Char
+from .sql import ColumnExpression
+
+StateSize = OID
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -58,7 +61,7 @@ class Schema(object):
         Column('zoid', OID),
         Column('tid', TID),
         Column('state', State),
-        Column('state_size'),
+        Column('state_size', StateSize),
         # These two only exist in history preserving.
         # TODO: Wrap this in a HistoryVariantTable
         Column('prev_tid', TID),
@@ -741,7 +744,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
             cursor.execute(self._rename_transaction_empty_stmt)
 
     _blank_transaction_query = Schema.transaction.select(
-        '*'
+        ColumnExpression('*')
     ).where(Schema.transaction.c.tid < 0)
 
     def _needs_transaction_empty_update(self, cursor):

--- a/src/relstorage/adapters/sql/__init__.py
+++ b/src/relstorage/adapters/sql/__init__.py
@@ -45,6 +45,7 @@ from .schema import TemporaryTable
 from .schema import HistoryVariantTable
 from .schema import Column
 from .schema import ColumnResolvingProxy
+from .schema import ColumnExpression
 
 from .dialect import DefaultDialect
 from .dialect import Compiler

--- a/src/relstorage/adapters/sql/_util.py
+++ b/src/relstorage/adapters/sql/_util.py
@@ -39,7 +39,12 @@ class Columns(object):
     def __init__(self, columns):
         cs = []
         for c in columns:
-            setattr(self, c.name, c)
+            try:
+                col_name = c.alias or c.name
+            except AttributeError:
+                pass
+            else:
+                setattr(self, col_name, c)
             cs.append(c)
         self._columns = tuple(cs)
 
@@ -58,6 +63,12 @@ class Columns(object):
 
     def has_column(self, name):
         return hasattr(self, name)
+
+    def __contains__(self, column):
+        return column in self._columns
+
+    def is_subset(self, other):
+        return all(c in other for c in self)
 
     def __getitem__(self, ix):
         return self._columns[ix]

--- a/src/relstorage/adapters/sql/ast.py
+++ b/src/relstorage/adapters/sql/ast.py
@@ -21,6 +21,10 @@ class LiteralNode(Resolvable):
         self.raw = raw
         self.name = 'anon_%x' % (id(self),)
 
+    @property
+    def alias(self):
+        return self.name
+
     def __compile_visit__(self, compiler):
         compiler.emit(str(self.raw))
 

--- a/src/relstorage/adapters/sql/expressions.py
+++ b/src/relstorage/adapters/sql/expressions.py
@@ -74,6 +74,7 @@ class OrderedBindParam(Expression):
     def __compile_visit__(self, compiler):
         compiler.visit_ordered_bind_param(self)
 
+
 @implementer(IOrderedBindParam)
 def orderedbindparam():
     return OrderedBindParam()

--- a/src/relstorage/adapters/sql/insert.py
+++ b/src/relstorage/adapters/sql/insert.py
@@ -38,9 +38,6 @@ class Insert(Query):
 
         if columns:
             self.column_list = ColumnList(resolved_against(columns, table))
-            # TODO: Probably want a different type, like a ValuesList
-            #self.values = ColumnList([self.orderedbindparam() for _ in columns])
-#            self.values = [self.orderedbindparam() for _ in columns]
 
     def from_select(self, names, select):
         i = copy(self)
@@ -92,7 +89,6 @@ class Insert(Query):
                 if IOrderedBindParam.providedBy(source)
             ]
             return dialect.datatypes_for_columns(columns_with_params)
-
 
 
 class _ExcludedColumn(Expression):

--- a/src/relstorage/adapters/sql/insert.py
+++ b/src/relstorage/adapters/sql/insert.py
@@ -18,6 +18,11 @@ from .interfaces import ITypedParams
 from .interfaces import IOrderedBindParam
 from .query import WhereMixin
 from .expressions import AssignmentExpression
+from .expressions import EmptyExpression
+from .expressions import Expression
+
+class _ValuesPlaceholderList(ColumnList):
+    pass
 
 @implementer(ITypedParams)
 class Insert(Query):
@@ -25,55 +30,57 @@ class Insert(Query):
     column_list = None
     select = None
     epilogue = ''
-    values = None
+#    values = None
 
     def __init__(self, table, *columns):
         super(Insert, self).__init__()
         self.table = table
+
         if columns:
             self.column_list = ColumnList(resolved_against(columns, table))
             # TODO: Probably want a different type, like a ValuesList
-            self.values = ColumnList([self.orderedbindparam() for _ in columns])
+            #self.values = ColumnList([self.orderedbindparam() for _ in columns])
+#            self.values = [self.orderedbindparam() for _ in columns]
 
     def from_select(self, names, select):
         i = copy(self)
-        i.column_list = ColumnList(names)
+        i.column_list = ColumnList(resolved_against(names, select))
         i.select = select
         return i
 
+    def _visit_command(self, compiler):
+        compiler.emit_keyword_insert_into()
+
+    def _visit_select(self, compiler):
+        compiler.visit(self.select)
+
     def __compile_visit__(self, compiler):
-        compiler.emit_keyword('INSERT INTO')
+        self._visit_command(compiler)
         compiler.visit(self.table)
         if self.column_list:
             compiler.visit_grouped(self.column_list)
         if self.select:
-            compiler.visit(self.select)
+            self._visit_select(compiler)
         else:
             compiler.emit_keyword('VALUES')
-            if self.values:
-                compiler.visit_grouped(self.values)
+            if self.column_list:
+                values = _ValuesPlaceholderList([self.orderedbindparam()
+                                                 for _ in self.column_list])
+                compiler.visit_grouped(values)
             else:
                 compiler.visit_no_values()
         compiler.emit(self.epilogue)
 
-    def __add__(self, extension):
-        # This appends a textual epilogue. It's a temporary
-        # measure until we have more nodes and can model what
-        # we're trying to accomplish.
-        assert isinstance(extension, str)
-        i = copy(self)
-        i.epilogue += extension
-        return i
-
     def datatypes_for_parameters(self):
         dialect = self.dialect
-        if self.values and self.column_list:
+        if self.column_list and not self.select:
             # If we're sending in a list of values, those have to
             # exactly match the columns, so we can easily get a list
             # of datatypes.
             column_list = self.column_list
-            datatypes = dialect.datatypes_for_columns(column_list)
-        elif self.select and self.select.column_list.has_bind_param():
+            return dialect.datatypes_for_columns(column_list)
+
+        if self.select and self.select.column_list.has_bind_param():
             targets = self.column_list
             sources = self.select.column_list
             # TODO: This doesn't support bind params anywhere except the
@@ -84,10 +91,76 @@ class Insert(Query):
                 for target, source in zip(targets, sources)
                 if IOrderedBindParam.providedBy(source)
             ]
-            datatypes = dialect.datatypes_for_columns(columns_with_params)
-        return datatypes
+            return dialect.datatypes_for_columns(columns_with_params)
 
 
+
+class _ExcludedColumn(Expression):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __compile_visit__(self, compiler): # pragma: no cover
+        raise AssertionError("Should only be used in upsert")
+
+    def __compile_visit_for_upsert__(self, compiler):
+        compiler.visit_upsert_excluded_column(self)
+
+class Upsert(Insert):
+    """
+    Perform an insert-or-update operation.
+
+    All supported databases have some version of this,
+    but not all of them have the same expressive power. This
+    interface is limited to the lowest common denominator.
+
+    You must call ``on_conflict()`` and ``do_update()``.
+    The on_conflict parameter must be a single column of the
+    primary key, though this isn't verified. ``do_update``
+    should be called to specify a subset of the columns in the
+    insert list to be updated; they will have the same values as the insert
+    list. Note that some databases may update all columns.
+    """
+
+    conflict_column = None
+    update_columns = None
+
+    def on_conflict(self, exp):
+        i = copy(self)
+        i.conflict_column = exp
+        return i
+
+    def do_update(self, *columns):
+        update_columns = ColumnList(resolved_against(columns, self.table))
+        assert update_columns.is_subset(self.column_list)
+        i = copy(self)
+        i.update_columns = update_columns
+        return i
+
+    @property
+    def update_clause(self):
+        return Update(EmptyExpression(), [
+            AssignmentExpression(col, _ExcludedColumn(col.name))
+            for col in self.update_columns
+        ])
+
+    def _visit_command(self, compiler):
+        compiler.emit_keyword_upsert()
+
+    def _visit_select(self, compiler):
+        super(Upsert, self)._visit_select(compiler)
+        compiler.visit_upsert_after_select(self.select)
+
+    def __compile_visit__(self, compiler):
+        assert self.conflict_column, "Didn't call on_conflict"
+        assert self.update_columns, "Didn't call do_update"
+        with compiler.visiting_upsert(self) as upsert_compiler:
+            upsert_compiler.visit_upsert(self)
+
+    def __compile_visit_for_upsert__(self, compiler):
+        super(Upsert, self).__compile_visit__(compiler)
+        compiler.visit_upsert_conflict_column(self.conflict_column)
+        compiler.visit_upsert_conflict_update(self.update_clause)
 
 class Insertable(object):
 
@@ -162,3 +235,9 @@ class Update(Query, WhereMixin):
         compiler.emit_keyword('SET')
         compiler.visit_csv(self.col_expressions)
         compiler.visit(self._where)
+
+
+class Upsertable(object):
+
+    def upsert(self, *columns):
+        return Upsert(self, *columns)

--- a/src/relstorage/adapters/sql/query.py
+++ b/src/relstorage/adapters/sql/query.py
@@ -99,8 +99,9 @@ class Query(ParamMixin,
         # does the job perfectly. In earlier versions, we're on our
         # own.
         #
-        # TODO: In test cases, we spend a lot of time binding and compiling.
-        # Can we find another layer of caching somewhere?
+        # TODO: In test cases, we spend a lot of time binding and
+        # compiling. Can we find another layer of caching somewhere?
+        # The dialect object would probably work.
 
         if not self.__name__:
             # Go through the class hierarchy, find out what we're called.
@@ -227,3 +228,6 @@ class CompiledQuery(object):
             cursor.execute(stmt, self.params)
         else:
             cursor.execute(stmt)
+
+    def executemany(self, cursor, paramlist):
+        return cursor.executemany(self.stmt, paramlist)

--- a/src/relstorage/adapters/sql/select.py
+++ b/src/relstorage/adapters/sql/select.py
@@ -18,6 +18,7 @@ from .ast import TextNode
 from .ast import resolved_against
 from .expressions import EmptyExpression
 
+
 class _SelectColumns(ColumnList):
 
     def __compile_visit__(self, compiler):
@@ -52,6 +53,7 @@ class Select(Query,
             self.column_list = _SelectColumns(resolved_against(columns, table))
         else:
             self.column_list = table
+        self.c = self.column_list
 
     def order_by(self, expression, dir=None):
         expression = expression.resolve_against(self.table)
@@ -85,6 +87,10 @@ class Select(Query,
         s = copy(self)
         s._distinct = TextNode('DISTINCT')
         return s
+
+    def is_unconstrained(self):
+        "Does this query have nothing after the basic table?"
+        return not self._order_by and not self._where
 
     def __compile_visit__(self, compiler):
         with compiler.visit_limited_select(self, self._limit):

--- a/src/relstorage/adapters/sqlite/dialect.py
+++ b/src/relstorage/adapters/sqlite/dialect.py
@@ -109,7 +109,7 @@ class _Sqlite3NoUpsertCompiler(_Sqlite3UpsertCompiler):
     # rows.
 
     def emit_keyword_upsert(self):
-        self.emit_keyword("INSERT OR REPLACE")
+        self.emit_keyword("INSERT OR REPLACE INTO")
 
     def visit_upsert_conflict_column(self, column):
         pass
@@ -119,6 +119,9 @@ class _Sqlite3NoUpsertCompiler(_Sqlite3UpsertCompiler):
 
     def visit_upsert_excluded_column(self, column):
         pass
+
+    def visit_upsert_after_select(self, select):
+        "No need to do anything"
 
 SqliteCompiler = _Sqlite3UpsertCompiler if SQ3_SUPPORTS_UPSERT else _Sqlite3NoUpsertCompiler
 

--- a/src/relstorage/adapters/sqlite/dialect.py
+++ b/src/relstorage/adapters/sqlite/dialect.py
@@ -55,25 +55,11 @@ SQ3_SUPPORTS_UPSERT = sq3_version >= (3, 24) # 2018-06-04
 SQ3_SUPPORTS_WINDOW = sq3_version >= (3, 25) # 2018-09-15
 
 
-class Sqlite3Dialect(DefaultDialect):
-    datatype_map = {
-        OID: 'INTEGER',
-        TID: 'INTEGER',
-        BinaryString: 'BLOB',
-        State: 'BLOB',
-        Boolean: 'INTEGER',
-    }
 
-    STMT_TRUNCATE = 'DELETE FROM'
-    STMT_IF_NOT_EXISTS = 'IF NOT EXISTS'
+class _Sqlite3UpsertCompiler(DefaultCompiler):
+    # We inherit (most of) the default upsert syntax (sqlite matches postgres
+    # in that area).
 
-    CONSTRAINT_AUTO_INCREMENT = 'AUTOINCREMENT'
-
-    def compiler_class(self):
-        return Sqlite3Compiler
-
-
-class Sqlite3Compiler(DefaultCompiler):
     def can_prepare(self):
         # sqlite3 has no notion of prepared statements.
         return False
@@ -82,7 +68,7 @@ class Sqlite3Compiler(DefaultCompiler):
         if identifier == "transaction":
             # Sigh. This has to be quoted for some reason.
             quoted = True
-        super(Sqlite3Compiler, self).emit_identifier(identifier, quoted)
+        super(_Sqlite3UpsertCompiler, self).emit_identifier(identifier, quoted)
 
     if not SQ3_SUPPORTS_BOOL_KW:
         def visit_boolean_literal_expression(self, value):
@@ -103,3 +89,52 @@ class Sqlite3Compiler(DefaultCompiler):
         # But sqlite doesn't like (), there must be at least one
         # column
         self.emit("(NULL)")
+
+    def visit_upsert_after_select(self, select):
+        if select.is_unconstrained():
+            # "The parser might not be able to tell if the "ON" keyword is
+            # introducing the UPSERT or if it is the ON clause of a join.
+            # To work around this, the SELECT statement should always
+            # include a WHERE clause, even if that WHERE clause is just
+            # ``WHERE true``."
+            self.emit(' WHERE true ')
+
+class _Sqlite3NoUpsertCompiler(_Sqlite3UpsertCompiler):
+    # we have to disable the upsert syntax, we're limited to the old
+    # syntax. The old 'INSERT OR REPLACE' syntax is supported from
+    # 3.0.0 forward. It's not as flexible as the true upsert: for
+    # example, you can't specify the type of conflict, nor can you use
+    # a WHERE clause or specify the values to use in the update. It
+    # also doesn't increment the cursor's change counter for replaced
+    # rows.
+
+    def emit_keyword_upsert(self):
+        self.emit_keyword("INSERT OR REPLACE")
+
+    def visit_upsert_conflict_column(self, column):
+        pass
+
+    def visit_upsert_conflict_update(self, update):
+        pass
+
+    def visit_upsert_excluded_column(self, column):
+        pass
+
+SqliteCompiler = _Sqlite3UpsertCompiler if SQ3_SUPPORTS_UPSERT else _Sqlite3NoUpsertCompiler
+
+class Sqlite3Dialect(DefaultDialect):
+    datatype_map = {
+        OID: 'INTEGER',
+        TID: 'INTEGER',
+        BinaryString: 'BLOB',
+        State: 'BLOB',
+        Boolean: 'INTEGER',
+    }
+
+    STMT_TRUNCATE = 'DELETE FROM'
+    STMT_IF_NOT_EXISTS = 'IF NOT EXISTS'
+
+    CONSTRAINT_AUTO_INCREMENT = 'AUTOINCREMENT'
+
+    def compiler_class(self):
+        return SqliteCompiler

--- a/src/relstorage/adapters/sqlite/mover.py
+++ b/src/relstorage/adapters/sqlite/mover.py
@@ -27,6 +27,7 @@ from ..mover import metricmethod_sampled
 
 from .batch import Sqlite3RowBatcher
 
+
 @implementer(IObjectMover)
 class Sqlite3ObjectMover(AbstractObjectMover):
 
@@ -61,16 +62,6 @@ class Sqlite3ObjectMover(AbstractObjectMover):
             cursor.execute(stmt)
 
         super(Sqlite3ObjectMover, self).on_store_opened(cursor, restart)
-
-    @metricmethod_sampled
-    def store_temp(self, _cursor, batcher, oid, prev_tid, data):
-        # suffix = """
-        # ON CONFLICT (zoid) DO UPDATE SET state = excluded.state,
-        #                       prev_tid = excluded.prev_tid,
-        #                       md5 = excluded.md5
-        # """
-        # TODO: Use the update syntax when available.
-        self._generic_store_temp(batcher, oid, prev_tid, data)
 
     _upload_blob_uses_chunks = False
 

--- a/src/relstorage/adapters/sqlite/tests/test_dialect.py
+++ b/src/relstorage/adapters/sqlite/tests/test_dialect.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2019 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from relstorage.adapters.sql.tests import test_sql
+
+from .. import dialect
+
+class TestSQLiteUpsertDialect(test_sql.TestUpsert):
+    keep_history = False
+    dialect = dialect.Sqlite3Dialect()
+
+    def test_default(self):
+        self.assertEqual(
+            dialect.SQ3_SUPPORTS_UPSERT,
+            dialect.SqliteCompiler is dialect._Sqlite3UpsertCompiler)
+
+    insert_or_replace = test_sql.TestUpsert.insert_or_replace.replace(
+        '%s', '?'
+    )
+
+    insert_or_replace_subquery = test_sql.TestUpsert.insert_or_replace_subquery.replace(
+        '%s', '?'
+    )
+
+    upsert_unconstrained_subquery = test_sql.TestUpsert.upsert_unconstrained_subquery.replace(
+        '%s', '?'
+    ).replace(
+        ' ON ', ' WHERE true ON '
+    )

--- a/src/relstorage/cache/local_database.py
+++ b/src/relstorage/cache/local_database.py
@@ -371,6 +371,11 @@ class Database(ABC):
 class _UpsertUpdateDatabase(Database):
 
     def move_from_temp(self):
+        # "The parser might not be able to tell if the "ON" keyword is
+        # introducing the UPSERT or if it is the ON clause of a join.
+        # To work around this, the SELECT statement should always
+        # include a WHERE clause, even if that WHERE clause is just
+        # ``WHERE true``."
         self.cursor.execute("""
         INSERT INTO object_state (zoid, tid, was_frozen, frequency, state)
         SELECT zoid, tid, was_frozen, frequency, state

--- a/src/relstorage/storage/tpc/temporary_storage.py
+++ b/src/relstorage/storage/tpc/temporary_storage.py
@@ -62,12 +62,9 @@ class TemporaryStorage(object):
 
     def __len__(self):
         # How many distinct OIDs have been stored?
+        # This also lets us be used in a boolean context to see
+        # if we've actually stored anything.
         return len(self._queue_contents)
-
-    def __bool__(self):
-        return True
-
-    __nonzero__ = __bool__
 
     @property
     def stored_oids(self):

--- a/src/relstorage/storage/tpc/vote.py
+++ b/src/relstorage/storage/tpc/vote.py
@@ -160,8 +160,9 @@ class AbstractVote(AbstractTPCState):
 
     @log_timed
     def _flush_temps_to_db(self, cursor):
-        mover = self.adapter.mover
-        mover.store_temps(cursor, self.temp_storage)
+        if self.temp_storage:
+            # Don't bother if we're empty.
+            self.adapter.mover.store_temps(cursor, self.temp_storage)
 
     def __enter_critical_phase_until_transaction_end(self):
         self.load_connection.enter_critical_phase_until_transaction_end()


### PR DESCRIPTION
This added UPSERT handling to the generic query framework and simplified quite a bit of code.