### PR TITLE
Improvements to cache validation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -33,6 +33,8 @@
 # chained-comparison: It wants you to rewrite `x > 2 and x < 3` using something like `2 < x < 3`,
 #   which I don't like, I find that less readable.
 # import-outside-toplevel: New in pylint 2.4. We have a large number of deferred imports.
+# super-with-arguments and raise-missing-from: New in pylint 2.7; we can't use them because
+#   we support Python 2.
 disable=
     invalid-name,
     missing-docstring,
@@ -55,7 +57,8 @@ disable=
     too-many-ancestors,
     import-outside-toplevel,
     relative-beyond-top-level,
-    super-with-arguments
+    super-with-arguments,
+    raise-missing-from
 #   undefined-all-variable
 
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -54,7 +54,8 @@ disable=
     chained-comparison,
     too-many-ancestors,
     import-outside-toplevel,
-    relative-beyond-top-level
+    relative-beyond-top-level,
+    super-with-arguments
 #   undefined-all-variable
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 3.2.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Improve the speed of loading large cache files by reducing the cost
+  of cache validation.
 
 
 3.2.0 (2020-07-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,15 @@
 - Improve the speed of loading large cache files by reducing the cost
   of cache validation.
 
+- The timing metrics for ``current_object_oids`` are always collected,
+  not just sampled. MySQL and PostgreSQL will only call this method
+  once at startup during persistent cache validation. Other databases
+  may call this method once during the commit process.
+
+- Add the ability to limit how long persistent cache validation will
+  spend polling the database for invalid OIDs. Set the environment
+  variable ``RS_CACHE_POLL_TIMEOUT`` to a number of seconds before
+  importing RelStorage to use this.
 
 3.2.0 (2020-07-20)
 ==================

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -316,7 +316,10 @@ class MockConnectionManager(object):
 
     def open_for_load(self):
         conn = MockConnection()
-        return conn, conn.cursor()
+        return conn, self.configure_cursor(conn.cursor())
+
+    def configure_cursor(self, cur):
+        return cur
 
     open_for_store = open_for_load
 
@@ -408,7 +411,8 @@ class MockObjectMover(object):
     def load_current(self, _cursor, oid_int):
         return self.data.get(oid_int, (None, None))
 
-    def current_object_tids(self, _cursor, oids):
+    def current_object_tids(self, _cursor, oids, timeout=None):
+        # pylint:disable=unused-argument
         return {
             oid: self.data[oid][1]
             for oid in oids


### PR DESCRIPTION
- Make the algorithm slightly faster by allocating fewer objects
- Add the ability to limit the amount of time spent making SQL queries
- Always record the timing metrics for `current_object_tids`