### PR TITLE
Implement IStorageCurrentRecorditeration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ script:
   - pip uninstall -y zope.schema && python -c 'import relstorage.interfaces, relstorage.adapters.interfaces, relstorage.cache.interfaces'
 after_success:
   - coverage combine
+  - coverage report -i --skip-covered
   - coveralls
 notifications:
   email: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@
 3.2.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- The "MySQLdb" driver didn't properly use server-side cursors when
+  requested. This would result in unexpected increased memory usage
+  for things like packing and storage iteration.
+
+- Make RelStorage instances implement
+  ``IStorageCurrentRecordIteration``. See :issue:`389`.
 
 
 3.2.1 (2020-08-28)

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -668,6 +668,21 @@ class IDatabaseIterator(Interface):
         :raises KeyError: if the object does not exist
         """
 
+    def iter_current_records(cursor, start_oid_int=0):
+        """
+        Cause the *cursor* (which should be a server-side cursor)
+        to execute a query that will iterate over
+        ``(oid_int, tid_int, state_bytes)`` values for all the current objects.
+
+        Each current object is returned only once, at the transaction most recently
+        committed for it.
+
+        Returns a generator.
+
+        For compatibility with FileStorage, this must iterate in ascending
+        OID order; it must also accept an OID to begin with for compatibility with
+        zodbupdate.
+        """
 
 class ILocker(Interface):
     """Acquire and release the commit and pack locks."""

--- a/src/relstorage/adapters/mysql/drivers/__init__.py
+++ b/src/relstorage/adapters/mysql/drivers/__init__.py
@@ -149,8 +149,9 @@ class AbstractMySQLDriver(AbstractModuleDriver):
 
     _server_side_cursor = None
 
-    def _make_cursor(self, conn, server_side=False):
+    def cursor(self, conn, server_side=False):
         if server_side:
+            assert self._server_side_cursor is not None
             cursor = conn.cursor(self._server_side_cursor)
             cursor.arraysize = self.cursor_arraysize
         else:

--- a/src/relstorage/interfaces.py
+++ b/src/relstorage/interfaces.py
@@ -227,6 +227,7 @@ class IRelStorage(
         ZODB.interfaces.IMultiCommitStorage,  # mandatory in ZODB5, returns tid from tpc_finish.
         ZODB.interfaces.IStorageRestoreable,  # tpc_begin(tid=) and restore()
         ZODB.interfaces.IStorageIteration,    # iterator()
+        ZODB.interfaces.IStorageCurrentRecordIteration, # record_iternext()
         ZODB.interfaces.ReadVerifyingStorage, # checkCurrentSerialInTransaction()
         IMVCCDatabaseViewer,
 ):

--- a/src/relstorage/storage/transaction_iterator.py
+++ b/src/relstorage/storage/transaction_iterator.py
@@ -132,6 +132,7 @@ class HistoryPreservingTransactionIterator(_TransactionIterator):
             self._conn = None
             super(HistoryPreservingTransactionIterator, self).close()
 
+
 class HistoryFreeTransactionIterator(_TransactionIterator):
     """
     Uses the given load connection cursor. Does not close the
@@ -211,7 +212,7 @@ class RelStorageTransactionRecord(TransactionRecord):
         TransactionRecord.__init__(self, tid, status, user, description, extension)
 
     def __iter__(self):
-        return RecordIterator(self)
+        return TransactionRecordIterator(self)
 
     def __repr__(self):
         return '<%s at %x tid=%d status=%r user=%r description=%r>' % (
@@ -223,7 +224,7 @@ class RelStorageTransactionRecord(TransactionRecord):
             self.description
         )
 
-class RecordIterator(object):
+class TransactionRecordIterator(object):
     """Iterate over the objects in a transaction."""
 
     __slots__ = (

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -43,6 +43,7 @@ from ZODB.POSException import ReadOnlyError
 from ZODB.serialize import referencesf
 from ZODB.utils import z64
 from ZODB.utils import u64 as bytes8_to_int64
+from ZODB.utils import p64 as int64_to_8bytes
 
 from ZODB.tests import BasicStorage
 from ZODB.tests import ConflictResolution
@@ -1388,34 +1389,61 @@ class GenericRelStorageTests(
     ###
     # IStorageCurrentRecordIteration tests
     ###
-    # TODO: Need tests for:
-    #   - handling of next as oid
-    #   - Getting only one revision of an object (history-preserving)
 
-    def check_record_iternext_basic(self):
-        # Nearly copied from FileStorage tests
+    def check_record_iternext_basic(self, start_oid_int=None):
+        # Based on code from FileStorage tests
+
         db = DB(self._storage)
         conn = db.open()
         conn.root()['abc'] = MinPO('abc')
         conn.root()['xyz'] = MinPO('xyz')
         transaction.commit()
 
+        # Now, add some additional revisions. This proves that we iterate latest reconds,
+        # not all transactions.
+        conn.root()['abc'].value = 'def'
+        conn.root()['xyz'].value = 'ghi'
+        transaction.commit()
+        conn.close()
+
         storage2 = self._closing(self._storage.new_instance())
 
-        key = None
-        for x in (b'\000', b'\001', b'\002'):
-            oid, tid, data, next_oid = self._storage.record_iternext(key)
-            self.assertEqual(oid, (b'\000' * 7) + x)
-            key = next_oid
+        # The special case: convert to byte OID
+        token = None if start_oid_int is None else int64_to_8bytes(start_oid_int)
+
+        # (0, 1, 2) by default, or, e.g, (1, 2)
+        expected_oids = range(start_oid_int or 0, 3)
+        if not expected_oids:
+            assert start_oid_int > 3
+            # Call at least once.
+            expected_oids = (0,)
+        record_count = 0
+        for x in expected_oids:
+            oid, tid, data, next_token = self._storage.record_iternext(token)
+            record_count += 1
+            self.assertEqual(oid, int64_to_8bytes(x))
+            token = next_token
             expected_data, expected_tid = storage2.load(oid)
             self.assertEqual(expected_data, data)
             self.assertEqual(expected_tid, tid)
-            if x == b'\002':
-                self.assertEqual(next_oid, None)
+            if x == 2:
+                check_token = self.assertIsNone
             else:
-                self.assertNotEqual(next_oid, None)
+                check_token = self.assertIsNotNone
+            check_token(token)
+        self.assertEqual(len(expected_oids), record_count)
 
+    def check_record_iternext_token_0(self):
+        # Passing a starting token.
+        self.check_record_iternext_basic(0)
 
+    def check_record_iternext_token_1(self):
+        # Gets a subset.
+        self.check_record_iternext_basic(1)
+
+    def check_record_iternext_too_large_oid(self):
+        with self.assertRaises(StopIteration):
+            self.check_record_iternext_basic(10)
 
 
 class AbstractRSZodbConvertTests(StorageCreatingMixin,


### PR DESCRIPTION
Fixes #389, adds compatibility with zodbupdate for history-preserving RelStorage.