### PR TITLE
Fix UnboundLocalError in StoreConnectionPool.borrowing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 3.3.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix an ``UnboundLocalError`` in case a store connection could not be
+  opened. This error shadowed the original error opening the
+  connection. See :issue:`421`.
 
 
 3.3.1 (2020-09-14)


### PR DESCRIPTION
We needed greater safety in StoreConnection.borrow. Test that this drops the connection if needed.

Fixes #421