### PR TITLE
SQLite: Fix a bug setting the minimum OID.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 3.0b3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- SQLite: Fix a bug that could lead to invalid OIDs being allocated if
+  transactions were imported from another storage.
 
 
 3.0b2 (2019-10-28)

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -282,7 +282,7 @@ try:
     from abc import ABC
 except ImportError:
     import abc
-    ABC = abc.ABCMeta('ABC', (object,), {})
+    ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
     del abc
 
 # Functions

--- a/src/relstorage/adapters/mysql/oidallocator.py
+++ b/src/relstorage/adapters/mysql/oidallocator.py
@@ -61,7 +61,7 @@ class MySQLOIDAllocator(AbstractTableOIDAllocator):
     # "Any AUTO_INCREMENT value is reset to its start value. This is
     # true even for MyISAM and InnoDB, which normally do not reuse
     # sequence values."
-    def set_min_oid(self, cursor, oid_int):
+    def _set_min_oid_from_range(self, cursor, n):
         # A simple statement like the following can easily deadlock:
         #
         # INSERT INTO new_oid (zoid)
@@ -78,8 +78,6 @@ class MySQLOIDAllocator(AbstractTableOIDAllocator):
         # Partly this is because MAX() is local to the current session.
         # We deal with this by using a stored procedure to efficiently make
         # multiple queries.
-
-        n = (oid_int + 15) // 16
         self.driver.callproc_multi_result(cursor, 'set_min_oid(%s)', (n,))
 
    # Notes on new_oids:

--- a/src/relstorage/adapters/oracle/oidallocator.py
+++ b/src/relstorage/adapters/oracle/oidallocator.py
@@ -21,18 +21,17 @@ from zope.interface import implementer
 
 from ..._compat import metricmethod
 from ..interfaces import IOIDAllocator
-from ..oidallocator import AbstractOIDAllocator
+from ..oidallocator import AbstractRangedOIDAllocator
 
 
 @implementer(IOIDAllocator)
-class OracleOIDAllocator(AbstractOIDAllocator):
+class OracleOIDAllocator(AbstractRangedOIDAllocator):
 
     def __init__(self, connmanager):
         self.connmanager = connmanager
 
-    def set_min_oid(self, cursor, oid_int):
+    def _set_min_oid_from_range(self, cursor, n):
         """Ensure the next OID is at least the given OID."""
-        n = (oid_int + 15) // 16
         stmt = "SELECT zoid_seq.nextval FROM DUAL"
         cursor.execute(stmt)
         next_n = cursor.fetchone()[0]

--- a/src/relstorage/adapters/postgresql/oidallocator.py
+++ b/src/relstorage/adapters/postgresql/oidallocator.py
@@ -21,17 +21,15 @@ from zope.interface import implementer
 
 from ..._compat import metricmethod
 from ..interfaces import IOIDAllocator
-from ..oidallocator import AbstractOIDAllocator
+from ..oidallocator import AbstractRangedOIDAllocator
 
 
 @implementer(IOIDAllocator)
-class PostgreSQLOIDAllocator(AbstractOIDAllocator):
+class PostgreSQLOIDAllocator(AbstractRangedOIDAllocator):
 
     __slots__ = ()
 
-    def set_min_oid(self, cursor, oid_int):
-        """Ensure the next OID is at least the given OID."""
-        n = (oid_int + 15) // 16
+    def _set_min_oid_from_range(self, cursor, n):
         # This potentially wastes a value from the sequence to find
         # out that we're already past the max. But that's the only option:
         # curval() is local to this connection, and 'ALTER SEQUENCE ... MINVALUE n STARTS WITH n'

--- a/src/relstorage/adapters/sqlite/drivers.py
+++ b/src/relstorage/adapters/sqlite/drivers.py
@@ -311,7 +311,7 @@ class Sqlite3GeventDriver(GeventDriverMixin,
     yield_to_gevent_instruction_interval = 100
 
     def configure_from_options(self, options):
-        if options.adapter:
+        if options.adapter and options.adapter.config.gevent_yield_interval:
             conf = options.adapter.config
             self.yield_to_gevent_instruction_interval = conf.gevent_yield_interval
 

--- a/src/relstorage/adapters/tests/test_oidallocator.py
+++ b/src/relstorage/adapters/tests/test_oidallocator.py
@@ -8,12 +8,12 @@ from __future__ import print_function
 
 from relstorage.tests import TestCase
 
-from ..oidallocator import AbstractOIDAllocator
+from ..oidallocator import AbstractRangedOIDAllocator
 
 
-class MockOIDAllocator(AbstractOIDAllocator):
+class MockOIDAllocator(AbstractRangedOIDAllocator):
 
-    def set_min_oid(self, cursor, oid_int):
+    def _set_min_oid_from_range(self, cursor, n):
         raise NotImplementedError
 
     def new_oids(self, cursor):


### PR DESCRIPTION
 Could be a problem after copying transactions.

Finally unifies all the various implementations into a single place so this doesn't happen again. 