### PR TITLE
Fix #385 by eliminating the multiple result sets for lock_objects_and

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ env:
 script:
 # coverage slows PyPy down from 2minutes to 12+.
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint --rcfile=.pylintrc relstorage -f parseable -r n; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=greenlet .travis/zope_testrunner_gevent.py -t check7 -t check2 -t BlobCache -t Switches --layer gevent; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=greenlet .travis/zope_testrunner_gevent.py -t checkBTreesLengthStress -t check7 -t check2 -t BlobCache -t Switches --layer gevent; fi
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then python $RS_TEST_CMD --layer "!gevent"; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=thread  $RS_TEST_CMD --layer "!gevent"; fi
   # Make sure we can import without zope.schema, which is intended to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,21 @@
 
 - MySQL+gevent: Release the critical section a bit sooner. See :issue:`381`.
 
-- SQLite+gevent: Fix possible deadlocks with gevent if switchers
+- SQLite+gevent: Fix possible deadlocks with gevent if switches
   occurred at unexpected times. See :issue:`382`.
+
+- MySQL+gevent: Fix possible deadlocks with gevent if switches
+  occurred at unexpected times. See :issue:`385`.  This also included
+  some minor optimizations.
+
+  .. caution::
+
+     This introduces a change in a stored procedure that is not
+     compatible with older versions of RelStorage. When this version
+     is first deployed, if there are older versions of RelStorage
+     still running, they will be unable to commit. They will fail with
+     a transient conflict error; they may attempt retries, but wil not
+     succeed. Read-only transactions will continue to work.
 
 3.0.0 (2019-11-12)
 ==================

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -1555,7 +1555,10 @@ class IRelStorageAdapter(Interface):
 class ReplicaClosedException(Exception):
     """The connection to the replica has been closed"""
 
-class UnableToAcquireCommitLockError(StorageError):
+class UnableToAcquireLockError(Exception):
+    "A lock cannot be acquired."
+
+class UnableToAcquireCommitLockError(StorageError, UnableToAcquireLockError):
     """
     The commit lock cannot be acquired due to a timeout.
 
@@ -1565,7 +1568,9 @@ class UnableToAcquireCommitLockError(StorageError):
     However, for historical reasons, this exception is not a ``TransientError``.
     """
 
-class UnableToLockRowsToModifyError(ConflictError):
+# TransientError -> ConflictError -> ReadConflictError
+
+class UnableToLockRowsToModifyError(ConflictError, UnableToAcquireLockError):
     """
     We were unable to lock one or more rows that we intend to modify
     due to a timeout.
@@ -1577,7 +1582,7 @@ class UnableToLockRowsToModifyError(ConflictError):
     This is a type of ``ConflictError``, which is a transient error.
     """
 
-class UnableToLockRowsToReadCurrentError(ReadConflictError):
+class UnableToLockRowsToReadCurrentError(ReadConflictError, UnableToAcquireLockError):
     """
     We were unable to lock one or more rows that belong to an object
     that ``Connection.readCurrent()`` was called on.
@@ -1589,7 +1594,7 @@ class UnableToLockRowsToReadCurrentError(ReadConflictError):
     This is a type of ``ReadConflictError``, which is a transient error.
     """
 
-class UnableToAcquirePackUndoLockError(StorageError):
+class UnableToAcquirePackUndoLockError(StorageError, UnableToAcquireLockError):
     """A pack or undo operation is in progress."""
 
 

--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -253,7 +253,7 @@ class AbstractLocker(DatabaseHelpersMixin,
             logger.debug("Failed to acquire commit lock:\n%s", debug_info)
         message = "Acquiring a commit lock failed: %s%s" % (
             sys.exc_info()[1],
-            '\n' + debug_info if debug_info else ''
+            '\n' + debug_info if debug_info else '(No debug info.)'
         )
         six.reraise(
             kind,

--- a/src/relstorage/adapters/mysql/drivers/__init__.py
+++ b/src/relstorage/adapters/mysql/drivers/__init__.py
@@ -181,6 +181,9 @@ class AbstractMySQLDriver(AbstractModuleDriver):
               ...
             ]
 
+        The last item in the list is the result of the stored procedure
+        itself.
+
         Note that, because 'CALL' potentially returns multiple result
         sets, there is potentially at least one extra database round
         trip involved when we call ``cursor.nextset()``. If the
@@ -216,6 +219,15 @@ class AbstractMySQLDriver(AbstractModuleDriver):
         while cursor.nextset():
             multi_results.append(cursor.fetchall())
         return multi_results
+
+    def callproc_no_result(self, cursor, proc, args=()):
+        """
+        An optimization for calling stored procedures that don't
+        produce any results, except for the null result of calling the
+        procedure itself.
+        """
+        cursor.execute('CALL ' + proc, args)
+        cursor.fetchall()
 
     def exit_critical_phase(self, connection, cursor):
         "Override if you implement critical phases."

--- a/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
@@ -208,6 +208,10 @@ class PyMySQLConnectorDriver(AbstractMySQLDriver):
                 break
         return multi_results
 
+    def callproc_no_result(self, cursor, proc, args=()):
+        # Again, weird. The call's empty result set seems to be consumed.
+        cursor.execute("CALL " + proc, args)
+
 class CMySQLConnectorDriver(PyMySQLConnectorDriver):
     __name__ = 'C ' + _base_name
 

--- a/src/relstorage/adapters/mysql/drivers/mysqldb.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqldb.py
@@ -118,6 +118,7 @@ class GeventMySQLdbDriver(GeventDriverMixin,
         # direct call to our desired class.
         self._connect = self._get_connection_class()
         self._strict_cursor = self._connect.default_cursor
+        self._server_side_cursor = self._connect.default_cursor
 
     _Connection = None
 
@@ -135,7 +136,3 @@ class GeventMySQLdbDriver(GeventDriverMixin,
     def _get_connection_class(cls):
         from ._mysqldb_gevent import Connection
         return Connection
-
-    @Lazy
-    def _server_side_cursor(self):
-        return self._get_connection_class().default_cursor

--- a/src/relstorage/adapters/mysql/mover.py
+++ b/src/relstorage/adapters/mysql/mover.py
@@ -28,8 +28,6 @@ from ..mover import metricmethod_sampled
 @implementer(IObjectMover)
 class MySQLObjectMover(AbstractObjectMover):
 
-    truncate_temp_tables = 'false'
-
     _create_temp_store = Schema.temp_store.create()
 
     @metricmethod_sampled
@@ -51,13 +49,9 @@ class MySQLObjectMover(AbstractObjectMover):
             # It's possible that the DDL lock that TRUNCATE takes can be a bottleneck
             # in some places, though?
 
-            # (Here, even though we don't actually expect any result, MySQLConnector
-            # likes to throw InterfaceError: No result set to fetch from, unlike
-            # every other driver that has a result for the proc. So we use, and ignore,
-            # callproc_multi_result)
-            self.driver.callproc_multi_result(
+            self.driver.callproc_no_result(
                 cursor,
-                "clean_temp_state(%s)" % (self.truncate_temp_tables,)
+                "clean_temp_state(false)"
             )
         else:
             # InnoDB tables benchmark much faster for concurrency=2

--- a/src/relstorage/adapters/mysql/oidallocator.py
+++ b/src/relstorage/adapters/mysql/oidallocator.py
@@ -78,7 +78,7 @@ class MySQLOIDAllocator(AbstractTableOIDAllocator):
         # Partly this is because MAX() is local to the current session.
         # We deal with this by using a stored procedure to efficiently make
         # multiple queries.
-        self.driver.callproc_multi_result(cursor, 'set_min_oid(%s)', (n,))
+        self.driver.callproc_no_result(cursor, 'set_min_oid(%s)', (n,))
 
    # Notes on new_oids:
 

--- a/src/relstorage/adapters/mysql/schema.py
+++ b/src/relstorage/adapters/mysql/schema.py
@@ -333,6 +333,9 @@ class MySQLVersionDetector(DatabaseHelpersMixin):
         return self._version_info
 
     def supports_nowait(self, cursor):
+        """
+        Can we use ``FOR SHARE NOWAIT``?
+        """
         return self.get_major_version(cursor) >= 8
 
     def supports_transaction_isolation(self, cursor):


### PR DESCRIPTION
…_detect_conflicts

It turns out the root of the problem was that there's no way to
reliably know whether we need to, or even can, go around the event
loop to get the second and subsequent result sets. And previously, it
could either be the first result set or the second result set that
blocked taking locks. If one green let blocked in the second, and another blocked in the first, for the same objects we’d deadlock

Now there's only one result set, so our normal way of waiting for IO
to arrive works.

Also throws in some minor optimizations targeted to avoiding extra
trips around the event loop.

Note the incompatible stored proc change. RelStorage took steps to make sure incompatible versions don’t commit at the same time