### PR TITLE
Fix sqlite+gevent deadlocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ env:
 script:
 # coverage slows PyPy down from 2minutes to 12+.
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --rcfile=.pylintrc relstorage -f parseable -r n; fi
-  - coverage run -p --concurrency=greenlet .travis/zope_testrunner_gevent.py -t check7 -t check2 -t BlobCache -t Switches --layer gevent
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=greenlet .travis/zope_testrunner_gevent.py -t check7 -t check2 -t BlobCache -t Switches --layer gevent; fi
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then python $RS_TEST_CMD --layer "!gevent"; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=thread  $RS_TEST_CMD --layer "!gevent"; fi
   # Make sure we can import without zope.schema, which is intended to

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,14 @@ env:
 script:
 # coverage slows PyPy down from 2minutes to 12+.
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --rcfile=.pylintrc relstorage -f parseable -r n; fi
-  - python -m gevent.monkey `which zope-testrunner` --test-path=src --color -vvv -t BlobCache -t Switches --layer gevent
+  - coverage run -p --concurrency=greenlet .travis/zope_testrunner_gevent.py -t check7 -t check2 -t BlobCache -t Switches --layer gevent
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then python $RS_TEST_CMD --layer "!gevent"; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run $RS_TEST_CMD --layer "!gevent"; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=thread  $RS_TEST_CMD --layer "!gevent"; fi
   # Make sure we can import without zope.schema, which is intended to
   # be a test dependency, and optional for production
   - pip uninstall -y zope.schema && python -c 'import relstorage.interfaces, relstorage.adapters.interfaces, relstorage.cache.interfaces'
 after_success:
+  - coverage combine
   - coveralls
 notifications:
   email: false

--- a/.travis/zope_testrunner_gevent.py
+++ b/.travis/zope_testrunner_gevent.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+Script to run zope.testrunner in a gevent monkey-patched environment.
+
+Using ``python -m gevent.monkey zope-testrunner ...`` is insufficient.
+
+This is because up through 1.5a2 there is a serious bug in the way the
+monkey-patcher patches the spawned process. The net effect is that the gevent
+threadpool isn't functional.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import gevent.monkey
+gevent.monkey.patch_all()
+# pylint:disable=wrong-import-position, wrong-import-order
+import sys
+
+from zope.testrunner import run
+
+sys.argv[:] = [
+    'zope-testrunner',
+    '--test-path=src',
+    '-vvv',
+    '--color',
+] + sys.argv[1:]
+print(sys.argv)
+run()

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 
 - MySQL+gevent: Release the critical section a bit sooner. See :issue:`381`.
 
+- SQLite+gevent: Fix possible deadlocks with gevent if switchers
+  occurred at unexpected times. See :issue:`382`.
+
 3.0.0 (2019-11-12)
 ==================
 

--- a/src/relstorage/_util.py
+++ b/src/relstorage/_util.py
@@ -250,7 +250,7 @@ def log_timed_only_self(func):
 
 _ThreadWithReady = None
 
-def thread_spawn(func, args, daemon=False):
+def thread_spawn(func, args=(), daemon=False):
     global _ThreadWithReady
     if _ThreadWithReady is None:
         import threading
@@ -282,7 +282,7 @@ def thread_spawn(func, args, daemon=False):
     t.start()
     return t
 
-def _gevent_pool_spawn(func, args):
+def _gevent_pool_spawn(func, args=()):
     import gevent
     return gevent.get_hub().threadpool.spawn(func, *args)
 

--- a/src/relstorage/adapters/connections.py
+++ b/src/relstorage/adapters/connections.py
@@ -233,7 +233,7 @@ class AbstractManagedConnection(object):
             if not can_reconnect:
                 raise
             logger.warning("Disconnected (%s) when running %s; attempting reconnect",
-                           e, f, self, exc_info=True)
+                           e, f, exc_info=True)
             self.drop()
             try:
                 self._open_connection()

--- a/src/relstorage/adapters/mysql/mover.py
+++ b/src/relstorage/adapters/mysql/mover.py
@@ -50,8 +50,15 @@ class MySQLObjectMover(AbstractObjectMover):
             #
             # It's possible that the DDL lock that TRUNCATE takes can be a bottleneck
             # in some places, though?
-            cursor.execute("CALL clean_temp_state(%s)" % (self.truncate_temp_tables,))
-            cursor.fetchall()
+
+            # (Here, even though we don't actually expect any result, MySQLConnector
+            # likes to throw InterfaceError: No result set to fetch from, unlike
+            # every other driver that has a result for the proc. So we use, and ignore,
+            # callproc_multi_result)
+            self.driver.callproc_multi_result(
+                cursor,
+                "clean_temp_state(%s)" % (self.truncate_temp_tables,)
+            )
         else:
             # InnoDB tables benchmark much faster for concurrency=2
             # and 6 than MyISAM tables under both MySQL 5.5 and 5.7,

--- a/src/relstorage/adapters/sqlite/adapter.py
+++ b/src/relstorage/adapters/sqlite/adapter.py
@@ -47,6 +47,7 @@ class Sqlite3Adapter(AbstractAdapter):
     driver_options = drivers
     WRITING_REQUIRES_EXCLUSIVE_LOCK = True
 
+
     def __init__(self, data_dir, pragmas,
                  options=None, oidallocator=None,
                  gevent_yield_interval=None):
@@ -78,7 +79,9 @@ class Sqlite3Adapter(AbstractAdapter):
         if not self.oidallocator:
             self.oidallocator = Sqlite3OIDAllocator(
                 os.path.join(self.data_dir, 'oids.sqlite3'),
-                driver=driver
+                # No switching during OID allocation. It holds an exclusive
+                # lock anyway.
+                driver=drivers.Sqlite3Driver()
             )
 
         self.runner = Sqlite3ScriptRunner()

--- a/src/relstorage/adapters/sqlite/locker.py
+++ b/src/relstorage/adapters/sqlite/locker.py
@@ -27,9 +27,9 @@ from ..locker import AbstractLocker
 class Sqlite3Locker(AbstractLocker):
 
     supports_row_lock_nowait = False
-    _lock_share_clause = ''
-    _lock_share_clause_nowait = ''
-    _lock_current_clause = ''
+    _lock_share_clause = '<This should not be used>'
+    _lock_share_clause_nowait = '<This should not be used>'
+    _lock_current_clause = '<This Should not be used>'
 
     def _lock_readCurrent_oids_for_share(self, cursor, current_oids, shared_locks_block):
         """
@@ -54,7 +54,7 @@ class Sqlite3Locker(AbstractLocker):
         # in a tranasction. In which case there's nothing to do (but for safety
         # we still execute the query)
         AbstractLocker._lock_rows_being_modified(self, cursor)
-        assert conn.in_transaction or conn.in_transaction is None # Py2
+        assert conn.in_transaction or conn.in_transaction is None, repr(conn) # Py2
 
     def hold_commit_lock(self, cursor, ensure_current=False, nowait=False):
         # We may or may not actually have locked rows; if we're doing a restore

--- a/src/relstorage/storage/tpc/temporary_storage.py
+++ b/src/relstorage/storage/tpc/temporary_storage.py
@@ -63,7 +63,7 @@ class TemporaryStorage(object):
     def __len__(self):
         # How many distinct OIDs have been stored?
         # This also lets us be used in a boolean context to see
-        # if we've actually stored anything.
+        # if we've actually stored anything or are closed.
         return len(self._queue_contents)
 
     @property
@@ -114,4 +114,4 @@ class TemporaryStorage(object):
         if self._queue is not None:
             self._queue.close()
             self._queue = None
-            self._queue_contents = None
+            self._queue_contents = () # Not None so len() keeps working

--- a/src/relstorage/tests/blob/blob_cache.py
+++ b/src/relstorage/tests/blob/blob_cache.py
@@ -110,10 +110,9 @@ class TestBlobCacheMixin(TestBlobMixin):
             self._verify_blob_number(blob_number, conn, mode)
         conn.close()
 
-
     def _wait_for_shrinks_to_finish(self):
         cache_checker = self.blob_storage.blobhelper.cache_checker
-        cache_checker.reduced_event.wait()
+        cache_checker.wait_for_checker()
         size = self._size_blobs_in_directory()
         self.assertLess(size, 5000)
 

--- a/src/relstorage/tests/blob/blob_cache.py
+++ b/src/relstorage/tests/blob/blob_cache.py
@@ -53,6 +53,14 @@ class TestBlobCacheMixin(TestBlobMixin):
     CLIENT_COUNT = 4 if not RUNNING_ON_CI else 2
 
     def setUp(self):
+        # and don't actually use native threads in gevent mode. They can't be
+        # waited on which makes this test racy.
+
+        from relstorage.blobhelper import cached
+        from relstorage._util import thread_spawn
+        assert cached.native_thread_spawn is not thread_spawn
+        cached.native_thread_spawn = thread_spawn
+
         super(TestBlobCacheMixin, self).setUp()
         # We're going to wait for any threads we started to finish, so...
         self._old_threads = list(threading.enumerate())
@@ -68,7 +76,10 @@ class TestBlobCacheMixin(TestBlobMixin):
 
     def tearDown(self):
         # # Let the shrink run as many more times as it needs to, if it's waiting.
-        # self.cleanup_finished.release()
+        from relstorage.blobhelper import cached
+        from relstorage._util import spawn as native_thread_spawn
+        cached.native_thread_spawn = native_thread_spawn
+
         self._wait_for_all_spawned_threads_to_finish()
         self._old_threads = []
         super(TestBlobCacheMixin, self).tearDown()


### PR DESCRIPTION
The problem happened if we switched away from a connection holding locks and into one that wanted to take those same locks, and wanted to do so *without* switching. This could be non-deterministic (or rather, very data specific because of how interval switching is done).

The solution was to move those operations that take locks into gevent's threadpool so they're guaranteed not to block the event loop. Fixes #382.

Add tests for this scenario. Also, CI wasn't properly testing gevent monkey-patching because of a bug in gevent.monkey. Workaround that and fix some small issues that the gevent.monkey bug was hiding (around mixing of real native threads and greenlets) and a couple of logging issues I encountered while debugging.