### PR TITLE
Remove psycopg2cffi dependency on psycopg2.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@
 - Make the error messages for unavailable drivers include more
   information on underlying causes.
 - Log a debug message when an "auto" driver is successfully resolved.
-
+- Add a ``--debug`` argument to the ``zodbconvert`` command line tool
+  to enable DEBUG level logging.
+- Add support for pg8000 1.16. Previously, a ``TypeError`` was raised.
 
 3.1.1 (2020-07-02)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@
 3.1.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix the psycopg2cffi driver inadvertently depending on the
+  ``psycopg2`` package. See :issue:`403`.
+- Make the error messages for unavailable drivers include more
+  information on underlying causes.
+- Log a debug message when an "auto" driver is successfully resolved.
 
 
 3.1.1 (2020-07-02)

--- a/docs/db-specific-options.rst
+++ b/docs/db-specific-options.rst
@@ -61,6 +61,10 @@ driver
 
       This is the default and preferred driver everywhere except PyPy.
 
+      If psycopg2 has a wait callback installed, this driver will not
+      be available. If no driver is specified, the next choice for
+      'auto' in this case will be gevent psycopg2.
+
     gevent psycopg2
       The same as ``psycopg2``, but made to be gevent compatible
       through the use of a wait callback. If the system is
@@ -81,6 +85,12 @@ driver
 
       This driver forfeits use of the COPY protocol and use of the
       C-accelerated BLOBs.
+
+      This driver will only be available if psycopg2 has a wait
+      callback installed, which, as mentioned above, happens
+      automatically when gevent monkey-patches the system. No attempt
+      is made to check that the wait callback is actually
+      gevent-friendly in case it has been replaced.
 
     psycopg2cffi
       A C-based driver that requires the PostgreSQL client

--- a/src/relstorage/adapters/postgresql/drivers/psycopg2cffi.py
+++ b/src/relstorage/adapters/postgresql/drivers/psycopg2cffi.py
@@ -63,7 +63,7 @@ class Psycopg2cffiDriver(Psycopg2Driver):
         return mod.RSPsycopg2cffiConnection
 
     def _get_extension_module(self):
-        from psycopg2cffi import extensions
+        from psycopg2cffi import extensions # pylint:disable=no-name-in-module
         return extensions
 
     # as of psycopg2cffi 2.8.1 connection has no '.info' attribute.

--- a/src/relstorage/adapters/postgresql/drivers/psycopg2cffi.py
+++ b/src/relstorage/adapters/postgresql/drivers/psycopg2cffi.py
@@ -22,7 +22,8 @@ from __future__ import print_function
 from .psycopg2 import Psycopg2Driver
 
 __all__ = [
-    'Psycopg2cffiDriver'
+    'Psycopg2cffiDriver',
+    # TODO: A gevent driver seems like it should be possible?
 ]
 
 class Psycopg2cffiDriver(Psycopg2Driver):
@@ -60,6 +61,10 @@ class Psycopg2cffiDriver(Psycopg2Driver):
             mod.RSPsycopg2cffiConnection = Connection
 
         return mod.RSPsycopg2cffiConnection
+
+    def _get_extension_module(self):
+        from psycopg2cffi import extensions
+        return extensions
 
     # as of psycopg2cffi 2.8.1 connection has no '.info' attribute.
 

--- a/src/relstorage/adapters/tests/test_drivers.py
+++ b/src/relstorage/adapters/tests/test_drivers.py
@@ -75,7 +75,8 @@ class TestAbstractDrivers(unittest.TestCase):
             drivers.select_driver()
 
         self.assertIn(
-            "Driver 'auto' is not available. "
+            "Driver 'auto' is not available "
+            "(reason={'BadDriver': \"DriverNotAvailableError: Driver 'Bad' is not available.\"}). "
             "Options: 'BadDriver' (Module: '<unknown>'; Available: False).",
             str(exc.exception))
 

--- a/src/relstorage/adapters/tests/test_interfaces.py
+++ b/src/relstorage/adapters/tests/test_interfaces.py
@@ -28,11 +28,11 @@ class TestExceptions(unittest.TestCase):
         from relstorage.adapters.mysql import drivers
         name = 'auto'
 
-        ex = klass(name, drivers)
+        ex = klass(name, drivers, 'reason')
 
         for s in str(ex), repr(ex):
             self.assertIn(
-                "%s: Driver 'auto' is not available. Options: " % (
+                "%s: Driver 'auto' is not available (reason=reason). Options: " % (
                     klass.__name__,
                 ),
                 s

--- a/src/relstorage/zodbconvert.py
+++ b/src/relstorage/zodbconvert.py
@@ -100,12 +100,18 @@ def main(argv=None):
              "and resume copying from the last transaction. WARNING: no "
              "effort is made to verify that the destination holds the same "
              "transaction data before this point! Use at your own risk. ")
+    parser.add_argument(
+        '--debug', dest="debug", action='store_true',
+        default=False,
+        help="Set the logging level to DEBUG instead of the default of "
+             "INFO."
+    )
     parser.add_argument("config_file", type=argparse.FileType('r'))
 
     options = parser.parse_args(argv[1:])
 
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.DEBUG if options.debug else logging.INFO,
         format="%(asctime)s [%(name)s] %(levelname)s %(message)s"
     )
 


### PR DESCRIPTION
Fixes #403

Also include more error information when possible, and log a selected driver.