### PR TITLE
PostgreSQL: Send the application_name at connect time.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,10 +12,20 @@
 - PostgreSQL: Reduce the load connection's isolation level from
   ``SERIALIZABLE`` to ``REPEATABLE READ`` (two of the three other
   supported databases also operate at this level). This allows
-  connecting to streaming replicas. Since the connection is read-only,
-  and there were no other ``SERIALIZABLE`` transactions (the store
-  connection operates in ``READ COMMITTED`` mode), there should be no
-  other visible effects. See :issue:`376`.
+  connecting to hot standby/streaming replicas. Since the connection
+  is read-only, and there were no other ``SERIALIZABLE`` transactions
+  (the store connection operates in ``READ COMMITTED`` mode), there
+  should be no other visible effects. See :issue:`376`.
+
+- PostgreSQL: pg8000: Properly handle a ``port`` specification in the
+  ``dsn`` configuration. See :issue:`378`.
+
+- PostgreSQL: All drivers pass the ``application_name`` parameter at
+  connect time instead of later. This solves an issue with psycopg2
+  and psycopg2cffi connecting to hot standbys.
+
+- All databases: If ``create-schema`` is false, use a read-only
+  connection to verify that the schema is correct.
 
 - Packaging: Prune unused headers from the include/ directory.
 

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -82,13 +82,17 @@ class IDBDriver(Interface):
     cursor_arraysize = Attribute(
         "The value to assign to each new cursor's ``arraysize`` attribute.")
 
-    def connect(*args, **kwargs):
-        """
-        Create and return a new connection object.
+    connect = Attribute("""
+    A callable to create and return a new connection object.
 
-        This connection, and all objects created from it such as cursors,
-        should be used within a single thread only.
-        """
+    The signature is not specified here because the
+    required parameters differ between databases and drivers. The interface
+    should be agreed upon between the :class:`IConnectionManager` and
+    the drivers for its database.
+
+    This connection, and all objects created from it such as cursors,
+    should be used within a single thread only.
+    """)
 
     def cursor(connection, server_side=False):
         """

--- a/src/relstorage/adapters/mysql/schema.py
+++ b/src/relstorage/adapters/mysql/schema.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from ZODB.POSException import StorageError
 from zope.interface import implementer
 
+from ..connmanager import connection_callback
 from ..interfaces import ISchemaInstaller
 from ..schema import AbstractSchemaInstaller
 from ..schema import Schema
@@ -193,7 +194,7 @@ class MySQLSchemaInstaller(AbstractSchemaInstaller):
             cursor.execute("ALTER TABLE %s ENGINE=Innodb" % (table,))
         logger.info("Done converting tables to InnoDB: %s", tables)
 
-
+    @connection_callback(inherit=AbstractSchemaInstaller._prepare_with_connection)
     def _prepare_with_connection(self, conn, cursor):
         from .oidallocator import MySQLOIDAllocator
         self.__convert_all_tables_to_innodb(cursor)

--- a/src/relstorage/adapters/postgresql/connmanager.py
+++ b/src/relstorage/adapters/postgresql/connmanager.py
@@ -132,5 +132,5 @@ class Psycopg2ConnectionManager(AbstractConnectionManager):
             read_only=True,
             deferrable=False,
             replica_selector=self.ro_replica_selector,
-            application_name='RS load'
+            application_name='RS: Load'
         )

--- a/src/relstorage/adapters/postgresql/drivers/__init__.py
+++ b/src/relstorage/adapters/postgresql/drivers/__init__.py
@@ -46,6 +46,20 @@ class AbstractPostgreSQLDriver(AbstractModuleDriver):
                                read_only=False,
                                deferrable=False,
                                application_name=None):
+        """
+        Return a connection whose transactions will have the defined
+        characteristics and which will use the given
+        ``application_name``.
+
+        The driver should pass the ``application_name`` as part of the
+        connect packet, and *not* via ``SET SESSION application_name``.
+        This is because the former is both faster and
+        because the latter does not work when connecting to a hot
+        standby (it triggers "cannot set transaction read-write mode
+        during recovery"). If it cannot be passed at connect time,
+        an alternative is ``SELECT set_config('application_name', %s, FALSE)``
+        which does not seem to have this problem.
+        """
         raise NotImplementedError
 
     def set_lock_timeout(self, cursor, timeout):

--- a/src/relstorage/adapters/postgresql/schema.py
+++ b/src/relstorage/adapters/postgresql/schema.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 from zope.interface import implementer
 
+from ..connmanager import connection_callback
 from ..interfaces import ISchemaInstaller
 from ..schema import AbstractSchemaInstaller
 
@@ -122,6 +123,7 @@ class PostgreSQLSchemaInstaller(AbstractSchemaInstaller):
         name, = row
         return self._metadata_to_native_str(name)
 
+    @connection_callback(inherit=AbstractSchemaInstaller._prepare_with_connection)
     def _prepare_with_connection(self, conn, cursor):
         super(PostgreSQLSchemaInstaller, self)._prepare_with_connection(conn, cursor)
 

--- a/src/relstorage/adapters/postgresql/stats.py
+++ b/src/relstorage/adapters/postgresql/stats.py
@@ -50,6 +50,7 @@ class PostgreSQLStats(AbstractStats):
         return self.connmanager.open_and_call(get_size)
 
     def large_database_change(self):
+
         def analyze(_conn, cursor):
             # VACUUM cannot be run inside a transaction block;
             # ANALYZE can be. Both update pg_class.reltuples.

--- a/src/relstorage/adapters/schema.py
+++ b/src/relstorage/adapters/schema.py
@@ -29,6 +29,8 @@ from ._util import DatabaseHelpersMixin
 from ._util import query_property
 from ._util import noop_when_history_free
 
+from .connmanager import connection_callback
+
 from .sql import View
 from .sql import Table
 from .sql import TemporaryTable
@@ -716,6 +718,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
                                     self.all_views,
                                     self.list_views(cursor))
 
+    @connection_callback(read_only=False, application_name="RS: PrepareSchema")
     def _prepare_with_connection(self, conn, cursor): # pylint:disable=unused-argument
         # XXX: We can generalize this to handle triggers, procs, etc,
         # to make subclasses have easier time.
@@ -737,6 +740,7 @@ class AbstractSchemaInstaller(DatabaseHelpersMixin,
     def verify(self):
         self.connmanager.open_and_call(self._verify)
 
+    @connection_callback(read_only=True, application_name='RS: VerifySchema')
     def _verify(self, conn, cursor): # pylint:disable=unused-argument
         tables = self.list_tables(cursor)
         self.check_compatibility(cursor, tables)


### PR DESCRIPTION
This is faster and more importantly works even when connecting to a hot standby. SET SESSION application_name does not work, eventhough it is documented that SET does work.

Also handle a port specification in pg8000.

Fixes #378 and further refines #376 (this time I set up a hot standby and ran zodbshootout's cold benchmark against it so that much at least works).