### PR TITLE
Use unsigned BTrees in the internal data structures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@
  Changes
 =========
 
-3.0.2 (unreleased)
+3.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Use unsigned BTrees for internal data structures to avoid wrapping
+  in large databases. Requires BTrees 4.7.0.
 
 
 3.0.1 (2019-11-22)

--- a/docs/db-specific-options.rst
+++ b/docs/db-specific-options.rst
@@ -99,6 +99,9 @@ driver
      <http://initd.org/psycopg/docs/connection.html#connection.set_session>`_
      with certain configurations of connection load balancers.
 
+     This driver cannot handle OID and TID parameters greater than
+     nine quintillion (``2^63``).
+
 dsn
     Specifies the data source name for connecting to PostgreSQL.
     A PostgreSQL DSN is a list of parameters separated with

--- a/docs/db-specific-options.rst
+++ b/docs/db-specific-options.rst
@@ -320,6 +320,12 @@ filesystem cache to serve that purpose.
 This adapter supports blobs, but you still must configure a
 ``blob-cache-dir``, or use a ``shared-blob-dir``.
 
+.. note::
+
+   SQLite is limited to 8-byte signed integers for OIDs and TIDs. If
+   you expect to go through more than nine quintillion objects, or use
+   the database past the year 5908, SQLite might not be the right choice.
+
 For more, see :doc:`faq`.
 
 There is one required setting:

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,11 @@ tests_require = [
     'nti.testing',
     'gevent >= 1.5a1; sys_platform != "win32"',
     'pyperf',
-    'psutil',
+    # Versions of PyPy2 prior to 7.4 (maybe?) are incompatible with
+    # psutil >= 5.6.4.
+    # https://github.com/giampaolo/psutil/issues/1659
+    'psutil; platform_python_implementation=="CPython" or python_version!="2.7"',
+    'psutil == 5.6.3; platform_python_implementation=="PyPy" and python_version=="2.7"',
 ] + memcache_require
 
 

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
         'zope.interface',
         'zope.dottedname',
         'zc.lockfile',
+        'BTrees >= 4.7.0', # unsigned btrees in 4.7+
         # These are the versions we're testing against. ZODB 5.2.2 is
         # when checkSecure() went away and IMVCCAfterCompletionStorage
         # was added, and 5.1.2 is when Connection.new_oid was added

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -283,6 +283,8 @@ TidList = OidList
 # This is b"\xff\xff\xff\xff\xff\xff\xff\xff"
 # It requires an 8 byte unsigned integer to store.
 MAX_TID = BTrees.family64.maxuint
+# The maximum TID if only signed values are allowed.
+MAX_S_TID = BTrees.family64.maxint
 
 def iteroiditems(d):
     # Could be either a BTree, which always has 'iteritems',

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -279,6 +279,9 @@ if _64bit_array and not PYPY:
 else:
     OidList = list
 TidList = OidList
+# The maximum theoretical TID (and OID, incidentally).
+# This is b"\xff\xff\xff\xff\xff\xff\xff\xff"
+# It requires an 8 byte unsigned integer to store.
 MAX_TID = BTrees.family64.maxuint
 
 def iteroiditems(d):

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -133,7 +133,7 @@ if BTrees.LLBTree.LLBTree is not BTrees.LLBTree.LLBTreePy: # pylint:disable=no-m
     # Using these values and an OidSet of about 800,000 objects (from
     # a real cache file) results in 12,000 fewer LLSet objects being
     # created, and 2MB less memory being used.
-    class OID_TID_MAP_TYPE(BTrees.family64.II.BTree):
+    class OID_TID_MAP_TYPE(BTrees.family64.UU.BTree):
         __slots__ = ()
         # Since these are contiguous arrays, there *might* be some
         # benefit in keeping them within a virtual memory page
@@ -149,18 +149,18 @@ if BTrees.LLBTree.LLBTree is not BTrees.LLBTree.LLBTreePy: # pylint:disable=no-m
         # This is definitely 64 bits
         max_leaf_size = 4095 # under 32K, or 8 pages.
 
-    class OID_OBJECT_MAP_TYPE(BTrees.family64.IO.BTree):
+    class OID_OBJECT_MAP_TYPE(BTrees.family64.UO.BTree):
         __slots__ = ()
         max_internal_size = OID_TID_MAP_TYPE.max_internal_size
         max_leaf_size = OID_TID_MAP_TYPE.max_leaf_size
 
-    class OID_SET_TYPE(BTrees.family64.II.TreeSet):
+    class OID_SET_TYPE(BTrees.family64.UU.TreeSet):
         max_internal_size = OID_TID_MAP_TYPE.max_internal_size
         max_leaf_size = OID_TID_MAP_TYPE.max_leaf_size
 
-    OidTMap_difference = BTrees.family64.II.difference  # pylint:disable=no-member
-    OidTMap_multiunion = BTrees.family64.II.multiunion  # pylint:disable=no-member
-    OidTMap_intersection = BTrees.family64.II.intersection  # pylint:disable=no-member
+    OidTMap_difference = BTrees.family64.UU.difference  # pylint:disable=no-member
+    OidTMap_multiunion = BTrees.family64.UU.multiunion  # pylint:disable=no-member
+    OidTMap_intersection = BTrees.family64.UU.intersection  # pylint:disable=no-member
     OidSet_difference = OidTMap_difference
     def OidSet_discard(s, val):
         try:
@@ -279,7 +279,7 @@ if _64bit_array and not PYPY:
 else:
     OidList = list
 TidList = OidList
-MAX_TID = BTrees.family64.maxint
+MAX_TID = BTrees.family64.maxuint
 
 def iteroiditems(d):
     # Could be either a BTree, which always has 'iteritems',

--- a/src/relstorage/_mvcc.py
+++ b/src/relstorage/_mvcc.py
@@ -50,7 +50,7 @@ class DetachableMVCCDatabaseCoordinator(object):
         # the set() in _registered_viewers to be atomic.
         self._lock = threading.RLock()
         # {tid: {viewer, ...}} of objects not detached and not None
-        self._by_tid = family64.IO.Bucket()
+        self._by_tid = family64.UO.Bucket()
         self._registered_viewers = set()
         self.is_registered = self._registered_viewers.__contains__
 

--- a/src/relstorage/adapters/_util.py
+++ b/src/relstorage/adapters/_util.py
@@ -21,6 +21,7 @@ from functools import update_wrapper
 from functools import wraps
 
 from .._compat import intern
+from .._compat import MAX_TID
 
 from .._util import Lazy
 
@@ -142,6 +143,8 @@ ResultDescription = namedtuple(
 
 
 class DatabaseHelpersMixin(object):
+
+    MAX_TID = MAX_TID
 
     def _metadata_to_native_str(self, value):
         # Some drivers, in some configurations, notably older versions

--- a/src/relstorage/adapters/dbiter.py
+++ b/src/relstorage/adapters/dbiter.py
@@ -18,15 +18,15 @@ from collections import namedtuple
 
 from zope.interface import implementer
 
-from relstorage._compat import MAX_TID
 from relstorage._compat import TidList
 from relstorage._util import Lazy
 
+from ._util import DatabaseHelpersMixin
 from .interfaces import IDatabaseIterator
 from .schema import Schema
 from .sql import it
 
-class DatabaseIterator(object):
+class DatabaseIterator(DatabaseHelpersMixin):
     """
     Abstract base class for database iteration.
     """
@@ -152,7 +152,7 @@ class HistoryPreservingDatabaseIterator(DatabaseIterator):
         """
         params = {
             'min_tid': start if start else 0,
-            'max_tid': stop if stop else MAX_TID
+            'max_tid': stop if stop else self.MAX_TID
         }
         self._iter_transactions_range_query.execute(cursor, params)
         return self._transaction_iterator(cursor)
@@ -254,7 +254,7 @@ class HistoryFreeDatabaseIterator(DatabaseIterator):
         """
         params = {
             'min_tid': start if start else 0,
-            'max_tid': stop if stop else MAX_TID
+            'max_tid': stop if stop else self.MAX_TID
         }
         self._iter_transactions_range_query.execute(cursor, params)
         return _HistoryFreeTransactionRange(TidList((tid for (tid,) in cursor)))

--- a/src/relstorage/adapters/drivers.py
+++ b/src/relstorage/adapters/drivers.py
@@ -129,6 +129,10 @@ class AbstractModuleDriver(object):
 
     DriverNotAvailableError = DriverNotAvailableError
 
+    # Can the driver support the full range of a 64-bit unsigned ID for
+    # OID and TID parameters?
+    supports_64bit_unsigned_id = True
+
     def __init__(self):
         if PYPY and not self.AVAILABLE_ON_PYPY:
             raise self.DriverNotAvailableError(self.__name__)

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -908,6 +908,8 @@ class IOIDAllocator(Interface):
 class IPackUndo(Interface):
     """Perform pack and undo operations"""
 
+    MAX_TID = Attribute("The maximum TID that can be stored.")
+
     def verify_undoable(cursor, undo_tid):
         """Raise UndoError if it is not safe to undo the specified txn.
         """

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -82,6 +82,8 @@ class IDBDriver(Interface):
     cursor_arraysize = Attribute(
         "The value to assign to each new cursor's ``arraysize`` attribute.")
 
+    supports_64bit_unsigned_id = Attribute("Can the driver handle 2**64 as a parameter?")
+
     connect = Attribute("""
     A callable to create and return a new connection object.
 

--- a/src/relstorage/adapters/postgresql/drivers/pg8000.py
+++ b/src/relstorage/adapters/postgresql/drivers/pg8000.py
@@ -71,6 +71,7 @@ class PG8000Driver(AbstractPostgreSQLDriver):
 
     dialect = PG8000Dialect()
     supports_multiple_statement_execute = False
+    supports_64bit_unsigned_id = False
 
     def __init__(self):
         super(PG8000Driver, self).__init__()

--- a/src/relstorage/adapters/sqlite/__init__.py
+++ b/src/relstorage/adapters/sqlite/__init__.py
@@ -18,7 +18,7 @@ sqlite3 adapter for RelStorage.
 General Design Notes
 ====================
 
-Sqlite3 ``INTEGER PRIMARY KEY`` values are always 64-bit unsigned
+Sqlite3 ``INTEGER PRIMARY KEY`` values are always 64-bit *signed*
 integers. If not given, they default to an unused integer (typically
 incrementing). If the ``AUTOINCREMENT`` keyword is provided, then they
 prevent reuse of values even after they are deleted via an auxiliary
@@ -76,6 +76,16 @@ essentially any time, even outside of the normal two-phase commit
 sequence (thanks to Connection.add()) and we cannot allow the main
 database to be locked like that.
 
+Because OIDs are signed 64-bit integers, they cannot store values
+larger than 2**63 - 1 (around nine quintillion)
+
+TIDs
+====
+
+Because TIDs are signed 64-bit integers, they cannot store values
+larger than 2**63 - 1, or nine quintillion transactions. Since TID is
+related to the current time, that suffices for values until the year 5908.
+
 Locks
 =====
 
@@ -86,3 +96,7 @@ and how they are taken and managed, see connmanager.py and locker.py
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
+import BTrees
+
+MAX_TID = BTrees.family64.maxint # Not maxuint

--- a/src/relstorage/adapters/sqlite/__init__.py
+++ b/src/relstorage/adapters/sqlite/__init__.py
@@ -96,7 +96,3 @@ and how they are taken and managed, see connmanager.py and locker.py
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-import BTrees
-
-MAX_TID = BTrees.family64.maxint # Not maxuint

--- a/src/relstorage/adapters/sqlite/adapter.py
+++ b/src/relstorage/adapters/sqlite/adapter.py
@@ -30,7 +30,6 @@ from ..packundo import HistoryFreePackUndo
 from ..packundo import HistoryPreservingPackUndo
 
 from . import drivers
-from . import MAX_TID
 from .batch import Sqlite3RowBatcher
 from .connmanager import Sqlite3ConnectionManager
 from .locker import Sqlite3Locker
@@ -47,7 +46,6 @@ from .scriptrunner import Sqlite3ScriptRunner
 class Sqlite3Adapter(AbstractAdapter):
     driver_options = drivers
     WRITING_REQUIRES_EXCLUSIVE_LOCK = True
-    MAX_TID = MAX_TID
 
     def __init__(self, data_dir, pragmas,
                  options=None, oidallocator=None,
@@ -139,8 +137,6 @@ class Sqlite3Adapter(AbstractAdapter):
             self.dbiter = HistoryFreeDatabaseIterator(
                 driver,
             )
-        self.packundo.MAX_TID = self.MAX_TID
-        self.dbiter.MAX_TID = self.MAX_TID
 
     def new_instance(self):
         inst = type(self)(

--- a/src/relstorage/adapters/sqlite/adapter.py
+++ b/src/relstorage/adapters/sqlite/adapter.py
@@ -30,6 +30,7 @@ from ..packundo import HistoryFreePackUndo
 from ..packundo import HistoryPreservingPackUndo
 
 from . import drivers
+from . import MAX_TID
 from .batch import Sqlite3RowBatcher
 from .connmanager import Sqlite3ConnectionManager
 from .locker import Sqlite3Locker
@@ -46,7 +47,7 @@ from .scriptrunner import Sqlite3ScriptRunner
 class Sqlite3Adapter(AbstractAdapter):
     driver_options = drivers
     WRITING_REQUIRES_EXCLUSIVE_LOCK = True
-
+    MAX_TID = MAX_TID
 
     def __init__(self, data_dir, pragmas,
                  options=None, oidallocator=None,
@@ -138,6 +139,8 @@ class Sqlite3Adapter(AbstractAdapter):
             self.dbiter = HistoryFreeDatabaseIterator(
                 driver,
             )
+        self.packundo.MAX_TID = self.MAX_TID
+        self.dbiter.MAX_TID = self.MAX_TID
 
     def new_instance(self):
         inst = type(self)(

--- a/src/relstorage/adapters/sqlite/drivers.py
+++ b/src/relstorage/adapters/sqlite/drivers.py
@@ -356,6 +356,7 @@ class Sqlite3Driver(MemoryViewBlobDriverMixin,
     CONNECTION_FACTORY = Connection
     DEFAULT_CONNECT_ARGS = {
     }
+    supports_64bit_unsigned_id = False
 
     def __init__(self):
         super(Sqlite3Driver, self).__init__()

--- a/src/relstorage/blobhelper/cached.py
+++ b/src/relstorage/blobhelper/cached.py
@@ -21,7 +21,7 @@ import time
 
 from binascii import hexlify
 
-import BTrees
+from BTrees import OOBTree # pylint:disable=no-name-in-module
 import zc.lockfile
 
 import ZODB.blob
@@ -594,7 +594,7 @@ class _BlobCacheSizeChecker(timer):
 
         blob_dir = self.blob_dir
         blob_suffix = ZODB.blob.BLOB_SUFFIX
-        files_by_atime = BTrees.OOBTree.BTree()
+        files_by_atime = OOBTree.BTree()
         size = 0
 
         # Use os.walk() instead of os.listdir(); on 3.5+ this is much faster

--- a/src/relstorage/cache/mvcc.py
+++ b/src/relstorage/cache/mvcc.py
@@ -115,7 +115,7 @@ class _TransactionRangeObjectIndex(OidTMap):
         min_stored_tid = self.min_stored_tid()
         hvt = self.highest_visible_tid
         assert max_stored_tid <= hvt, (max_stored_tid, hvt, self)
-        assert min_stored_tid > 0, min_stored_tid
+        assert min_stored_tid > 0, min_stored_tid # BTrees won't allow that, but dicts (pypy) could
         if initial:
             # This is only true at startup. Over time we can add older entries.
             assert self.complete_since_tid is None or min_stored_tid > self.complete_since_tid, (

--- a/src/relstorage/cache/tests/test_mvcc.py
+++ b/src/relstorage/cache/tests/test_mvcc.py
@@ -521,7 +521,8 @@ class TestObjectIndex(TestCase):
                           data=[(1, 3)])
 
         # Too low
-        with self.assertRaises(AssertionError):
+        with self.assertRaises((AssertionError, OverflowError)):
+            # OverflowError is BTrees, AssertionError is dicts
             self._makeOne(highest_visible_tid=2,
                           data=[(1, -1)])
 

--- a/src/relstorage/storage/pack.py
+++ b/src/relstorage/storage/pack.py
@@ -100,7 +100,7 @@ class Pack(object):
             # Packing for the current time or in the future means to pack
             # to the lastest commit in the database. This matters if not all
             # machine clocks are synchronized.
-            best_pack_tid_int = MAX_TID - 1
+            best_pack_tid_int = self.packundo.MAX_TID - 1
         else:
             # Find the latest commit before or at the pack time.
             # Note that several TIDs will fit in the resolution of a time.time(),

--- a/src/relstorage/storage/pack.py
+++ b/src/relstorage/storage/pack.py
@@ -29,7 +29,6 @@ from ZODB.utils import p64 as int64_to_8bytes
 from ZODB.utils import u64 as bytes8_to_int64
 
 from relstorage._compat import OID_SET_TYPE
-from relstorage._compat import MAX_TID
 from relstorage._compat import metricmethod
 from .util import writable_storage_method
 

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -372,6 +372,7 @@ class LockException(Exception):
     pass
 
 class MockDriver(object):
+    supports_64bit_unsigned_id = True
     cursor_arraysize = 64
     disconnected_exceptions = (DisconnectedException,)
     close_exceptions = (CloseException,)

--- a/src/relstorage/tests/bigpack.py
+++ b/src/relstorage/tests/bigpack.py
@@ -3,7 +3,7 @@ import sys
 import time
 
 import transaction
-from BTrees.OOBTree import OOBTree  # pylint:disable=no-name-in-module
+from BTrees.OOBTree import OOBTree  # pylint:disable=no-name-in-module,import-error
 from ZODB.DB import DB
 
 from relstorage.adapters.postgresql import PostgreSQLAdapter


### PR DESCRIPTION
OIDs and TIDs  are conceptually unsigned.  

It's unlikely anyone would pass the nine quintillion mark for OIDs or TIDs, but this is a better match.