### PR TITLE
Improve the efficiency of packing databases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
   (Sadly this just squashes the warning, it doesn't eliminate the
   round trip that generates it.)
 
+- Improve the performance of packing databases, especially
+  history-free databases. See :issue:`275`.
 
 3.3.2 (2020-09-21)
 ==================

--- a/docs/postgresql/setup.rst
+++ b/docs/postgresql/setup.rst
@@ -36,3 +36,22 @@ PostgreSQL re-reads ``pg_hba.conf`` when you ask it to reload its
 configuration file::
 
     /etc/init.d/postgresql reload
+
+Configuration
+=============
+
+.. tip::
+
+   For packing large databases, a larger value of the PostgreSQL
+   configuration paramater ``work_mem`` is likely to yield improved
+   performance. The default is 4MB; try 16MB if packing performance is
+   unacceptable.
+
+.. tip::
+
+   For packing large databases, setting the ``pack_object``,
+   ``object_ref`` and ``object_refs_added`` tables to `UNLOGGED
+   <https://www.postgresql.org/docs/12/sql-createtable.html#SQL-CREATETABLE-UNLOGGED>`_
+   can provide a performance boost (if replication doesn't matter and
+   you don't care about the contents of these tables). This can be
+   done after the schema is created with ``ALTER TABLE table SET UNLOGGED``.

--- a/docs/sqlite3/faq.rst
+++ b/docs/sqlite3/faq.rst
@@ -81,6 +81,12 @@ parallel commits?
    database is locked as close to the end of the commit process as
    possible.
 
+   Note that packing a SQLite database makes no effort to reduce the
+   amount of time spent writing to the database. It's unlikely you'll
+   get meaningful parallel writes to happen while packing the
+   database. If you plan to deploy SQLite databases to production,
+   also plan to schedule downtime to pack them.
+
 Q: Should I disable RelStorage's cache when used with SQLite?
 
    A: Possibly (with ``cache-local-mb 0``). Let the operating system

--- a/docs/things-to-know.rst
+++ b/docs/things-to-know.rst
@@ -139,3 +139,30 @@ maintain a registry of open databases. Here's an example using
 It might also be necessary to register a signal handler to perform the
 same operation in the event of unclean shutdowns. See :issue:`183` for
 more discussion.
+
+.. _to-know-about-pack:
+
+Packing A Database May Increase Disk Usage
+==========================================
+
+After packing a RelStorage, whether history-free or history-preserving,
+whether through the ZODB APIs or the command line tool
+:doc:`zodbpack`, you may find that the database disk usage has
+actually increased, sometimes by a substantial fraction of the main
+database size.
+
+RelStorage deliberately stores information in the database about the
+object references it discovered during packing. The next time a pack
+is run, this information is used for objects that haven't changed,
+making it unnecessary for RelStorage to discover it again. In turn,
+this makes subsequent packs substantially faster when there are many
+objects that haven't changed (which is typically the case for many
+applications.)
+
+A future version of RelStorage might provide the option to remove this
+data when a pack finishes.
+
+You can also use the ``multi-zodb-gc`` script provided by the
+``zc.zodbdgc`` project to pack a RelStorage. It does not store this
+persistent data, but it may be substantially slower than the native
+packing capabilities, especially on large databases.

--- a/docs/zodbpack.rst
+++ b/docs/zodbpack.rst
@@ -16,6 +16,8 @@ the storages to pack, in ZConfig format. An example configuration file::
     </mysql>
   </relstorage>
 
+When packing a RelStorage, please read :ref:`to-know-about-pack`.
+
 Options for ``zodbpack``
 ========================
 

--- a/src/relstorage/adapters/batch.py
+++ b/src/relstorage/adapters/batch.py
@@ -287,7 +287,7 @@ class RowBatcher(object):
             params = list(itertools.chain.from_iterable(rows))
 
             stmt = "%s INTO %s VALUES\n%s\n%s" % (
-                command, header, ',\n'.join(values_template), suffix)
+                command, header, ', '.join(values_template), suffix)
             # e.g.,
             # INSERT INTO table(c1, c2)
             # VALUES (%s, %s), (%s, %s), (%s, %s)

--- a/src/relstorage/adapters/batch.py
+++ b/src/relstorage/adapters/batch.py
@@ -210,14 +210,18 @@ class RowBatcher(object):
         Rows are net expected to be returned, so the cursor is completely consumed between
         batches.
         """
-        for cursor in self.__select_like(
+        # We actually just consume the iteration of the cursor itself;
+        # we can't consume the cursor. Some drivers (pg8000) throw ProgrammingError
+        # if we try to iterate the cursor that has no rows.
+        consume(
+            self.__select_like(
                 update_set,
                 None, # table not used
                 '', # suffix not used,
                 timeout,
                 kw
-        ):
-            consume(cursor)
+        ))
+
         return self.__last_select_like_count
 
     __last_select_like_count = 0

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -41,6 +41,15 @@ class IDBDialect(Interface):
 
     # TODO: Fill this in.
 
+    def boolean_str(value):
+        """
+        Given exactly a `bool` (`True` or `False`) return the string the database
+        uses to represent that literal.
+
+        By default, this will be "TRUE" or "FALSE", but older versions of SQLite
+        need 1 or 0, while Oracle needs "'Y'" or "'N'".
+        """
+
 class IDBDriver(Interface):
     """
     An abstraction over the information needed for RelStorage to work

--- a/src/relstorage/adapters/oracle/dialect.py
+++ b/src/relstorage/adapters/oracle/dialect.py
@@ -21,10 +21,6 @@ from ..sql.insert import _ExcludedColumn
 
 class OracleCompiler(Compiler):
 
-    def visit_boolean_literal_expression(self, value):
-        sql = "'Y'" if value else "'N'"
-        self.emit(sql)
-
     def can_prepare(self):
         # We haven't investigated preparing statements manually
         # with cx_Oracle. There's a chance that `cx_Oracle.Connection.stmtcachesize`
@@ -117,3 +113,7 @@ class OracleDialect(DefaultDialect):
 
     def compiler_class(self):
         return OracleCompiler
+
+    def boolean_str(self, value):
+        sql = "'Y'" if value else "'N'"
+        return sql

--- a/src/relstorage/adapters/postgresql/batch.py
+++ b/src/relstorage/adapters/postgresql/batch.py
@@ -29,9 +29,14 @@ class PostgreSQLRowBatcher(RowBatcher):
     def _make_single_column_query(self, command, table,
                                   filter_column, filter_value,
                                   rows_need_flattened):
-        stmt = "%s FROM %s WHERE %s = ANY (%s)" % (
-            command, table, filter_column, self.delete_placeholder
-        )
+        if not command.startswith("UPDATE"):
+            stmt = "%s FROM %s WHERE %s = ANY (%s)" % (
+                command, table, filter_column, self.delete_placeholder
+            )
+        else:
+            stmt = '%s WHERE %s = ANY (%s)' % (
+                command, filter_column, self.delete_placeholder
+            )
         # We only pass a single parameter, and it doesn't need further
         # flattening.
         # It does have to be an actual list, though

--- a/src/relstorage/adapters/sql/ast.py
+++ b/src/relstorage/adapters/sql/ast.py
@@ -44,6 +44,10 @@ class BooleanNode(LiteralNode):
 
     __slots__ = ()
 
+    def __compile_visit__(self, compiler):
+        compiler.emit_boolean(self.raw)
+
+
 class TextNode(LiteralNode):
     __slots__ = ()
 

--- a/src/relstorage/adapters/sql/dialect.py
+++ b/src/relstorage/adapters/sql/dialect.py
@@ -45,6 +45,9 @@ class DefaultDialect(object):
     STMT_TABLE_TRAILER = ''
     STMT_IF_NOT_EXISTS = ''
 
+    def boolean_str(self, value):
+        return str(value).upper()
+
     def bind(self, context):
         # The context will reference us most likely
         # (compiled statement in instance dictionary)
@@ -396,12 +399,17 @@ class Compiler(object):
             placeholder = self._placeholder_for_literal_param_value(value)
             self.emit(placeholder)
 
-    def visit_boolean_literal_expression(self, value):
+    def emit_boolean(self, value):
         # In the oracle dialect, this needs to be
         # either "'Y'" or "'N'". sqlite supports only 1 and 0,
         # prior to certain versions.
         assert isinstance(value, bool)
-        self.emit(str(value).upper())
+        value = self.dialect.boolean_str(value)
+
+        self.emit(value)
+
+    def visit_boolean_literal_expression(self, value):
+        self.emit_boolean(value)
 
     def visit_immediate_expression(self, value):
         # Like a literal, but never uses a placeholder.

--- a/src/relstorage/adapters/sqlite/dialect.py
+++ b/src/relstorage/adapters/sqlite/dialect.py
@@ -70,11 +70,6 @@ class _Sqlite3UpsertCompiler(DefaultCompiler):
             quoted = True
         super(_Sqlite3UpsertCompiler, self).emit_identifier(identifier, quoted)
 
-    if not SQ3_SUPPORTS_BOOL_KW:
-        def visit_boolean_literal_expression(self, value):
-            assert isinstance(value, bool)
-            self.emit('1' if value else '0')
-
     def _placeholder(self, key):
         if key == '?':
             return key
@@ -141,3 +136,8 @@ class Sqlite3Dialect(DefaultDialect):
 
     def compiler_class(self):
         return SqliteCompiler
+
+    if not SQ3_SUPPORTS_BOOL_KW:
+        def boolean_str(self, value):
+            assert isinstance(value, bool)
+            return '1' if value else '0'

--- a/src/relstorage/adapters/tests/test_batch.py
+++ b/src/relstorage/adapters/tests/test_batch.py
@@ -191,7 +191,7 @@ class RowBatcherTests(TestCase):
             cursor.executed,
             [(
                 'INSERT INTO mytable (id, name) VALUES\n'
-                '(%s, id || %s),\n'
+                '(%s, id || %s), '
                 '(%s, id || %s)\n',
                 (1, 'a', 2, 'B'))
             ])
@@ -221,14 +221,16 @@ class RowBatcherTests(TestCase):
             rowkey=2,
             size=5,
             )
+        self.assertLength(cursor.executed, 1)
         self.assertEqual(
-            cursor.executed,
-            [(
-                'INSERT INTO mytable (id, name) VALUES\n'
-                '(%s, id || %s),\n'
-                '(%s, id || %s)\n',
-                (1, 'a', 2, 'B'))
-            ])
+            cursor.executed[0][0],
+            'INSERT INTO mytable (id, name) VALUES\n'
+            '(%s, id || %s), '
+            '(%s, id || %s)\n')
+        self.assertEqual(
+            cursor.executed[0][1],
+            (1, 'a', 2, 'B')
+            )
         self.assertEqual(batcher.rows_added, 0)
         self.assertEqual(batcher.size_added, 0)
         self.assertEqual(batcher.inserts, {})

--- a/src/relstorage/cache/mvcc.py
+++ b/src/relstorage/cache/mvcc.py
@@ -35,7 +35,7 @@ from relstorage._compat import IN_TESTRUNNER
 from relstorage._util import log_timed
 from relstorage._util import positive_integer
 from relstorage._util import TRACE as LTRACE
-from relstorage._util import get_time_from_environ
+from relstorage._util import get_duration_from_environ
 from relstorage._mvcc import DetachableMVCCDatabaseCoordinator
 from relstorage.options import Options
 from relstorage.interfaces import IMVCCDatabaseViewer
@@ -50,7 +50,7 @@ DEBUG = __debug__ and IN_TESTRUNNER
 #: database for OIDS when restoring the cache. If this time is exceeded,
 #: we will only partially use the cache. This is not set by default because
 #: doing so introduces a slight speed penalty to the polling process.
-POLL_TIMEOUT = get_time_from_environ('RS_CACHE_POLL_TIMEOUT', None)
+POLL_TIMEOUT = get_duration_from_environ('RS_CACHE_POLL_TIMEOUT', None)
 
 ###
 # Notes on in-process concurrency:

--- a/src/relstorage/options.py
+++ b/src/relstorage/options.py
@@ -42,6 +42,11 @@ class Options(object):
        Add the ``blob_cache_size_check_external`` option, defaulting to False.
 
        Change the default for ``shared_blob_dir`` to False.
+
+    .. versionchanged:: 3.3.3
+       Since packing no longer holds the commit lock, ``pack_batch_timeout`` is the interval
+       between committing deletions. Changed from 1.0s to 15s.
+       Note that this is not universally applied.
     """
 
     #: The adapter factory configuration.
@@ -90,8 +95,8 @@ class Options(object):
     pack_prepack_only = False
     #: Skip prepack
     pack_skip_prepack = False
-    #: Length of time to hold a lock.
-    pack_batch_timeout = 1.0
+    #: Amount of time between commits/log messages.
+    pack_batch_timeout = 15.0
 
     #: List of memcache servers
     cache_servers = ()  # ['127.0.0.1:11211']

--- a/src/relstorage/tests/packundo.py
+++ b/src/relstorage/tests/packundo.py
@@ -190,10 +190,10 @@ class HistoryFreeTestPack(TestPackBase):
         # and we don't bother to look at it.
         expect_oids = self._create_initial_state()
 
-        def inject_changes(oid_batch, refs_found):
+        def inject_changes(oid_batch, num_refs_found):
             # We're examining the root and the first three objects
             self.assertEqual(sorted(oid_batch), sorted(self.OID_INITIAL_SET))
-            self.assertEqual(len(refs_found), 3)
+            self.assertEqual(num_refs_found, 3)
             # We're only called once: a single batch
             self.assertNotIn('D', expect_oids)
             self._mutate_state(expect_oids)
@@ -210,7 +210,7 @@ class HistoryFreeTestPack(TestPackBase):
         # We mutate just before we examine the state for the B object.
         expect_oids = self._create_initial_state()
         seen_oids = []
-        def inject_changes(oid_batch, refs_found): # pylint:disable=unused-argument
+        def inject_changes(oid_batch, num_refs_found): # pylint:disable=unused-argument
             oid_batch = list(oid_batch)
             seen_oids.extend(oid_batch)
             self.assertEqual(1, len(oid_batch))

--- a/src/relstorage/tests/test__util.py
+++ b/src/relstorage/tests/test__util.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2020 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+"""
+Tests for _util.py
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+import doctest
+
+from relstorage import _util
+
+def test_suite():
+    # zope-testrunner specific test loading.
+    return unittest.TestSuite((
+        doctest.DocTestSuite(_util)
+    ))

--- a/src/relstorage/zodbpack.py
+++ b/src/relstorage/zodbpack.py
@@ -77,6 +77,13 @@ def main(argv=None):
         storage = s.open()
         logger.info("Packing %s.", name)
         if options.prepack or options.reuse_prepack:
+            # TODO: For RelStorages, add options to:
+            #
+            # - Reset the pre-pack state entirely (pack_object is always reset, but
+            #   what about object_ref and object_refs_added)?
+            # - Make the pack tables unlogged (ALTER TABLE table SET UNLOGGED on postgres.
+            #   Seems much faster?)
+            #
             storage.pack(t, ZODB.serialize.referencesf,
                          prepack_only=options.prepack,
                          skip_prepack=options.reuse_prepack)


### PR DESCRIPTION
Especially, but not only, history-free databases, by using more batch operations. It can now be substantially faster than using the external `multi-zodb-gc` script in addition to using less memory. See #275 for some timing information.

Added documentation about persistent reference information being stored. That should fix #395.