### PR TITLE
Improve logging for zodbconvert and with psycopg2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,15 @@
 3.3.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Improve the logging of ``zodbconvert``. The regular minute logging
+  contains more information and takes blob sizes into account, and
+  debug logging is more useful, logging about four times a minute.
+  Some extraneous logging was bumped down to trace.
+
+- Fix psycopg2 logging debug-level warnings from the PostgreSQL server
+  on transaction commit about not actually being in a transaction.
+  (Sadly this just squashes the warning, it doesn't eliminate the
+  round trip that generates it.)
 
 
 3.3.2 (2020-09-21)

--- a/src/relstorage/_compat.py
+++ b/src/relstorage/_compat.py
@@ -83,6 +83,13 @@ MAC = sys.platform.startswith('darwin')
 
 try:
     # Python 3.3+ (PEP 418)
+
+    # The value (in fractional seconds) of a performance counter, i.e.
+    # a clock with the highest available resolution to measure a short
+    # duration. It does include time elapsed during sleep and is
+    # system-wide. The reference point of the returned value is
+    # undefined, so that only the difference between the results of
+    # consecutive calls is valid.
     from time import perf_counter
 except ImportError:
     import time

--- a/src/relstorage/adapters/postgresql/drivers/__init__.py
+++ b/src/relstorage/adapters/postgresql/drivers/__init__.py
@@ -81,7 +81,6 @@ class AbstractPostgreSQLDriver(AbstractModuleDriver):
                 notices = [d[b'M'] for d in notices]
                 conn.notices.clear()
             else:
-                notices = list(notices)
                 del conn.notices[:]
         return notices
 

--- a/src/relstorage/storage/copy.py
+++ b/src/relstorage/storage/copy.py
@@ -21,16 +21,19 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import logging
 import tempfile
-import time
 
+from ZODB.loglevels import TRACE
 from ZODB.blob import is_blob_record
-from ZODB.utils import u64 as bytes8_to_int64
 from ZODB.utils import cp as copy_blob
+from ZODB.utils import readable_tid_repr
 from ZODB.POSException import POSKeyError
 
+from relstorage._compat import perf_counter
+from relstorage._util import byte_display
 
-logger = __import__('logging').getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 class Copy(object):
 
@@ -45,26 +48,94 @@ class Copy(object):
         self.tpc = tpc
         self.restore = restore
 
-    # Time in seconds between progress logging.
-    log_interval = 60
-
-    # Number of transactions to copy before checking if we should log.
-    log_count = 10
-
     def copyTransactionsFrom(self, other):
-        # pylint:disable=too-many-locals,too-many-statements,too-many-branches
-        # adapted from ZODB.blob.BlobStorageMixin
-        begin_time = time.time()
-        log_at = begin_time + self.log_interval
-        txnum = 0
-        total_size = 0
-        blobhelper = self.blobhelper
-        tpc = self.tpc
-        restore = self.restore
-
         logger.info("Counting the transactions to copy.")
         other_it = other.iterator()
         logger.debug("Opened the other iterator: %s", other_it)
+        num_txns, other_it = self.__get_num_txns_to_copy(other, other_it)
+        logger.info("Copying %d transactions", num_txns)
+
+        progress = _ProgressLogger(num_txns, other, self.__copy_transaction)
+
+        try:
+            for trans in other_it:
+                progress(trans)
+        finally:
+            try:
+                close = other_it.close
+            except AttributeError:
+                pass
+            else:
+                close()
+
+        now = perf_counter()
+        logger.info(
+            "Copied transactions: %s",
+            progress.display_at(now))
+
+    def __copy_transaction(self, other, trans):
+        # Originally adapted from ZODB.blob.BlobStorageMixin
+        tpc = self.tpc
+        num_txn_records = 0
+        txn_data_size = 0
+        num_blobs = 0
+        tmp_blobs_to_rm = []
+
+        tpc.tpc_begin(trans, trans.tid, trans.status)
+        for record in trans:
+            num_txn_records += 1
+            if record.data:
+                txn_data_size += len(record.data)
+
+            blobfile = None
+            if is_blob_record(record.data):
+                try:
+                    blobfile = other.openCommittedBlobFile(
+                        record.oid, record.tid)
+                except POSKeyError:
+                    logger.exception("Failed to open blob to copy")
+            if blobfile is not None:
+                fd, name = tempfile.mkstemp(
+                    suffix='.tmp',
+                    dir=self.blobhelper.temporaryDirectory()
+                )
+                tmp_blobs_to_rm.append(name)
+                logger.log(
+                    TRACE,
+                    "Copying %s to temporary blob file %s for upload",
+                    blobfile, name)
+
+                with os.fdopen(fd, 'wb') as target:
+                    # If we don't get the length, ``copy_blob`` will.
+                    old_pos = blobfile.tell()
+                    blobfile.seek(0, 2)
+                    length = blobfile.tell()
+                    blobfile.seek(old_pos)
+
+                    copy_blob(blobfile, target, length)
+                    txn_data_size += length
+                blobfile.close()
+                self.restore.restoreBlob(record.oid, record.tid, record.data,
+                                         name, record.data_txn, trans)
+            else:
+                self.restore.restore(record.oid, record.tid, record.data,
+                                     '', record.data_txn, trans)
+
+        tpc.tpc_vote(trans)
+        tpc.tpc_finish(trans)
+
+        num_blobs = len(tmp_blobs_to_rm)
+        if num_blobs:
+            for tmp_blob in tmp_blobs_to_rm:
+                logger.log(TRACE, "Removing temporary blob file %s", tmp_blob)
+                try:
+                    os.unlink(tmp_blob)
+                except OSError:
+                    pass
+
+        return num_txn_records, txn_data_size, num_blobs
+
+    def __get_num_txns_to_copy(self, other, other_it):
         try:
             num_txns = len(other_it)
             if num_txns == 0:
@@ -78,71 +149,128 @@ class Copy(object):
                 num_txns += 1
             other_it.close()
             other_it = other.iterator()
-        logger.info("Copying %d transactions", num_txns)
 
-        tmp_blobs_to_rm = []
-        for trans in other_it:
-            txnum += 1
-            num_txn_records = 0
+        return num_txns, other_it
 
-            tpc.tpc_begin(trans, trans.tid, trans.status)
-            for record in trans:
-                blobfile = None
-                if is_blob_record(record.data):
-                    try:
-                        blobfile = other.openCommittedBlobFile(
-                            record.oid, record.tid)
-                    except POSKeyError:
-                        pass
-                if blobfile is not None:
-                    fd, name = tempfile.mkstemp(
-                        suffix='.tmp',
-                        dir=blobhelper.temporaryDirectory()
-                    )
-                    tmp_blobs_to_rm.append(name)
-                    logger.debug("Copying %s to temporary blob file %s for upload",
-                                 blobfile, name)
 
-                    with os.fdopen(fd, 'wb') as target:
-                        copy_blob(blobfile, target)
-                    blobfile.close()
-                    restore.restoreBlob(record.oid, record.tid, record.data,
-                                        name, record.data_txn, trans)
-                else:
-                    restore.restore(record.oid, record.tid, record.data,
-                                    '', record.data_txn, trans)
-                num_txn_records += 1
-                if record.data:
-                    total_size += len(record.data)
-            tpc.tpc_vote(trans)
-            tpc.tpc_finish(trans)
+class _ProgressLogger(object):
 
-            for tmp_blob in tmp_blobs_to_rm:
-                logger.debug("Removing temporary blob file %s", tmp_blob)
-                try:
-                    os.unlink(tmp_blob)
-                except OSError:
-                    pass
-            del tmp_blobs_to_rm[:]
+    # Time in seconds between major progress logging.
+    # (minor progress logging occurs every ``log_count`` commits)
+    log_interval = 60
 
-            if txnum % self.log_count == 0 and time.time() > log_at:
-                now = time.time()
-                log_at = now + self.log_interval
+    # Number of transactions to copy before checking if we should perform a major
+    # log.
+    log_count = 100
 
-                pct_complete = '%1.2f%%' % (txnum * 100.0 / num_txns)
-                elapsed = now - begin_time
-                if elapsed:
-                    rate = total_size / 1e6 / elapsed
-                else:
-                    rate = 0.0
-                rate_str = '%1.3f' % rate
+    # Number of transactions to copy before performing a minor log.
+    minor_log_count = 25
 
-                logger.info(
-                    "Copied tid %d,%5d records | %6s MB/s (%6d/%6d,%7s)",
-                    bytes8_to_int64(trans.tid), num_txn_records, rate_str,
-                    txnum, num_txns, pct_complete)
+    minor_log_interval = 15
 
-        elapsed = time.time() - begin_time
+    minor_log_tx_record_count = 100
+    minor_log_tx_size = 100 * 1024
+    minor_log_copy_time_threshold = 1.0
+
+    class _IntervalStats(object):
+        __slots__ = (
+            'begin_time',
+            'txns_copied',
+            'total_size',
+        )
+
+        def __init__(self, begin_time):
+            self.begin_time = begin_time
+            self.txns_copied = 0
+            self.total_size = 0
+
+        def display_at(self, now, total_num_txns, include_elapsed=False):
+            pct_complete = '%1.2f%%' % (self.txns_copied * 100.0 / total_num_txns)
+            elapsed_total = now - self.begin_time
+            if elapsed_total:
+                rate_mb = self.total_size / elapsed_total
+                rate_tx = self.txns_copied / elapsed_total
+            else:
+                rate_mb = rate_tx = 0.0
+            rate_mb_str = byte_display(rate_mb)
+            rate_tx_str = '%1.3f' % rate_tx
+
+            result = "%d/%d,%7s, %6s/s %6s TX/s, %s" % (
+                self.txns_copied, total_num_txns, pct_complete,
+                rate_mb_str, rate_tx_str,
+                byte_display(self.total_size),
+            )
+            if include_elapsed:
+                result += ' %4.1f minutes' % (elapsed_total / 60.0)
+            return result
+
+    def __init__(self, num_txns, other_storage, copy):
+        self.num_txns = num_txns
+        begin_time = perf_counter()
+        self._entire_stats = self._IntervalStats(begin_time)
+        self._interval_stats = self._IntervalStats(begin_time)
+
+        self.log_at = begin_time + self.log_interval
+        self.minor_log_at = begin_time + self.minor_log_interval
+        self.debug_enabled = logger.isEnabledFor(logging.DEBUG)
+
+        self._other_storage = other_storage
+        self._copy = copy
+
+    def display_at(self, now):
+        return self._entire_stats.display_at(now, self.num_txns, True)
+
+    def __call__(self, trans):
+        begin_copy = perf_counter()
+        result = self._copy(self._other_storage, trans)
+        now = perf_counter()
+        self._copied(now, now - begin_copy, trans, result)
+
+    def _copied(self, now, copy_duration, trans, copy_result):
+        entire_stats = self._entire_stats
+        interval_stats = self._interval_stats
+
+        entire_stats.txns_copied += 1
+        interval_stats.txns_copied += 1
+        total_txns_copied = self._entire_stats.txns_copied
+        txn_byte_size = copy_result[1]
+
+        entire_stats.total_size += txn_byte_size
+        interval_stats.total_size += txn_byte_size
+
+        if self.debug_enabled:
+            num_txn_records, txn_byte_size, _num_txn_blobs = copy_result
+            if (total_txns_copied % self.minor_log_count == 0 and now >= self.minor_log_at) \
+               or txn_byte_size >= self.minor_log_tx_size \
+               or num_txn_records >= self.minor_log_tx_record_count \
+               or copy_duration >= self.minor_log_copy_time_threshold:
+                self.minor_log_at = now + self.minor_log_interval
+                logger.debug(
+                    "Copied %s in %1.4fs",
+                    self.__transaction_display(trans, copy_result),
+                    copy_duration
+                )
+
+        if total_txns_copied % self.log_count and now >= self.log_at:
+            self.log_at = now + self.log_interval
+            self.__major_log(
+                now,
+                self.__transaction_display(trans, copy_result))
+            self._interval_stats = self._IntervalStats(now)
+
+
+    def __major_log(self, now, transaction_display):
+
         logger.info(
-            "All %d transactions copied successfully in %4.1f minutes.",
-            txnum, elapsed / 60.0)
+            "Copied %s | %60s | (%s)",
+            transaction_display,
+            self._interval_stats.display_at(now, self.num_txns),
+            self._entire_stats.display_at(now, self.num_txns, True)
+        )
+
+    def __transaction_display(self, trans, copy_result):
+        num_txn_records, txn_byte_size, num_txn_blobs = copy_result
+        return 'transaction %s <%4d records, %3d blobs, %9s>' % (
+            readable_tid_repr(trans.tid),
+            num_txn_records, num_txn_blobs, byte_display(txn_byte_size)
+        )

--- a/src/relstorage/zodbconvert.py
+++ b/src/relstorage/zodbconvert.py
@@ -24,6 +24,8 @@ from io import StringIO
 
 import ZConfig
 from persistent.timestamp import TimeStamp
+
+from ZODB import loglevels
 from ZODB.utils import p64
 from ZODB.utils import readable_tid_repr
 from ZODB.utils import u64
@@ -100,19 +102,26 @@ def main(argv=None):
              "and resume copying from the last transaction. WARNING: no "
              "effort is made to verify that the destination holds the same "
              "transaction data before this point! Use at your own risk. ")
-    parser.add_argument(
-        '--debug', dest="debug", action='store_true',
-        default=False,
-        help="Set the logging level to DEBUG instead of the default of "
-             "INFO."
+    log_group = parser.add_mutually_exclusive_group()
+    log_group.add_argument(
+        '--debug', dest="log_level", action='store_const',
+        const=logging.DEBUG,
+        default=logging.INFO,
+        help="Set the logging level to DEBUG instead of the default of INFO."
+    )
+    log_group.add_argument(
+        '--trace', dest="log_level", action='store_const',
+        const=loglevels.TRACE,
+        default=logging.INFO,
+        help="Set the logging level to TRACE instead of the default of INFO."
     )
     parser.add_argument("config_file", type=argparse.FileType('r'))
 
     options = parser.parse_args(argv[1:])
 
     logging.basicConfig(
-        level=logging.DEBUG if options.debug else logging.INFO,
-        format="%(asctime)s [%(name)s] %(levelname)s %(message)s"
+        level=options.log_level,
+        format="%(asctime)s [%(name)s] %(levelname)-6s %(message)s"
     )
 
     source, destination = open_storages(options)


### PR DESCRIPTION
zodbconvert logs more useful data at DEBUG level and drops some things to TRACE. A new CLI argument can enable TRACE. Regular logging includes more data too.

Avoid logging the warning about not being in a transaction during normal TPC when using psycopg2.
Deal gracefully with psycopg2 Connection.notices of None.

Example zodbconvert logging at DEBUG:
```
INFO   Copied transaction 0x03cba93d6dab2211 2018-11-16 09:01:25.703552 <   2 records,   0 blobs,   5.02 KB> |     6211/6932754,  0.09%, 182.90 KB/s 103.497 TX/s, 10.72 MB | (259766/6932754,  3.75%, 922.52 KB/s 76.206 TX/s, 3070.90 MB 56.8 minutes)
DEBUG  Copied transaction 0x03cba94182012622 2018-11-16 09:05:30.469802 <   1 records,   0 blobs,   1.17 KB> in 0.0163s
DEBUG  Copied transaction 0x03cba94e3873c1dd 2018-11-16 09:18:13.230979 <   1 records,   0 blobs,   2.13 KB> in 0.0078s
DEBUG  Copied transaction 0x03cba95f60f3ccee 2018-11-16 09:35:22.723206 <   1 records,   0 blobs,   1.00 KB> in 0.0082s
DEBUG  Copied transaction 0x03cba96e5c3f85dd 2018-11-16 09:50:21.620657 <   1 records,   0 blobs, 419 bytes> in 0.0099s
INFO   Copied transaction 0x03cba9769f0ce022 2018-11-16 09:58:37.277413 <   2 records,   0 blobs,   2.92 KB> |      5955/6932754,  0.09%, 190.70 KB/s 99.248 TX/s, 11.17 MB | (265721/6932754,  3.83%, 909.86 KB/s 76.605 TX/s, 3082.08 MB 57.8 minutes)
```