### PR TITLE
Restore the RowBatcher for non-COPY capable PostgreSQL drivers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@
 - SQLite: Improve the speed of copying transactions into a SQLite
   storage (e.g., with zodbconvert).
 
+- PostgreSQL: Improve the speed of  writes when using the 'gevent
+  psycopg2' driver.
+
 3.0b1 (2019-10-22)
 ==================
 

--- a/src/relstorage/adapters/oracle/tests/test_dialect.py
+++ b/src/relstorage/adapters/oracle/tests/test_dialect.py
@@ -23,6 +23,7 @@ class Context(object):
 class Driver(object):
     dialect = OracleDialect()
     binary_column_as_state_type = binary_column_as_bytes = lambda b: b
+    Binary = bytes
 
 class TestOracleDialect(TestCase):
 


### PR DESCRIPTION
psycopg2 uses a simple loop, AFAICS, for executemany so our batcher generally ought to be better.

Also share a lot of the gevent support code between psycopg2 and mysqlclient.