### PR TITLE
SQLite: Make wal_autocheckpoint more reliable. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 3.1.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for pg8000 >= 1.15.3. Previously, a ``TypeError`` was raised.
 
 
 3.1.0 (2020-06-11)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@
 3.1.1 (unreleased)
 ==================
 
-- Add support for pg8000 >= 1.15.3. Previously, a ``TypeError`` was raised.
+- Add support for pg8000 >= 1.15.3. Previously, a ``TypeError`` was
+  raised.
+
+- SQLite: Committing a transaction releases some resources sooner.
+  This makes it more likely that auto-checkpointing of WAL files will be
+  able to reclaim space in some scenarios. See :issue:`401`.
 
 
 3.1.0 (2020-06-11)

--- a/setup.py
+++ b/setup.py
@@ -180,11 +180,14 @@ setup(
         # compile on windows for Python 2.7 (it doesn't support the
         # old Visual C) and is hard to compile for anything newer; it sometimes
         # has wheels but not always, so don't suggest it.
+        #
+        # Note that mysqlclient 2.0.0 has a crashing bug:
+        # https://github.com/PyMySQL/mysqlclient-python/issues/435
 
 
         # pylint:disable=line-too-long
         'mysql:platform_python_implementation=="CPython" and (sys_platform != "win32")': [
-            'mysqlclient >= 1.4',
+            'mysqlclient >= 1.4, != 2.0.0',
         ],
         'mysql:platform_python_implementation=="PyPy" or (sys_platform == "win32")': [
             'PyMySQL>=0.6.6',
@@ -236,7 +239,7 @@ setup(
             'PyMySQL >= 0.6.6; python_version == "3.6" or platform_python_implementation == "PyPy" or sys_platform == "win32"',
             # mysqlclient (binary) on all CPythons. It's the default,
             # except on old Windows. We get coverage from Travis.
-            'mysqlclient >= 1.4;platform_python_implementation=="CPython" and (sys_platform != "win32")',
+            'mysqlclient >= 1.4,!=2.0.0;platform_python_implementation=="CPython" and (sys_platform != "win32")',
             # mysql-connector-python on Python 3.7 for coverage on Travis and ensuring it works
             # on Windows, and PyPy for testing there, since it's one of two pure-python versions.
             'mysql-connector-python >= 8.0.16; python_version == "3.7" or platform_python_implementation == "PyPy"',

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -127,7 +127,7 @@ class AbstractAdapter(DatabaseHelpersMixin):
 
     @metricmethod_sampled
     def lock_database_and_move(self,
-                               store_connection,
+                               store_connection, load_connection,
                                blobhelper,
                                ude,
                                commit=True,
@@ -166,7 +166,7 @@ class AbstractAdapter(DatabaseHelpersMixin):
             store_connection, committing_tid_int)
 
         if commit:
-            self.txncontrol.commit_phase2(store_connection, prepared_txn_id)
+            self.txncontrol.commit_phase2(store_connection, prepared_txn_id, load_connection)
 
         return committing_tid_int, prepared_txn_id
 

--- a/src/relstorage/adapters/mysql/adapter.py
+++ b/src/relstorage/adapters/mysql/adapter.py
@@ -229,7 +229,7 @@ class MySQLAdapter(AbstractAdapter):
 
     @metricmethod_sampled
     def lock_database_and_move(self,
-                               store_connection,
+                               store_connection, load_connection,
                                blobhelper,
                                ude,
                                commit=True,
@@ -239,7 +239,7 @@ class MySQLAdapter(AbstractAdapter):
             # XXX: When can we drop this? Probably not until AppVeyor upgrades
             # MySQL past 5.7.12.
             return super(MySQLAdapter, self).lock_database_and_move(
-                store_connection,
+                store_connection, load_connection,
                 blobhelper,
                 ude,
                 commit=commit,

--- a/src/relstorage/adapters/mysql/tests/test_adapter.py
+++ b/src/relstorage/adapters/mysql/tests/test_adapter.py
@@ -51,7 +51,7 @@ class TestAdapter(test_adapter.AdapterTestBase):
         adapter.version_detector = MockVersionDetector()
 
         result = adapter.lock_database_and_move(
-            MockConnection(),
+            MockConnection(), None,
             None,
             (),
             commit=commit

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -199,7 +199,7 @@ class PostgreSQLAdapter(AbstractAdapter):
         return tid
 
     def lock_database_and_move(self,
-                               store_connection,
+                               store_connection, load_connection,
                                blobhelper, # pylint:disable=unused-argument
                                ude,
                                commit=True,
@@ -268,7 +268,7 @@ class PostgreSQLAdapter(AbstractAdapter):
             if self.driver.supports_multiple_statement_execute:
                 self.driver.sync_status_after_commit(store_connection.connection)
             else:
-                self.txncontrol.commit_phase2(store_connection, "-")
+                self.txncontrol.commit_phase2(store_connection, "-", load_connection)
         after_selecting_tid(tid_int)
         return tid_int, "-"
 

--- a/src/relstorage/adapters/postgresql/drivers/pg8000.py
+++ b/src/relstorage/adapters/postgresql/drivers/pg8000.py
@@ -115,17 +115,35 @@ class PG8000Driver(AbstractPostgreSQLDriver):
                              user, host='localhost',
                              unix_sock=None,
                              port=5432, database=None,
-                             password=None, ssl=None,
+                             password=None, ssl_context=None,
                              timeout=None, application_name=None,
                              max_prepared_statements=1000,
                              tcp_keepalive=True):
                     # pylint:disable=useless-super-delegation
-                    # We have to do this because the super class requires
-                    # all these arguments and doesn't have defaults
-                    super(Connection, self).__init__(
-                        user, host, unix_sock,
-                        port, database, password, ssl, timeout, application_name,
-                        max_prepared_statements, tcp_keepalive)
+
+                    # Prior to pg8000 1.15.1, we had to do this
+                    # because the super class requires all these
+                    # arguments and didn't have defaults. In that release, it gained
+                    # defaults, but our order had been wrong for some time. In
+                    # 1.15.3 our bad ordering started causing TypeError.
+                    # Pass these things in this way to be compatible with older versions too
+                    # that didn't have defaults or extra parameters, but the names
+                    # were the same...except for `ssl` vs `ssl_context`: the latter
+                    # is only in versions that run on Python 3.
+                    # We could probably do better than this
+                    kwargs = dict(
+                        user=user, host=host, unix_sock=unix_sock,
+                        port=port, database=database,
+                        password=password, ssl_context=ssl_context,
+                        timeout=timeout,
+                        application_name=application_name,
+                        max_prepared_statements=max_prepared_statements,
+                        tcp_keepalive=tcp_keepalive
+                    )
+                    if str is bytes: # PY2
+                        del kwargs['ssl_context']
+                        kwargs['ssl'] = ssl_context
+                    super(Connection, self).__init__(**kwargs)
 
                 def cursor(self):
                     return Cursor(self)

--- a/src/relstorage/adapters/sqlite/connmanager.py
+++ b/src/relstorage/adapters/sqlite/connmanager.py
@@ -103,6 +103,7 @@ class Sqlite3ConnectionManager(AbstractConnectionManager):
         }
         nice_to_have_pragmas.update(pragmas)
         self.pragmas = nice_to_have_pragmas
+        # XXX: Why do we override the default for this?
         self.pragmas['journal_size_limit'] = None
         super(Sqlite3ConnectionManager, self).__init__(options, driver)
 

--- a/src/relstorage/adapters/sqlite/drivers.py
+++ b/src/relstorage/adapters/sqlite/drivers.py
@@ -222,6 +222,7 @@ class Connection(sqlite3.Connection):
         finally:
             self._at_transaction_end()
 
+
     def rollback(self):
         try:
             sqlite3.Connection.rollback(self)
@@ -501,14 +502,13 @@ class Sqlite3Driver(MemoryViewBlobDriverMixin,
             # an exclusive lock. That could be at arbitrary times, so we don't want that.
             'cache_spill': 0,
 
-            # Disable auto-checkpoint so that commits have
+            # In the past, we considered disabling auto-checkpoint so that commits have
             # reliable duration; after commit, if it's a good time,
             # we can run 'PRAGMA wal_checkpoint'. (In most cases, the last
             # database connection that's open will essentially do that
-            # automatically.)
-            # XXX: Is that really worth it? We have seen some apparent corruptions,
-            # maybe due to that? It's also a balance between readers and writers.
-            # so we'le leave it at the default and just report it.
+            # automatically.) This is a balancing act, though, and
+            # we expose this setting to the end user to allow them to tune it.
+            # By default, use the compiled-in default and report what that is.
             'wal_autocheckpoint': None,
             # Things to query and report.
             'soft_heap_limit': None, # 0 means no limit

--- a/src/relstorage/adapters/tests/test_txncontrol.py
+++ b/src/relstorage/adapters/tests/test_txncontrol.py
@@ -91,7 +91,7 @@ class TestTransactionControl(TestCase):
     def test_commit_phase2(self):
         inst = self._makeOne()
         conn = MockConnection()
-        inst.commit_phase2(MockStoreConnection(conn), None)
+        inst.commit_phase2(MockStoreConnection(conn), None, None)
         self.assertTrue(conn.committed)
 
     def test_abort(self):

--- a/src/relstorage/adapters/txncontrol.py
+++ b/src/relstorage/adapters/txncontrol.py
@@ -38,7 +38,7 @@ class AbstractTransactionControl(ABC):
     def commit_phase1(self, store_connection, tid):
         return '-'
 
-    def commit_phase2(self, store_connection, txn):
+    def commit_phase2(self, store_connection, txn, load_connection):
         store_connection.commit()
 
     def abort(self, store_connection, txn=None):

--- a/src/relstorage/storage/tpc/finish.py
+++ b/src/relstorage/storage/tpc/finish.py
@@ -35,7 +35,8 @@ def Finish(vote_state, needs_store_commit=True):
         assert txn is not None
         vote_state.adapter.txncontrol.commit_phase2(
             vote_state.store_connection,
-            txn)
+            txn,
+            vote_state.load_connection)
 
     vote_state.committing_tid_lock.release_commit_lock(vote_state.store_connection.cursor)
     vote_state.cache.after_tpc_finish(vote_state.committing_tid_lock.tid,

--- a/src/relstorage/storage/tpc/vote.py
+++ b/src/relstorage/storage/tpc/vote.py
@@ -449,19 +449,11 @@ class AbstractVote(AbstractTPCState):
             # support doing that in a single operation, we need to go critical and
             # regain control ASAP so we can complete the operation.
             self.__enter_critical_phase_until_transaction_end()
-        if kwargs['commit']:
-            # If committing, terminate the load connection's transaction now.
-            # This allows any actions taken on commit, such as SQLite's auto-checkpoint,
-            # to see a state where this reader is not holding open old MVCC resources.
-            # See https://github.com/zodb/relstorage/issues/401
-            # XXX: This is temporary for testing with other databases. This should be formalized
-            # more (and we need a specific test case that it fixes the sqlite auto-checkpoint issue)
-            # example formalisms:
-            # - make the adapter responsible for doing this, if needed;
-            # - set it to None in this object now or otherwise mark it as unusable.
-            self.load_connection.rollback_quietly()
+
+        # Note that this may commit the load_connection and make it not
+        # viable for a historical view anymore.
         committing_tid_int, prepared_txn = self.adapter.lock_database_and_move(
-            self.store_connection,
+            self.store_connection, self.load_connection,
             self.blobhelper,
             self.ude,
             **kwargs


### PR DESCRIPTION
Also some changes that had to happen to make the tests run:  add support for pg8000 1.15, and don't allow using mysqlclient 2.0.0 right now because it crashes.

Fixes #401 