### PR TITLE
Test Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 group: travis_latest
 services:
   - mysql
@@ -17,6 +17,7 @@ addons:
 
 matrix:
   include:
+    - python: 3.9-dev
     - python: 3.8
     - python: 2.7
     - python: pypy3
@@ -29,7 +30,6 @@ matrix:
         - docker pull mysql:8.0
         - docker run -d --publish 3306:3306 --rm --name mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8.0
         - cp .travis/docker.cnf ~/.my.cnf
-    - python: 3.5
     - python: 3.6
     - python: pypy
 
@@ -58,6 +58,7 @@ script:
   # Make sure we can import without zope.schema, which is intended to
   # be a test dependency, and optional for production
   - pip uninstall -y zope.schema && python -c 'import relstorage.interfaces, relstorage.adapters.interfaces, relstorage.cache.interfaces'
+
 after_success:
   - coverage combine
   - coverage report -i --skip-covered
@@ -73,9 +74,9 @@ before_script:
 
 install:
   - pip install -U pip
-  - pip install -U setuptools wheel coveralls
+  - pip install -U setuptools wheel coveralls twine
   - pip install -U "pylint>=1.7.1"
-  - pip install -U cython
+  - pip install -U 'cython>=3.0a6'
   # Print debugging for the build
   - python setup.py build_ext -i
   - pip install -U -e ".[test,all_tested_drivers]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ addons:
   postgresql: "9.6"
 # The default mysql is 5.7; we have a specific test for 8.0.
 
+# To get a recent PyPy, we still (as of bionic, 2020-09) must
+# give an exact version. Supported versions are listed at
+# https://docs.travis-ci.com/user/languages/python/#specifying-python-versions
 matrix:
   include:
-    - python: 3.9-dev
-    - python: 3.8
-    - python: 2.7
-    - python: pypy3
+    # The 3.7 build runs the linter.
     - python: 3.7
       services:
         - docker
@@ -30,8 +30,12 @@ matrix:
         - docker pull mysql:8.0
         - docker run -d --publish 3306:3306 --rm --name mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8.0
         - cp .travis/docker.cnf ~/.my.cnf
+    - python: pypy2.7-7.3.1
+    - python: 3.9-dev
+    - python: pypy3.6-7.3.1
+    - python: 3.8
+    - python: 2.7
     - python: 3.6
-    - python: pypy
 
 
 env:
@@ -47,13 +51,15 @@ env:
         - CCACHE_NOHASHDIR=true
         - CFLAGS="-g -pipe -std=gnu++11"
         - CXXFLAGS="-g -pipe -std=gnu++11"
-        - RS_TEST_CMD="-m zope.testrunner --test-path=src --auto-color -vvv --slow-test=3"
+        - RS_TEST_CMD="-m zope.testrunner --test-path=src --auto-color --auto-progress -vvv --slow-test=3"
 
 script:
-# coverage slows PyPy down from 2minutes to 12+.
+  # coverage slows PyPy down from 2minutes to 12+.
+  # Fail fast
+  - set -e
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint -j 0 --limit-inference-results=1 --rcfile=.pylintrc relstorage -f parseable -r n; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=greenlet .travis/zope_testrunner_gevent.py -t checkBTreesLengthStress -t check7 -t check2 -t BlobCache -t Switches --layer gevent -vvv; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then PYTHONTRACEMALLOC=15 python $RS_TEST_CMD --layer "!gevent"; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then python $RS_TEST_CMD --layer "!gevent"; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=thread  $RS_TEST_CMD --layer "!gevent"; fi
   # Make sure we can import without zope.schema, which is intended to
   # be a test dependency, and optional for production

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,8 @@ env:
 
 script:
   # coverage slows PyPy down from 2minutes to 12+.
-  # Fail fast
-  - set -e
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pylint -j 0 --limit-inference-results=1 --rcfile=.pylintrc relstorage -f parseable -r n; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=greenlet .travis/zope_testrunner_gevent.py -t checkBTreesLengthStress -t check7 -t check2 -t BlobCache -t Switches --layer gevent -vvv; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=greenlet .travis/zope_testrunner_gevent.py -t checkBTreesLengthStress -t check7 -t check2 -t BlobCache -t Switches --layer gevent; fi
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then python $RS_TEST_CMD --layer "!gevent"; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -p --concurrency=thread  $RS_TEST_CMD --layer "!gevent"; fi
   # Make sure we can import without zope.schema, which is intended to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@
   connection) by using the store connection. This ability has been
   removed.
 
+- Add support for Python 3.9.
+
+- Drop support for Python 3.5.
+
 
 3.2.1 (2020-08-28)
 ==================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,11 +59,6 @@ environment:
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.2
-      PYTHON_ARCH: "64"
-      PYTHON_EXE: python
-
     ## 32-bit, wheel only (no testing)
 
     - PYTHON: "C:\\Python38"
@@ -80,12 +75,6 @@ environment:
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x" # currently 3.6.3
-      PYTHON_ARCH: "32"
-      PYTHON_EXE: python
-      GWHEEL_ONLY: true
-
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.2
       PYTHON_ARCH: "32"
       PYTHON_EXE: python
       GWHEEL_ONLY: true
@@ -116,7 +105,7 @@ install:
   # https://ci.appveyor.com/project/denik/gevent/builds/23810605/job/83aw4u67artt002b#L602
   # So we violate DRY and repeate some requirements in order to use
   # --no-build-isolation
-  - "%CMD_IN_ENV% %PYEXE% -m pip install -U pycparser wheel cython setuptools cffi twine"
+  - "%CMD_IN_ENV% %PYEXE% -m pip install -U pycparser wheel \"cython>=3.0a6\" setuptools cffi twine"
 
 
 build_script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,4 @@
 [build-system]
-# Our setup.py imports other things from this directory, meaning
-# in needs to be on sys.path. That's not guaranteed in a PEP517 world;
-# the __legacy__ build module makes that true. Ultimately we need to do that
-# ourself (and/or continue to simplify our build system).
 build-backend = "setuptools.build_meta"
 requires = [
      "setuptools >= 40.8.0",
@@ -12,6 +8,11 @@ requires = [
      # name to be created so that we can have both foo.py and _foo.so
      # at the same time. 0.29 fixes some issues with Python 3.7,
      # and adds the 3str mode for transition to Python 3. 0.29.12+ is
-     # required for Python 3.8
-     "Cython >= 0.29.13",
+     # required for Python 3.8. 3.0a2 introduced a change that prevented
+     # us from compiling (https://github.com/gevent/gevent/issues/1599)
+     # but once that was fixed, 3.0a4 led to all of our leak tests
+     # failing in Python 2 (https://travis-ci.org/github/gevent/gevent/jobs/683782800);
+     # This was fixed in 3.0a5 (https://github.com/cython/cython/issues/3578).
+     # 3.0 in general has improved language support.
+     "Cython >= 3.0a6",
 ]

--- a/setup.py
+++ b/setup.py
@@ -108,10 +108,10 @@ setup(
         "License :: OSI Approved :: Zope Public License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Database",
@@ -153,6 +153,10 @@ setup(
                     'src/relstorage/cache/c_cache.cpp',
                 ],
                 include_dirs=['include'],
+                # https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model
+                # /EHsc: `s`: enable stack unwinding, catch C++ exceptions in catch(...)
+                #        `c`: extern C functions never throw C++ exceptions.
+                # XXX: Why this flag or Python 2/Windows? /EHa (catch SEH and standard) seems better.
                 extra_compile_args=["/EHsc"] if WINDOWS and PY2 else [],
             ),
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-mysql,py27-postgresql,pypy-mysql,pypy-postgresql,py37-mysql,py37-postgresql
+envlist = py27-mysql,py27-postgresql,pypy-mysql,pypy-postgresql,py37-mysql,py37-postgresql,py39-mysql-postgresql
 
 [testenv]
 # JAM: The comment and setting are cargo-culted from zope.interface.


### PR DESCRIPTION
- Test newer (current) versions of PyPy. This required a small fix to workaround an issue in PyPy3.6-7.3.1's sqlite.
- Stop testing Python 3.5 as it is going out of support.