### PR TITLE
Finer control over sqlite storage locking, oid allocation and stats.

### DIFF
--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -37,6 +37,7 @@ __all__ = [
     # Constants
     'PY3',
     'PY2',
+    'PY36',
     'PYPY',
     'WIN',
     'MAC',
@@ -72,6 +73,7 @@ __all__ = [
 ]
 
 PY3 = sys.version_info[0] == 3
+PY36 = sys.version_info[:2] >= (3, 6)
 PY2 = not PY3
 PYPY = platform.python_implementation() == 'PyPy'
 WIN = sys.platform.startswith('win')

--- a/src/relstorage/adapters/_util.py
+++ b/src/relstorage/adapters/_util.py
@@ -12,6 +12,8 @@
 #
 ##############################################################################
 "Internal helper utilities."
+from __future__ import print_function
+from __future__ import absolute_import
 
 from collections import namedtuple
 from functools import partial
@@ -186,7 +188,11 @@ class DatabaseHelpersMixin(object):
         """
         Return the rows formatted in a way for easy human consumption.
         """
-        # This could be tabular, but its easiest just to use pprint
-        import pprint
-        rows = list(self._rows_as_dicts(cursor))
-        return pprint.pformat(rows)
+        from .._compat import NStringIO
+        out = NStringIO()
+        names = [d.name for d in self._column_descriptions(cursor)]
+        kwargs = {'sep': '\t', 'file': out}
+        print(*names, **kwargs)
+        for row in cursor:
+            print(*row, **kwargs)
+        return out.getvalue()

--- a/src/relstorage/adapters/connections.py
+++ b/src/relstorage/adapters/connections.py
@@ -286,6 +286,10 @@ class StoreConnection(AbstractManagedConnection):
     def begin(self):
         self.connmanager.begin(*self.open_if_needed())
 
+class PrePackConnection(StoreConnection):
+    __slots__ = ()
+    _NEW_CONNECTION_NAME = 'open_for_pre_pack'
+
 @implementer(interfaces.IManagedDBConnection)
 class ClosedConnection(object):
     """

--- a/src/relstorage/adapters/drivers.py
+++ b/src/relstorage/adapters/drivers.py
@@ -29,6 +29,7 @@ from .._compat import PYPY
 from .._compat import PY3
 from .._compat import casefold
 from .._util import positive_integer
+from .._util import consume
 
 from .interfaces import IDBDriver
 from .interfaces import IDBDriverFactory
@@ -116,6 +117,8 @@ class AbstractModuleDriver(ABC):
 
     def __init__(self):
         if PYPY and not self.AVAILABLE_ON_PYPY:
+            raise DriverNotAvailableError(self.__name__)
+        if not self.STATIC_AVAILABLE:
             raise DriverNotAvailableError(self.__name__)
         try:
             self.driver_module = mod = self.get_driver_module()
@@ -205,9 +208,8 @@ class AbstractModuleDriver(ABC):
         # it in certain circumstances.
 
         if cursor is not None:
-            fetchall = cursor.fetchall
             try:
-                fetchall()
+                consume(cursor)
             except Exception: # pylint:disable=broad-except
                 pass
 

--- a/src/relstorage/adapters/drivers.py
+++ b/src/relstorage/adapters/drivers.py
@@ -84,6 +84,11 @@ class AbstractModuleDriver(ABC):
     #: Can this module be used on PyPy?
     AVAILABLE_ON_PYPY = True
 
+    #: Set this to false if your subclass can do static checks
+    #: at import time to determine it should not be used.
+    #: Helpful for things like Python version detection.
+    STATIC_AVAILABLE = True
+
     #: Priority of this driver, when available. Lower is better.
     #: (That is, first choice should have value 1, and second choice value
     #: 2, and so on.)
@@ -123,6 +128,7 @@ class AbstractModuleDriver(ABC):
         try:
             self.driver_module = mod = self.get_driver_module()
         except ImportError:
+            logger.exception("Unable to import driver")
             raise DriverNotAvailableError(self.__name__)
 
 

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -449,6 +449,21 @@ class IConnectionManager(Interface):
         :return: ``(conn, cursor)``
         """
 
+    def open_for_pack_lock():
+        """
+        Open a connection to be used for the sole purpose of holding
+        the pack lock.
+
+        Use a private connection (lock_conn and lock_cursor) to hold
+        the pack lock. Have the adapter open temporary connections
+        to do the actual work, allowing the adapter to use special
+        transaction modes for packing, and to commit at will without
+        losing the lock.
+
+        If the database doesn't actually use a pack lock,
+        this may return ``(None, None)``.
+        """
+
     def cursor_for_connection(conn):
         """
         If the cursor returned by an open method was discarded

--- a/src/relstorage/adapters/packundo.py
+++ b/src/relstorage/adapters/packundo.py
@@ -32,7 +32,7 @@ from ..treemark import TreeMarker
 
 from .schema import Schema
 from .connections import LoadConnection
-from .connections import StoreConnection
+from .connections import PrePackConnection
 from .interfaces import IPackUndo
 from ._util import DatabaseHelpersMixin
 from .sql import it
@@ -634,7 +634,7 @@ class HistoryPreservingPackUndo(PackUndo):
         much faster.
         """
         load_connection = LoadConnection(self.connmanager)
-        store_connection = StoreConnection(self.connmanager)
+        store_connection = PrePackConnection(self.connmanager)
         try:
             # The pre-pack functions are responsible for managing
             # their own commits; when they return, the transaction
@@ -1297,7 +1297,7 @@ class HistoryFreePackUndo(PackUndo):
             return
 
         load_connection = LoadConnection(self.connmanager)
-        store_connection = StoreConnection(self.connmanager)
+        store_connection = PrePackConnection(self.connmanager)
         try:
             try:
                 self._pre_pack_main(load_connection, store_connection,

--- a/src/relstorage/adapters/postgresql/drivers/psycopg2.py
+++ b/src/relstorage/adapters/postgresql/drivers/psycopg2.py
@@ -133,7 +133,7 @@ class Psycopg2Driver(MemoryViewBlobDriverMixin,
 
 
 class GeventPsycopg2Driver(Psycopg2Driver):
-    __name__ = 'gevent ' + Psycopg2Driver.__name__
+    __name__ = 'gevent ' + Psycopg2Driver.MODULE_NAME
 
     _GEVENT_CAPABLE = True
     _GEVENT_NEEDS_SOCKET_PATCH = False

--- a/src/relstorage/adapters/sqlite/__init__.py
+++ b/src/relstorage/adapters/sqlite/__init__.py
@@ -37,7 +37,8 @@ main database to be locked like that.
 Locks
 =====
 
-Sqlite3 only supports database-wide locks.
+Sqlite3 only supports database-wide write locks. For details on when and how
+they are taken and managed, see connmanager.py and locker.py
 """
 
 from __future__ import absolute_import

--- a/src/relstorage/adapters/sqlite/connmanager.py
+++ b/src/relstorage/adapters/sqlite/connmanager.py
@@ -20,11 +20,8 @@ from __future__ import print_function
 import os.path
 import sqlite3
 
-from relstorage._util import log_timed
-from relstorage._compat import PY3
-from relstorage._compat import WIN
-
 from ..connmanager import AbstractConnectionManager
+from .drivers import Connection
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -68,11 +65,83 @@ DEFAULT_TIMEOUT = 15
 
 
 class Sqlite3ConnectionManager(AbstractConnectionManager):
+    """
+    SQLite doesn't really have isolation levels in the traditional
+    sense; as far as that goes, it always operates in SERIALIZABLE
+    mode. Instead, the connection's ``isolation_level`` parameter
+    determines how autocommit behaves and the interaction between it
+    at the SQLite and Python levels::
 
-    def __init__(self, driver, path, options):
+        - If it is ``None``, then the Python Connection object has nothing
+          to do with transactions. SQLite operates in its default autocommit
+          mode, beginning and ending a (read or write, as needed)
+          transaction around every statement execution.
+
+        - If it is set to IMMEDIATE or DEFERRED, than the Python
+          Connection object watches each statement sent
+          to ``Cursor.execute`` or ``Cursor.executemany`` to see
+          if it's a DML statement (INSERT/UPDATE/DELETE/REPLACE, and
+          prior to Python 3.6, basically anything else except a
+          SELECT). If it is, and the sqlite level is not already
+          in a transaction, then the Connection begins a transaction
+          of the specified type before executing the statement. The
+          Connection COMMITs when commit() is called or when a DDL
+          statement is executed (prior to Python 3.6).
+
+    Now, those are all write statements that theoretically would begin
+    a write transaction and take a database lock, so it would seem
+    like there's no difference between IMMEDIATE and DEFERRED. But
+    there is: recall that temporary tables are actually in a temporary
+    *database*, so when you write to one of those, sqlite's internal
+    transaction locks only apply to it. A DEFERRED transaction thus
+    allows other connections to write to their own temporary tables,
+    while an IMMEDIATE transaction blocks other from writing to their
+    temporaries.
+
+    We thus tell Python SQLite to operate in DEFERRED mode; for load
+    connections, we must explicitly execute the BEGIN to get a
+    consistent snapshot of the database, but for load, we can let the
+    Python Connection detect when we execute a write operation and
+    begin the transaction then, letting SQLite upgrade the locks to
+    explicit mode when we attempt a write to the main database.
+
+    Taking an exclusive lock on the main database can be accomplished
+    with any UPDATE statement, even one that doesn't match any actual
+    rows.
+    """
+
+    # super copies these into isolation_load/store
+    # We use 'EXCLUSIVE' for the load connection isolation but we don't
+    # ever actually expect to get to that. It just makes problems
+    # more apparent should that happen.
+    isolation_serializable = 'EXCLUSIVE'
+    isolation_read_committed = 'DEFERRED'
+
+    def __init__(self, driver, pragmas, path, options):
+        """
+        :param dict pragmas: A map from string pragma name to string
+            pragma value. These will be executed at connection open
+            time. Except for WAL, and a few other critical values, we
+            allow changing just about all the settings, letting the
+            user turn off just about all the safety features so that
+            the user can tune to their liking. The user can also set the
+            ``max_page_count`` to operate as a quota system.
+        """
         self.path = path
         self.keep_history = options.keep_history
+        self.pragmas = pragmas.copy()
+        # Things that we really want to be on.
+        nice_to_have_pragmas = {
+            'foreign_keys': 1
+        }
+        nice_to_have_pragmas.update(pragmas)
+        self.pragmas = nice_to_have_pragmas
+        self.pragmas['journal_size_limit'] = None
         super(Sqlite3ConnectionManager, self).__init__(options, driver)
+
+        assert self.isolation_load == type(self).isolation_serializable
+        assert self.isolation_store == type(self).isolation_read_committed
+
 
     def open(self,
              isolation=None,
@@ -81,115 +150,119 @@ class Sqlite3ConnectionManager(AbstractConnectionManager):
              replica_selector=None,
              application_name=None,
              **kwargs):
-        # SQLite doesn't really have isolation levels
-        # in the traditional sense. It always operates in SERIALIZABLE
-        # mode.
+
+        if not os.path.exists(os.path.dirname(self.path)) and self.options.create_schema:
+            os.makedirs(os.path.dirname(self.path))
+
         conn = connect_to_file(self.path,
                                query_only=read_only,
                                timeout=self.options.commit_lock_timeout,
                                quick_check=False,
-                               extra_pragmas={
-                                   'foreign_keys': 'on',
-                                   'journal_size_limit': None,
-                               })
+                               isolation_level=isolation,
+                               extra_pragmas=self.pragmas)
         cur = conn.cursor()
         return conn, cur
 
     def _do_open_for_load(self):
         conn, cur = self.open(
-            isolation=self.isolation_load)
-
+            isolation=self.isolation_load,
+            read_only=True
+        )
+        # If we don't explicitly begin a transaction block, we're in
+        # autocommit-mode for SELECT, which is essentially REPEATABLE READ, i.e.,
+        # our MVCC state moves forward each time we read and we don't have a consistent
+        # view.
         cur.execute('BEGIN DEFERRED TRANSACTION')
         return conn, cur
 
-    def rollback_store_quietly(self, conn, cur):
-        super(Sqlite3ConnectionManager, self).rollback_store_quietly(conn, cur)
-        # Important to ensure that our temp tables get cleared out
-        self._call_hooks(self._on_store_opened, conn, cur, cur, restart=True)
+    def _do_open_for_store(self, **open_args):
+        # We also make sure some stats are populated about the
+        # size of the database. We make sure it assumes that the main
+        # state tables are large in comparison to the temp tables. If
+        # we don't, then we tend to get a query plan for detecting
+        # conflicts that is very bad: SCAN object_state SEARCH
+        # temp_store BY PRIMARY KEY instead of the good one, SCAN
+        # temp_store SEARCH object_state BY PRIMARY KEY
+        conn, cur = AbstractConnectionManager._do_open_for_store(self, **open_args)
+        # We're in an autocommit connection right now
+        assert not conn.in_transaction
+        if not self.are_stats_ok(cur):
+            self.correct_stats(cur)
+            conn.commit()
+        return conn, cur
+
+    desired_large_table_stat = 2000000
+
+    def are_stats_ok(self, cursor):
+        try:
+            cursor.execute("""
+            SELECT stat FROM sqlite_stat1
+            WHERE tbl in ('object_state', 'current_object')
+            """)
+        except sqlite3.OperationalError:
+            return False
+        rows = cursor.fetchall()
+        if not rows:
+            return False
+        for row in rows:
+            # a space separated list, first item is integer giving # rows
+            # But the Python library may have already taken it as an integer.
+            try:
+                count = int(row[0])
+            except ValueError:
+                count = int(row[0].split()[0])
+            if count < self.desired_large_table_stat:
+                return False
+        return True
+
+    def correct_stats(self, cursor):
+        """
+        Takes a lock and commits the transaction.
+        """
+        script = """
+        DELETE FROM sqlite_stat1 WHERE tbl in ('object_state', 'current_object')
+        AND idx IS NULL;
+        """
+        try:
+            cursor.execute(script)
+        except sqlite3.OperationalError:
+            pass
+
+        script = """
+        ANALYZE;
+        INSERT INTO sqlite_stat1
+            SELECT 'object_state', NULL, {count}
+            WHERE NOT EXISTS (
+                SELECT 1 FROM sqlite_stat1 WHERE tbl = 'object_state'
+                AND idx IS NULL
+        );
+        INSERT INTO sqlite_stat1
+            SELECT 'current_object', NULL, {count}
+            WHERE NOT EXISTS (
+                SELECT 1 FROM sqlite_stat1 WHERE tbl = 'current_object'
+                AND idx IS NULL
+        );
+        ANALYZE sqlite_master;
+        """.format(count=self.desired_large_table_stat)
+        cursor.executescript(script)
+        cursor.connection.commit()
 
     def restart_load(self, conn, cursor, needs_rollback=True):
+        needs_rollback = True
         super(Sqlite3ConnectionManager, self).restart_load(conn, cursor, needs_rollback)
-        # If we don't explicitly begin a transaction block, we're in
-        # autocommit-mode, meaning we move forward and don't have a consistent view.
+        assert not conn.in_transaction
+        # See _do_open_for_load.
         cursor.execute('BEGIN DEFERRED TRANSACTION')
 
+    def open_for_pre_pack(self):
+        # This operates in auto-commit mode.
+        conn, cur = self.open(isolation=None)
+        assert conn.isolation_level is None
+        return conn, cur
 
-class Cursor(sqlite3.Cursor):
-
-    def execute(self, stmt, params=None):
-        # While we transition away from hardcoded SQL to the query
-        # objects, we still have some %s params out there. This papers
-        # over that.
-        if params is not None:
-            stmt = stmt.replace('%s', '?')
-            return sqlite3.Cursor.execute(self, stmt, params)
-
-        return sqlite3.Cursor.execute(self, stmt)
-
-    def executemany(self, stmt, params):
-        stmt = stmt.replace('%s', '?')
-        return sqlite3.Cursor.executemany(self, stmt, params)
-
-class Connection(sqlite3.Connection):
-    # pylint:disable=assigning-non-slot
-    # Something about inheriting from an extension
-    # class seems to get pylint confused.
-
-    __slots__ = (
-        'rs_db_filename',
-        '_rs_has_closed',
-        'replica',
-    )
-
-    def __init__(self, *args, **kwargs):
-        __traceback_info__ = args, kwargs
-        super(Connection, self).__init__(*args, **kwargs)
-
-        self.rs_db_filename = None
-        self._rs_has_closed = False
-        self.replica = None
-
-    def __repr__(self):
-        if not self.rs_db_filename:
-            return super(Connection, self).__repr__()
-        return '<Connection at %x to %r>' % (
-            id(self), self.rs_db_filename
-        )
-
-    def cursor(self):
-        return sqlite3.Connection.cursor(self, Cursor)
-
-    @log_timed
-    def close(self):
-        # If we're the only connection open to this database,
-        # and SQLITE_FCNTL_PERSIST_WAL is true (by default
-        # *most* places, but apparently not in the sqlite3
-        # 3.24 shipped with Apple in macOS 10.14.5), then when
-        # we close the database the wal file that was built up
-        # by any of the writes that have been done will be automatically
-        # combined with the database file, as if with
-        # "PRAGMA wal_checkpoint(RESTART)".
-        #
-        # This can be slow. It releases the GIL, so it could be done in another thread;
-        # but most often (aside from tests) we're closing connections because we're
-        # shutting down the process so spawning threads isn't really a good thing.
-        if self._rs_has_closed: # pragma: no cover
-            return
-        self._rs_has_closed = True
-
-        # Recommended best practice is to OPTIMIZE the database for
-        # each closed connection. OPTIMIZE needs to run in each connection
-        # so it can see what tables and indexes were used. It's usually fast,
-        # but has the potential to be slow.
-        try:
-            self.execute("PRAGMA optimize")
-        except sqlite3.OperationalError:
-            logger.debug("Failed to optimize databas, probably in use", exc_info=True)
-        except sqlite3.DatabaseError:
-            # It's possible the file was removed.
-            logger.exception("Failed to optimize database; was it removed?")
-
-        super(Connection, self).close()
+    def open_for_pack_lock(self):
+        # We don't use a pack lock.
+        return (None, None)
 
 
 _last_changed_settings = ()
@@ -228,22 +301,27 @@ def _execute_pragma(cur, name, value):
 def _execute_pragmas(cur, **kwargs):
     report = {}
     changed = {} # {setting: (original, desired, updated)}
-    for k, v in kwargs.items():
+    if 'page_size' in kwargs:
+        # This has to happen before changing into WAL.
+        ps = kwargs.pop('page_size')
+        items = [('page_size', ps)]
+        items.extend(kwargs.items())
+    else:
+        items = kwargs.items()
+
+    for pragma, desired in items:
         # Query, report, then change
-        __traceback_info__ = k, v
-        stmt = 'PRAGMA %s' % (k,)
-        cur.execute(stmt)
-        row = cur.fetchone()
+        stmt = 'PRAGMA %s' % (pragma,)
+        row, = cur.execute(stmt).fetchall() or ((),)
         orig_value = row[0] if row else None
-        if v is not None and v != orig_value:
-            _execute_pragma(cur, k, v)
+        if desired is not None and desired != orig_value:
+            _execute_pragma(cur, pragma, desired)
             cur.execute(stmt)
             row = cur.fetchone()
             new_value = row[0] if row else None
-            changed[k] = (orig_value, v, new_value)
+            changed[pragma] = (orig_value, desired, new_value)
         else:
-            report[k] = orig_value
-
+            report[pragma] = orig_value
     __check_and_log(report, changed)
 
 def _connect_to_file_or_uri(fname,
@@ -251,16 +329,19 @@ def _connect_to_file_or_uri(fname,
                             timeout=DEFAULT_TIMEOUT,
                             pragmas=None,
                             quick_check=True,
+                            isolation_level=None,
                             **connect_args):
 
-    assert issubclass(factory, Connection)
+    _factory = factory
+    factory = lambda *args, **kwargs: _factory(fname, *args, **kwargs)
 
     connection = sqlite3.connect(
         fname,
-        # If we do nothing, this means we're in autocommit
-        # mode. Creating our own transactions with BEGIN
-        # disables that until the COMMIT.
-        isolation_level=None,
+        # See Sqlite3ConnectionManager for the meaning of this.
+        # We default to None which puts us in the underlying sqlite autocommit
+        # mode. This is unlike the standard library, so you must
+        # either set this or manage your own transactions explicitly
+        isolation_level=isolation_level,
         factory=factory,
         # We explicitly push closing off to a new thread.
         check_same_thread=False,
@@ -306,8 +387,6 @@ def _connect_to_file_or_uri(fname,
     return connection
 
 
-USE_SHARED_CACHE = False
-
 def connect_to_file(fname,
                     query_only=False,
                     max_wal_size=DEFAULT_MAX_WAL,
@@ -317,7 +396,9 @@ def connect_to_file(fname,
                     temp_store=DEFAULT_TEMP_STORE,
                     timeout=DEFAULT_TIMEOUT,
                     quick_check=True,
-                    extra_pragmas=None):
+                    isolation_level=None,
+                    extra_pragmas=None,
+                    override_pragmas=None):
     """
     Return a DB-API Connection object.
 
@@ -325,52 +406,35 @@ def connect_to_file(fname,
        result in the connection being closed, only committed or rolled back.
     """
 
-    # There are some things we'd like to do, but we can't
-    # unless we're operating on at least Python 3.4, where the uri
-    # syntax is supported.
+    # There are some things we might like to do, but we can't
+    # unless we're operating on at least Python 3.4, where the URI
+    # syntax is supported. It also turns out that they don't really work either:
     #
     # - Enable shared cache. (https://www.sqlite.org/sharedcache.html)
     # This doesn't work because of locking: all connections sharing the cache
     # lock at the same time.
+    # - Use ?mode=ro for true query_only mode. But if the file doesn't
+    # exist that fails, and we can't execute certain pragmas that way either.
 
     fname = os.path.abspath(fname) if fname and fname != ':memory:' else fname
 
-    connect_args = {}
-    if PY3 and USE_SHARED_CACHE:
-        connect_args = {'uri': True}
-        # Follow the steps to convert to a URI
-        # https://www.sqlite.org/uri.html#the_uri_path
-        fname = fname.replace('?', '%3f')
-        fname = fname.replace('#', '%23')
-        if WIN:
-            fname = fname.replace('\\', '/')
-        while '//' in fname:
-            fname = fname.replace('//', '/')
-        if WIN and os.path.splitdrive(fname)[0]:
-            fname = '/' + fname
-        fname = 'file:' + fname + '?cache=shared'
-        # It might seem nice to use '?mode=ro' if query_only, but
-        # we can't do that if the file doesn't exist, and we can't execute
-        # certain pragmas either.
-
+    # Things we like but don't require.
+    # Note that we use the primitive values for these things so that we can
+    # detect when they get set for reporting purposes.
     pragmas = {
-        # WAL mode can actually be a bit slower at commit time,
-        # but buys us far better concurrency.
-        # Note: In-memory databases always use 'memory' as the journal mode;
-        # temporary databases always use 'delete'.
-        'journal_mode': 'wal',
         'journal_size_limit': max_wal_size,
         'mmap_size': mmap_size,
         'page_size': page_size,
         'temp_store': temp_store,
+        # WAL mode is always consistent even after a operating system
+        # crash in NORMAL mode. It might lose a transaction, though.
+        # The default is often FULL/2, which is higher than NORMAL/1.
+        'synchronous': 1,
         # If cache_spill is allowed, at some point a transaction
         # can begin writing dirty pages to the database file, taking
         # an exclusive lock. That could be at arbitrary times, so we don't want that.
-        'cache_spill': 'off',
-        # WAL mode is always consistent even after a operating system
-        # crash in NORMAL mode. It might lose a transaction, though.
-        # The default is often FULL, which is higher than NORMAL.
-        'synchronous': 'NORMAL',
+        'cache_spill': 0,
+
         # Disable auto-checkpoint so that commits have
         # reliable duration; after commit, if it's a good time,
         # we can run 'PRAGMA wal_checkpoint'. (In most cases, the last
@@ -387,17 +451,31 @@ def connect_to_file(fname,
         'page_count': None,
     }
 
-    if query_only:
-        pragmas['query_only'] = 'on'
-
+    # User-specified extra pragmas go here.
     pragmas.update(extra_pragmas or {})
+
+    # Things that *must* be set.
+    required_pragmas = {
+        # WAL mode can actually be a bit slower at commit time,
+        # but buys us far better concurrency.
+        # Note: In-memory databases always use 'memory' as the journal mode;
+        # temporary databases always use 'delete'.
+        'journal_mode': 'wal',
+    }
+
+    if query_only:
+        required_pragmas['query_only'] = 1
+
+    pragmas.update(required_pragmas)
+
+    pragmas.update(override_pragmas or {})
 
     connection = _connect_to_file_or_uri(
         fname,
         pragmas=pragmas,
         timeout=timeout,
         quick_check=quick_check,
-        **connect_args
+        isolation_level=isolation_level
     )
 
     return connection

--- a/src/relstorage/adapters/sqlite/drivers.py
+++ b/src/relstorage/adapters/sqlite/drivers.py
@@ -17,14 +17,20 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sqlite3
+
 from zope.interface import implementer
 
 from relstorage._compat import PY3
+from relstorage._compat import PY2
+from relstorage._compat import PY36
+from relstorage._util import log_timed
 
 from ..drivers import implement_db_driver_options
 from ..drivers import AbstractModuleDriver
 from ..drivers import MemoryViewBlobDriverMixin
 from ..interfaces import IDBDriver
+from .._util import DatabaseHelpersMixin
 
 from .dialect import Sqlite3Dialect
 
@@ -33,6 +39,7 @@ __all__ = [
 ]
 
 database_type = 'sqlite3'
+logger = __import__('logging').getLogger(__name__)
 
 @implementer(IDBDriver)
 class Sqlite3Driver(MemoryViewBlobDriverMixin,
@@ -40,10 +47,17 @@ class Sqlite3Driver(MemoryViewBlobDriverMixin,
     dialect = Sqlite3Dialect()
     __name__ = 'sqlite3'
     MODULE_NAME = __name__
+    STATIC_AVAILABLE = (
+        # Tested to work on Python 2.7 and Python 3.6+;
+        # seen some strange ``ProgrammingError: closed``
+        # on Python 3.5
+        (PY2 or PY36)
+        # 3.11 is the oldest version tested on CI
+        and sqlite3.sqlite_version_info[:2] >= (3, 11)
+    )
 
     def __init__(self):
         super(Sqlite3Driver, self).__init__()
-
         # Sadly, if a connection is closed out from under it,
         # sqlite3 throws ProgrammingError, which is not very helpful.
         # That should really only happen in tests, though, since
@@ -51,10 +65,179 @@ class Sqlite3Driver(MemoryViewBlobDriverMixin,
         self.disconnected_exceptions += (self.driver_module.ProgrammingError,)
 
     if PY3:
+        # in_transaction doesn't work there, so assume the worst.
+        def connection_may_need_rollback(self, conn):
+            try:
+                return conn.in_transaction
+            except sqlite3.ProgrammingError:
+                # we're closed. We do need to attempt the rollback so
+                # we catch the error and know to drop the connection.
+                return True
+
+        connection_may_need_commit = connection_may_need_rollback
+
+
         # Py2 returns buffer for blobs, hence the Mixin.
         # But Py3 returns plain bytes.
         def binary_column_as_state_type(self, data):
             return data
+
+class UnableToConnect(sqlite3.OperationalError):
+    filename = None
+    def with_filename(self, f):
+        self.filename = f
+        return self
+
+    def __str__(self):
+        s = super(UnableToConnect, self).__str__()
+        if self.filename:
+            s += " (At: %r)" % self.filename
+        return s
+
+
+class Cursor(sqlite3.Cursor):
+    has_analyzed_temp = False
+
+    def execute(self, stmt, params=None):
+        # While we transition away from hardcoded SQL to the query
+        # objects, we still have some %s params out there. This papers
+        # over that.
+        if params is not None:
+            stmt = stmt.replace('%s', '?')
+            return sqlite3.Cursor.execute(self, stmt, params)
+
+        return sqlite3.Cursor.execute(self, stmt)
+
+    def executemany(self, stmt, params):
+        stmt = stmt.replace('%s', '?')
+        return sqlite3.Cursor.executemany(self, stmt, params)
+
+    def __repr__(self):
+        return '<Cursor at 0x%x from %r>' % (
+            id(self), self.connection
+        )
+
+    def close(self):
+        try:
+            sqlite3.Cursor.close(self)
+        except sqlite3.ProgrammingError:
+            pass
+
+
+class _ExplainCursor(DatabaseHelpersMixin): # pragma: no cover (A debugging aid)
+    def __init__(self, cur):
+        self.cur = cur
+
+    def __getattr__(self, name):
+        return getattr(self.cur, name)
+
+    def __iter__(self):
+        return iter(self.cur)
+
+    def execute(self, sql, *args):
+        if sql.strip().startswith(('INSERT', 'SELECT', 'DELETE', 'WITH')):
+            exp = 'EXPLAIN QUERY PLAN ' + sql.lstrip()
+            print(sql)
+            self.cur.execute(exp, *args)
+            print(self._rows_as_pretty_string(self.cur))
+        return self.cur.execute(sql, *args)
+
+
+class Connection(sqlite3.Connection):
+    # pylint:disable=assigning-non-slot
+    # Something about inheriting from an extension
+    # class seems to get pylint confused.
+    has_analyzed_temp = False
+    before_commit_functions = ()
+    _rs_has_closed = False
+    replica = None
+
+    def __init__(self, rs_db_filename, *args, **kwargs):
+        __traceback_info__ = args, kwargs
+        # PyPy3 calls self.commit() during __init__.
+        self.rs_db_filename = rs_db_filename
+        self.before_commit_functions = []
+
+        try:
+            super(Connection, self).__init__(*args, **kwargs)
+        except sqlite3.OperationalError as e:
+            raise UnableToConnect(e).with_filename(rs_db_filename)
+
+
+    def __repr__(self):
+        if not self.rs_db_filename:
+            return super(Connection, self).__repr__()
+        try:
+            in_tx = self.in_transaction
+        except sqlite3.ProgrammingError:
+            in_tx = 'closed'
+
+        return '<Connection at 0x%x to %r in_transaction=%s>' % (
+            id(self), self.rs_db_filename,
+            in_tx
+        )
+
+    if not PY3:
+        # This helpful attribute is Python 3 only.
+        assert not hasattr(sqlite3.Connection, 'in_transaction')
+        @property
+        def in_transaction(self):
+            return None
+
+    def register_before_commit_cleanup(self, func):
+        self.before_commit_functions.append(func)
+
+    if 0: # pylint:disable=using-constant-test
+        def cursor(self):
+            return _ExplainCursor(sqlite3.Connection.cursor(self, Cursor))
+    else:
+        def cursor(self):
+            return sqlite3.Connection.cursor(self, Cursor)
+
+    def commit(self, run_cleanups=True):
+        if run_cleanups:
+            for func in self.before_commit_functions:
+                func(self)
+        sqlite3.Connection.commit(self)
+
+    def rollback(self):
+        sqlite3.Connection.rollback(self)
+        for func in self.before_commit_functions:
+            func(self, True)
+
+    @log_timed
+    def close(self):
+        # If we're the only connection open to this database,
+        # and SQLITE_FCNTL_PERSIST_WAL is true (by default
+        # *most* places, but apparently not in the sqlite3
+        # 3.24 shipped with Apple in macOS 10.14.5), then when
+        # we close the database the wal file that was built up
+        # by any of the writes that have been done will be automatically
+        # combined with the database file, as if with
+        # "PRAGMA wal_checkpoint(RESTART)".
+        #
+        # This can be slow. It releases the GIL, so it could be done in another thread;
+        # but most often (aside from tests) we're closing connections because we're
+        # shutting down the process so spawning threads isn't really a good thing.
+        if self._rs_has_closed: # pragma: no cover
+            return
+
+        self._rs_has_closed = True
+        self.before_commit_functions = ()
+        # Recommended best practice is to OPTIMIZE the database for
+        # each closed connection. OPTIMIZE needs to run in each connection
+        # so it can see what tables and indexes were used. It's usually fast,
+        # but has the potential to be slow.
+        try:
+            self.execute("PRAGMA optimize")
+        except sqlite3.OperationalError:
+            logger.debug("Failed to optimize databas, probably in use", exc_info=True)
+        except sqlite3.DatabaseError:
+            # It's possible the file was removed.
+            logger.exception("Failed to optimize database; was it removed?")
+
+        super(Connection, self).close()
+
 
 implement_db_driver_options(
     __name__,

--- a/src/relstorage/adapters/sqlite/tests/test_adapter.py
+++ b/src/relstorage/adapters/sqlite/tests/test_adapter.py
@@ -16,9 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from unittest import skipUnless
+
 from ..adapter import Sqlite3Adapter as Adapter
+from ..drivers import Sqlite3Driver
 from ...tests import test_adapter
 
+@skipUnless(Sqlite3Driver.STATIC_AVAILABLE, "Driver not available")
 class TestAdapter(test_adapter.AdapterTestBase):
 
     def _makeOne(self, options):

--- a/src/relstorage/adapters/sqlite/tests/test_adapter.py
+++ b/src/relstorage/adapters/sqlite/tests/test_adapter.py
@@ -22,4 +22,5 @@ from ...tests import test_adapter
 class TestAdapter(test_adapter.AdapterTestBase):
 
     def _makeOne(self, options):
-        return Adapter(":memory:", options=options)
+        return Adapter(":memory:",
+                       options=options, pragmas={})

--- a/src/relstorage/adapters/sqlite/tests/test_sqlite.py
+++ b/src/relstorage/adapters/sqlite/tests/test_sqlite.py
@@ -20,13 +20,16 @@ from __future__ import division
 from __future__ import print_function
 import tempfile
 import os.path
-
+import unittest
 
 from relstorage.adapters.sqlite.adapter import Sqlite3Adapter
 from relstorage.options import Options
 
 from relstorage.tests.util import AbstractTestSuiteBuilder
-from relstorage.tests.util import skipOnAppveyor
+from relstorage.tests.util import RUNNING_ON_TRAVIS
+from relstorage.tests.util import RUNNING_ON_APPVEYOR
+from relstorage._compat import PYPY
+from relstorage._compat import PY3
 
 class Sqlite3AdapterMixin(object):
 
@@ -117,23 +120,42 @@ class Sqlite3TestSuiteBuilder(AbstractTestSuiteBuilder):
     def _compute_large_blob_size(self, use_small_blobs):
         return Options().blob_chunk_size
 
+    __BASE_SKIPPED_TESTS = (
+        # These were both seen on Travis with PyPy3.6 7.1.1, sqlite 3.11.
+        # I can't reproduce locally.
+        ('checkAutoReconnect', PYPY and PY3 and RUNNING_ON_TRAVIS,
+         "Somehow still winds up closed"),
+        ('checkAutoReconnectOnSync', PYPY and PY3 and RUNNING_ON_TRAVIS,
+         "Somehow still winds up closed"),
+    )
+
+    def __add_skips(self, klass, extra_skips=()):
+        for mname, skip, message in self.__BASE_SKIPPED_TESTS + extra_skips:
+            meth = getattr(klass, mname)
+            meth = unittest.skipIf(skip, message)(meth)
+            setattr(klass, mname, meth)
+
     def _make_check_class_HistoryPreservingRelStorageTests(self, bases,
                                                            name, klass_dict=None):
         klass = self._default_make_check_class(bases, name, klass_dict=klass_dict)
-        for mname in (
-                # For some reason this fails to get the undo log. Something
-                # to do with the way we manage the connection? Seen on Python 3.7
-                # with sqlite 3.28
-                'checkPackUnlinkedFromRoot',
-                # Ditto, but on Python 2.7 with sqlite 3.14
-                'checkTransactionalUndoAfterPackWithObjectUnlinkFromRoot',
-        ):
-            meth = getattr(klass, mname)
-            meth = skipOnAppveyor("Fails to get the undo log")(meth)
-            setattr(klass, mname, meth)
+        skips = (
+            # For some reason this fails to get the undo log. Something
+            # to do with the way we manage the connection? Seen on Python 3.7
+            # with sqlite 3.28
+            ('checkPackUnlinkedFromRoot', RUNNING_ON_APPVEYOR,
+             "Fails to get undo log"),
+            # Ditto, but on Python 2.7 with sqlite 3.14
+            ('checkTransactionalUndoAfterPackWithObjectUnlinkFromRoot', RUNNING_ON_APPVEYOR,
+             "Fails to get undo log"),
+        )
+        self.__add_skips(klass, skips)
         return klass
 
-
+    def _make_check_class_HistoryFreeRelStorageTests(self, bases,
+                                                     name, klass_dict=None):
+        klass = self._default_make_check_class(bases, name, klass_dict=klass_dict)
+        self.__add_skips(klass)
+        return klass
 
 def test_suite():
     return Sqlite3TestSuiteBuilder().test_suite()

--- a/src/relstorage/cache/local_database.py
+++ b/src/relstorage/cache/local_database.py
@@ -445,23 +445,3 @@ class _InsertReplaceDatabase(Database):
             cp0,
             cp0, cp1
         ))
-
-
-class _ExplainCursor(object): # pragma: no cover (A debugging aid)
-    def __init__(self, cur):
-        self.cur = cur
-
-    def __getattr__(self, name):
-        return getattr(self.cur, name)
-
-    def __iter__(self):
-        return iter(self.cur)
-
-    def execute(self, sql, *args):
-        if sql.strip().startswith(('INSERT', 'SELECT', 'DELETE', 'WITH')):
-            exp = 'EXPLAIN QUERY PLAN ' + sql.lstrip()
-            print(sql)
-            self.cur.execute(exp, *args)
-            for row in self.cur:
-                print(*row)
-        return self.cur.execute(sql, *args)

--- a/src/relstorage/component.xml
+++ b/src/relstorage/component.xml
@@ -231,16 +231,38 @@
 
   </sectiontype>
 
+  <sectiontype name="pragmas" datatype=".SQLitePragmas">
+      <!-- A few of the important pragmas we know about and can
+           provide optimized handling of. -->
+      <key name="page_size" datatype="byte-size" />
+      <key name="mmap_size" datatype="byte-size" />
+      <key name="max_page_count" datatype="integer" />
+      <key name="threads" datatype="integer" />
+      <key name="cache_size" datatype="byte-size" />
+      <key name="wal_autocheckpoint" datatype="integer" />
+      <key name="soft_heap_limit" datatype="byte-size" />
+      <multikey name="+" attribute="pragmas" datatype="string">
+          <description>
+              A SQLite pragma that will be executed when the
+              connection is opened.
+          </description>
+      </multikey>
+  </sectiontype>
+
   <sectiontype name="sqlite3" implements="relstorage.adapter"
-    datatype=".Sqlite3AdapterFactory">
+               datatype=".Sqlite3AdapterFactory">
 	<key name="driver" datatype="string" required="no" default="auto">
       <description>See the RelStorage documentation.</description>
 	</key>
-    <key name="path" datatype="string" required="yes">
+    <key name="data-dir" datatype="existing-dirpath" required="yes">
       <description>
-        The path to the sqlite3 file.
+        The path to the directory used to store the sqlite database
+        and associated files. The directory must be on a local filesystem.
       </description>
     </key>
+
+    <section name="*" attribute="pragmas" required="no" type="pragmas">
+    </section>
   </sectiontype>
 
 </component>

--- a/src/relstorage/storage/pack.py
+++ b/src/relstorage/storage/pack.py
@@ -192,12 +192,7 @@ class Pack(object):
         if prepack_only and skip_prepack:
             raise ValueError('Pick either prepack_only or skip_prepack.')
 
-        # Use a private connection (lock_conn and lock_cursor) to hold
-        # the pack lock. Have the adapter open temporary connections
-        # to do the actual work, allowing the adapter to use special
-        # transaction modes for packing, and to commit at will without
-        # losing the lock.
-        lock_conn, lock_cursor = self.connmanager.open()
+        lock_conn, lock_cursor = self.connmanager.open_for_pack_lock()
         try:
             self.locker.hold_pack_lock(lock_cursor)
             try:

--- a/src/relstorage/storage/tpc/__init__.py
+++ b/src/relstorage/storage/tpc/__init__.py
@@ -170,7 +170,6 @@ class AbstractTPCState(object):
 
         try:
             self.load_connection.rollback_quietly()
-
             self.adapter.txncontrol.abort(
                 self.store_connection,
                 self.prepared_txn)

--- a/src/relstorage/storage/tpc/temporary_storage.py
+++ b/src/relstorage/storage/tpc/temporary_storage.py
@@ -86,7 +86,6 @@ class TemporaryStorage(object):
         """
         Return the bytes for a previously stored temporary item.
         """
-        __traceback_info__ = dict(self._queue_contents.items())
         startpos, endpos, _ = self._queue_contents[oid_int]
         return self._read_temp_state(startpos, endpos)
 

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -771,7 +771,7 @@ class GenericRelStorageTests(
         r = c1.root()
 
         c1._storage._load_connection.connection.close()
-        c1._storage.sync()
+        c1._storage.sync(True)
         # ZODB5 calls sync when a connection is opened. Our monkey
         # patch on a Connection makes sure that works in earlier
         # versions, but we don't have that patch on ZODB5. So test


### PR DESCRIPTION
This makes it consistently at least 2x to 3x faster in most benchmarks and it also closes some potential concurrency issues.

Also expose all the pragmas in the configuration so users can tune it appropriately for their environment. This changes the config schema a bit, so since we were doing that, clean that up a bit.

Documentation still needs updated, I'll do that separately. 