### PR TITLE
Make copyTransactionsFrom much faster in history-free storages when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,7 +139,7 @@ env:
         - PIP_NO_WARN_SCRIPT_LOCATION=1
         - CFLAGS="-pipe -std=gnu++11"
         - CXXFLAGS="-pipe -std=gnu++11"
-        - RS_TEST_CMD="-m zope.testrunner --test-path=src --auto-color --auto-progress -vvv --slow-test=3"
+        - RS_TEST_CMD="-m zope.testrunner --test-path=src --auto-color --auto-progress -v --slow-test=3"
         # Uploading built wheels for releases.
         # TWINE_PASSWORD is encrypted and stored directly in the
         # travis repo settings.

--- a/.travis/zope_testrunner_gevent.py
+++ b/.travis/zope_testrunner_gevent.py
@@ -23,7 +23,7 @@ from zope.testrunner import run
 sys.argv[:] = [
     'zope-testrunner',
     '--test-path=src',
-    '-vvv',
+    '-v',
     '--color',
 ] + sys.argv[1:]
 print(sys.argv)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,13 @@
 
 - Require ZODB 5.6, up from ZODB 5.5. See :issue:`424`.
 
+- Make ``zodbconvert`` *much faster* (around 5 times faster) when the
+  destination is a history-free RelStorage and the source supports
+  ``record_iternext()`` (like RelStorage and FileStorage do). This
+  also applies to the ``copyTransactionsFrom`` method. This is disabled
+  with the ``--incremental`` option, however. Be sure to read the
+  updated zodbconvert documentation.
+
 3.3.2 (2020-09-21)
 ==================
 

--- a/docs/zodbconvert.rst
+++ b/docs/zodbconvert.rst
@@ -54,6 +54,63 @@ want to reverse the conversion, exchange the names "source" and
 "destination". All storage types and storage options available in
 zope.conf are also available in this configuration file.
 
+Incremental Copies
+------------------
+
+The option ``--incremental`` asks zodbconvert to perform a partial
+copy of the data. It requires that the destination storage contains a
+*complete* copy of all data from the source up through the last
+transaction recorded in the destination. (For the first invocation of
+the program, the destination storage should be empty.)
+
+For this to work correctly, the source database must provide a
+consistent view of the database through its iterators. RelStorage does
+this, as does a FileStorage; it is not know if ZEO or other storages
+do this.
+
+This can be used to update a previous copy or update a backup. It can
+also be used to perform an online migration while the source is in use
+and changing, without requiring much downtime. Each invocation of
+``zodbconvert --incremental`` will come closer and closer to "catching
+up" to the most recent transaction in the source database (and run for
+shorter periods). When the copy is "close enough," stop writing to the
+source database, perform one final ``zodbconvert --incremental`` (thus
+matching the exact state of the source database), and finally
+re-configure your software to use the destination database instead of
+the source database and restart writing to the "new" database.
+
+.. tip::
+
+   When the destination is a history-free RelStorage, using
+   ``--incremental`` is several times slower than performing a regular
+   copy. For this reason, and for the reason outlined below, using
+   ``--incremental`` with history-free RelStorage destinations is
+   discouraged.
+
+.. caution::
+
+   If a copy into a history-free RelStorage is interrupted and does
+   not complete, *it is not safe* to restart the copy with
+   ``--incremental``; doing so could result in data loss. This is
+   because copying into a history-free RelStorage copies in order of
+   object ID, while copying with ``--incremental`` copies in order of
+   transaction ID.
+
+   To safely use incremental with a history-free RelStorage
+   destination, first ensure that a complete copy of the source has
+   been performed at least once. After that, the destination can be
+   updated with ``--incremental``.
+
+   ``zodbconvert`` will not warn you about the potential corruption
+   that can occur if a non-incremental copy was halted part way and
+   then a ``--incremental`` copy was begun.
+
+   To safely copy into a history-free database,  perform a
+   complete copy *without* ``--incremental`` and then perform further
+   updates with ``--incremental``. If the source database is so large
+   that performing a single complete copy is impractical, you must
+   begin the very first copy with ``--incremental``.
+
 Tips
 ====
 

--- a/docs/zodbconvert.rst
+++ b/docs/zodbconvert.rst
@@ -54,6 +54,71 @@ want to reverse the conversion, exchange the names "source" and
 "destination". All storage types and storage options available in
 zope.conf are also available in this configuration file.
 
+Tips
+====
+
+When using a storage wrapper, such as `zc.zlibstorage
+<https://pypi.org/project/zc.zlibstorage/>`_ to provide
+transformations of the stored data, it is not necessary to keep the
+wrapper when both the source and destination storage would use the
+same wrapper.
+
+In fact it is faster, to *remove the wrapper* on both the source and
+destination storage when performing the copy. This avoids the
+redundant decompressing and recompressing of the data as it is read
+from one storage and copied to the next.
+
+The exception, of course, is if you want the destination to feature a
+transformation (or untransformation) that the source does not have.
+
+For example, if you initially have a configuration like this::
+
+  <zlibstorage>
+    <filestorage>
+      path /zope/var/Data.fs
+    </filestorage>
+  </zlibstorage>
+
+The fastest way to create a compressed RelStorage copy will be to omit
+the storage wrapper::
+
+  <filestorage source>
+    path /zope/var/Data.fs
+  </filestorage>
+
+  <relstorage destination>
+    <mysql>
+      db zodb
+    </mysql>
+  </relstorage>
+
+
+To use the resulting RelStorage, you'll need to re-apply the wrapper::
+
+  <zlibstorage>
+    <relstorage>
+      <mysql>
+        db zodb
+      </mysql>
+    </relstorage>
+  </zlibstorage>
+
+
+In contrast, this configuration will produce an *uncompressed* RelStorage::
+
+  <zlibstorage>
+    <filestorage source>
+      path /zope/var/Data.fs
+    </filestorage>
+  </zlibstorage>
+
+  <relstorage destination>
+    <mysql>
+      db zodb
+    </mysql>
+  </relstorage>
+
+
 Options for ``zodbconvert``
 ===========================
 

--- a/src/relstorage/adapters/connections.py
+++ b/src/relstorage/adapters/connections.py
@@ -269,7 +269,7 @@ class AbstractManagedConnection(object):
         try:
             yield ss_cursor
         finally:
-            ss_cursor.close()
+            self.connmanager.close(cursor=ss_cursor)
 
     def __repr__(self):
         return "<%s at 0x%x active=%s, conn=%r cur=%r>" % (

--- a/src/relstorage/adapters/connmanager.py
+++ b/src/relstorage/adapters/connmanager.py
@@ -184,6 +184,7 @@ class AbstractConnectionManager(object):
                 try:
                     obj.close()
                 except self._ignored_exceptions: # pylint:disable=catching-non-exception
+                    logger.debug("Exception closing %r", obj, exc_info=1)
                     clean = False
         return clean
 

--- a/src/relstorage/adapters/dbiter.py
+++ b/src/relstorage/adapters/dbiter.py
@@ -74,7 +74,7 @@ class DatabaseIterator(DatabaseHelpersMixin):
     ).where(
         it.c.zoid >= it.bindparam('start_oid')
     ).order_by(
-        it.c.tid
+        it.c.zoid
     )
 
     def iter_current_records(self, cursor, start_oid_int=0):
@@ -86,8 +86,7 @@ class DatabaseIterator(DatabaseHelpersMixin):
         Each current object is returned only once, at the transaction most recently
         committed for it.
 
-        Objects are iterated from oldest transaction to newest transaction
-        for compatibility with the ``--incremental`` mode of zodbconvert.
+        Objects are iterated or order of their OID for compatibility with FileStorage.
 
         Returns a generator.
         """

--- a/src/relstorage/adapters/dbiter.py
+++ b/src/relstorage/adapters/dbiter.py
@@ -74,7 +74,7 @@ class DatabaseIterator(DatabaseHelpersMixin):
     ).where(
         it.c.zoid >= it.bindparam('start_oid')
     ).order_by(
-        it.c.zoid
+        it.c.tid
     )
 
     def iter_current_records(self, cursor, start_oid_int=0):
@@ -85,6 +85,9 @@ class DatabaseIterator(DatabaseHelpersMixin):
 
         Each current object is returned only once, at the transaction most recently
         committed for it.
+
+        Objects are iterated from oldest transaction to newest transaction
+        for compatibility with the ``--incremental`` mode of zodbconvert.
 
         Returns a generator.
         """

--- a/src/relstorage/storage/__init__.py
+++ b/src/relstorage/storage/__init__.py
@@ -935,7 +935,7 @@ class RelStorage(LegacyMethodsMixin,
 
 try:
     from zc import zlibstorage
-except ImportError:
+except ImportError: # pragma: no cover
     zlibstorage = None
 
 def _zlibstorage_new_instance(self):

--- a/src/relstorage/storage/copy.py
+++ b/src/relstorage/storage/copy.py
@@ -81,7 +81,7 @@ class Copy(object):
     # using the regular iterator():
     #
     # - We could copy and discard the state for a single object
-    #   many times. Doing too much work.
+    #   many times. Doing way too much work.
 
     def copyTransactionsFrom(self, other):
         # Just the interface, not the attribute, in case we have a
@@ -181,6 +181,9 @@ class _AbstractCopier(object):
                     oid, tid)
             except POSKeyError:
                 logger.exception("Failed to open blob to copy")
+
+        # We may not be able to read the data after this.
+        data = self.restore._crs_transform_record_data(data)
         if blobfile is not None:
             fd, name = tempfile.mkstemp(
                 suffix='.tmp',

--- a/src/relstorage/storage/copy.py
+++ b/src/relstorage/storage/copy.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 def close(it):
     try:
         c = it.close
-    except AttributeError:
+    except AttributeError: # pragma: no cover
         pass
     else:
         c()
@@ -175,7 +175,7 @@ class _AbstractCopier(object):
             try:
                 blobfile = self.storage.openCommittedBlobFile(
                     oid, tid)
-            except POSKeyError:
+            except POSKeyError: # pragma: no cover
                 logger.exception("Failed to open blob to copy")
 
         # We may not be able to read the data after this.
@@ -288,7 +288,7 @@ class _RecordIternextIterator(object):
         self.storage = storage
         self.cookie = self
 
-    def __iter__(self):
+    def __iter__(self): # pragma: no cover
         return self
 
     def __next__(self):
@@ -300,7 +300,7 @@ class _RecordIternextIterator(object):
             self.cookie = None
         try:
             result = self.storage.record_iternext(self.cookie)
-        except ValueError:
+        except ValueError:  # pragma: no cover
             # FileStorage can raise this if the underlying storage
             # is completely empty.
             # See https://github.com/zopefoundation/ZODB/issues/330
@@ -455,11 +455,11 @@ class _ProgressLogger(object):
             ))
 
             elapsed_total = now - self.begin_time
+            rate_mb = rate_units = 0.0
             if elapsed_total:
                 rate_mb = self.total_size / elapsed_total
                 rate_units = self.units_copied / elapsed_total
-            else:
-                rate_mb = rate_units = 0.0
+
             rate_mb_str = byte_display(rate_mb)
             rate_unit_str = '%1.2f' % rate_units
 
@@ -523,7 +523,8 @@ class _ProgressLogger(object):
         return total_units_copied % self.log_count and now >= self.log_at
 
     def _should_minor_log(self, now, total_units_copied, txn_byte_size, num_txn_records,
-                          copy_duration):
+                          copy_duration): # pragma: no cover
+        # This is mocked out by test_zodbconvert so we always try to log.
         if (total_units_copied % self.minor_log_count == 0 and now >= self.minor_log_at):
             return True
         if txn_byte_size >= self.minor_log_tx_size:

--- a/src/relstorage/storage/copy.py
+++ b/src/relstorage/storage/copy.py
@@ -84,8 +84,10 @@ class Copy(object):
     #   many times. Doing too much work.
 
     def copyTransactionsFrom(self, other):
-        other_has_record_iternext = IRecordIter.providedBy(other) or hasattr(other,
-                                                                             'record_iternext')
+        # Just the interface, not the attribute, in case we have a
+        # partial proxy.
+        other_has_record_iternext = IRecordIter.providedBy(other)
+
         copier_factory = _HistoryFreeCopier
         if self.tpc.keep_history or not other_has_record_iternext:
             copier_factory = _HistoryPreservingCopier

--- a/src/relstorage/storage/copy.py
+++ b/src/relstorage/storage/copy.py
@@ -24,16 +24,26 @@ import os
 import logging
 import tempfile
 
+from ZODB.Connection import TransactionMetaData
 from ZODB.loglevels import TRACE
 from ZODB.blob import is_blob_record
 from ZODB.utils import cp as copy_blob
 from ZODB.utils import readable_tid_repr
 from ZODB.POSException import POSKeyError
+from ZODB.interfaces import IStorageCurrentRecordIteration as IRecordIter
 
 from relstorage._compat import perf_counter
 from relstorage._util import byte_display
 
 logger = logging.getLogger(__name__)
+
+def close(it):
+    try:
+        c = it.close
+    except AttributeError:
+        pass
+    else:
+        c()
 
 class Copy(object):
 
@@ -45,118 +55,307 @@ class Copy(object):
 
     def __init__(self, blobhelper, tpc, restore):
         self.blobhelper = blobhelper
+        # In practice, both *tpc* and *restore* are the
+        # RelStorage instance.
         self.tpc = tpc
         self.restore = restore
 
-    def copyTransactionsFrom(self, other):
-        logger.info("Counting the transactions to copy.")
-        other_it = other.iterator()
-        logger.debug("Opened the other iterator: %s", other_it)
-        num_txns, other_it = self.__get_num_txns_to_copy(other, other_it)
-        logger.info("Copying %d transactions", num_txns)
+    # Issues with iternext:
+    # - No way to specify a starting transaction (FileStorage and RelStorage
+    #   iterate by OID and can specify a starting OID).
+    #   So this silently breaks the ``incremental`` mode of zodbconvert;
+    #   Things still work, we just copy all objects from the beginning, and
+    #   if we copied some, stopped, then start again, and in the meantime the source
+    #   storage was packed, we could wind up with extra objects. That's the case
+    #   anyway, though.
+    # - Doesn't support len(); we iterate manually to find it. This requires
+    #   downloading all the object states. In a RelStorage, that's not good.
+    # - We could iterate the current records and store them into a local
+    #   FileStorage, and then use the regular iterator to get guaranteed-unique
+    #   object states. This uses lots of temporary disk space, though.
+    # - The number of transactions and the number of distinct objects are not necessarily
+    #   related. Basically we need to rethink our progress reporting to handle this.
+    #   Use number-of-objects.
+    #
+    # Issues copying from history-preserving to history-free
+    # using the regular iterator():
+    #
+    # - We could copy and discard the state for a single object
+    #   many times. Doing too much work.
 
-        progress = _ProgressLogger(num_txns, other, self.__copy_transaction)
+    def copyTransactionsFrom(self, other):
+        other_has_record_iternext = IRecordIter.providedBy(other) or hasattr(other,
+                                                                             'record_iternext')
+        copier_factory = _HistoryFreeCopier
+        if self.tpc.keep_history or not other_has_record_iternext:
+            copier_factory = _HistoryPreservingCopier
+        logger.info(
+            "Copying transactions to %s "
+            "from %s (supports IStorageCurrentRecordIteration? %s) "
+            "using %s",
+            self.tpc,
+            other,
+            other_has_record_iternext,
+            copier_factory,
+        )
+        copier = copier_factory(other, self.blobhelper, self.tpc, self.restore)
 
         try:
-            for trans in other_it:
-                progress(trans)
+            logger.info("Counting the %s to copy.", copier.units)
+            num_txns = len(copier)
+            logger.info("Copying %d %s", num_txns, copier.units)
+
+            progress = _ProgressLogger(num_txns)
+            copier.copy(progress)
         finally:
-            try:
-                close = other_it.close
-            except AttributeError:
-                pass
-            else:
-                close()
+            copier.close()
 
         now = perf_counter()
         logger.info(
             "Copied transactions: %s",
             progress.display_at(now))
 
-    def __copy_transaction(self, other, trans):
-        # Originally adapted from ZODB.blob.BlobStorageMixin
-        tpc = self.tpc
-        num_txn_records = 0
-        txn_data_size = 0
-        num_blobs = 0
-        tmp_blobs_to_rm = []
 
-        tpc.tpc_begin(trans, trans.tid, trans.status)
-        for record in trans:
-            num_txn_records += 1
-            if record.data:
-                txn_data_size += len(record.data)
+class _AbstractCopier(object):
 
-            blobfile = None
-            if is_blob_record(record.data):
-                try:
-                    blobfile = other.openCommittedBlobFile(
-                        record.oid, record.tid)
-                except POSKeyError:
-                    logger.exception("Failed to open blob to copy")
-            if blobfile is not None:
-                fd, name = tempfile.mkstemp(
-                    suffix='.tmp',
-                    dir=self.blobhelper.temporaryDirectory()
-                )
-                tmp_blobs_to_rm.append(name)
-                logger.log(
-                    TRACE,
-                    "Copying %s to temporary blob file %s for upload",
-                    blobfile, name)
+    units = 'transactions'
+    total_count = None
 
-                with os.fdopen(fd, 'wb') as target:
-                    # If we don't get the length, ``copy_blob`` will.
-                    old_pos = blobfile.tell()
-                    blobfile.seek(0, 2)
-                    length = blobfile.tell()
-                    blobfile.seek(old_pos)
+    def __init__(self, storage, blobhelper, tpc, restore):
+        self.storage = storage
+        self.restore = restore
+        self.blobhelper = blobhelper
+        self.tpc = tpc
+        self.temp_blobs_to_rm = []
 
-                    copy_blob(blobfile, target, length)
-                    txn_data_size += length
-                blobfile.close()
-                self.restore.restoreBlob(record.oid, record.tid, record.data,
-                                         name, record.data_txn, trans)
-            else:
-                self.restore.restore(record.oid, record.tid, record.data,
-                                     '', record.data_txn, trans)
+    def __len__(self):
+        if self.total_count is None:
+            self.total_count = self._compute_total_count()
+        return self.total_count
 
-        tpc.tpc_vote(trans)
-        tpc.tpc_finish(trans)
+    def _compute_total_count(self):
+        raise NotImplementedError
 
-        num_blobs = len(tmp_blobs_to_rm)
+    def copy(self, progress):
+        # type: (_ProgressLogger) -> None
+        raise NotImplementedError
+
+    def clean_temp_blobs(self):
+        num_blobs = len(self.temp_blobs_to_rm)
         if num_blobs:
-            for tmp_blob in tmp_blobs_to_rm:
+            for tmp_blob in self.temp_blobs_to_rm:
                 logger.log(TRACE, "Removing temporary blob file %s", tmp_blob)
                 try:
                     os.unlink(tmp_blob)
                 except OSError:
                     pass
+            del self.temp_blobs_to_rm[:]
+        return num_blobs
 
-        return num_txn_records, txn_data_size, num_blobs
+    def close(self):
+        self.clean_temp_blobs()
+        self.storage = None
 
-    def __get_num_txns_to_copy(self, other, other_it):
+    def restore_one(self, active_txn_meta,
+                    oid, tid, data):
+
+        # The signature for both ``restore`` and ``restoreBlob``
+        # is:
+        #
+        #   (oid, serial, data, (blobfilename|prev_txn), version, txn)
+        #
+        # Where ``txn`` is the TransactionMetaData object
+        # originally passed to ``tpc_begin``. It is only used to
+        # check that the same object has been passed.
+        #
+        # ``prev_txn`` is not used but would come from ``record.data_txn``
+
+        txn_data_size = len(data) if data else 0
+
+        blobfile = None
+        if is_blob_record(data):
+            try:
+                blobfile = self.storage.openCommittedBlobFile(
+                    oid, tid)
+            except POSKeyError:
+                logger.exception("Failed to open blob to copy")
+        if blobfile is not None:
+            fd, name = tempfile.mkstemp(
+                suffix='.tmp',
+                dir=self.blobhelper.temporaryDirectory()
+            )
+            self.temp_blobs_to_rm.append(name)
+            logger.log(
+                TRACE,
+                "Copying %s to temporary blob file %s for upload",
+                blobfile, name)
+
+            with os.fdopen(fd, 'wb') as target:
+                # If we don't get the length, ``copy_blob`` will.
+                old_pos = blobfile.tell()
+                blobfile.seek(0, 2)
+                length = blobfile.tell()
+                blobfile.seek(old_pos)
+
+                copy_blob(blobfile, target, length)
+                txn_data_size += length
+            blobfile.close()
+            self.restore.restoreBlob(oid, tid, data,
+                                     name, None, active_txn_meta)
+        else:
+            self.restore.restore(oid, tid, data,
+                                 '', None, active_txn_meta)
+
+        return txn_data_size
+
+
+class _HistoryPreservingCopier(_AbstractCopier):
+
+    def __init__(self, storage, blobhelper, tpc, restore):
+        super(_HistoryPreservingCopier, self).__init__(storage, blobhelper, tpc, restore)
+        self.storage_it = storage.iterator()
+
+    def _compute_total_count(self):
         try:
-            num_txns = len(other_it)
+            num_txns = len(self.storage_it)
             if num_txns == 0:
                 # Hmm, that shouldn't really be right, should it?
                 # Try the other path.
                 raise TypeError()
         except TypeError:
-            logger.debug("Iterator %s doesn't support len()", other_it)
+            logger.warning("Iterator %s doesn't support len(); counting manually", self.storage_it)
             num_txns = 0
-            for _ in other_it:
+            for _ in self.storage_it:
                 num_txns += 1
-            other_it.close()
-            other_it = other.iterator()
+            close(self.storage_it)
+            self.storage_it = self.storage.iterator()
 
-        return num_txns, other_it
+        return num_txns
+
+    def close(self):
+        close(self.storage_it)
+        self.storage_it = None
+        super(_HistoryPreservingCopier, self).close()
+
+    def copy(self, progress):
+        # type: (_ProgressLogger) -> None
+        for trans in self.storage_it:
+            begin = perf_counter()
+            num_txn_records, txn_data_size, num_blobs = self(trans)
+            now = perf_counter()
+            progress.copied(now, now - begin, trans, 1, num_txn_records, txn_data_size, num_blobs)
+
+    def __call__(self, trans):
+        # Originally adapted from ZODB.blob.BlobStorageMixin
+        tpc = self.tpc
+        num_txn_records = 0
+        txn_data_size = 0
+
+        tpc.tpc_begin(trans, trans.tid, trans.status)
+        for record in trans:
+            num_txn_records += 1
+            txn_data_size += self.restore_one(
+                trans,
+                record.oid,
+                record.tid,
+                record.data
+            )
+        tpc.tpc_vote(trans)
+        tpc.tpc_finish(trans)
+
+        num_blobs = self.clean_temp_blobs()
+
+        return num_txn_records, txn_data_size, num_blobs
+
+
+class _RecordIternextIterator(object):
+
+    __slots__ = (
+        'storage',
+        'cookie',
+    )
+
+    def __init__(self, storage):
+        self.storage = storage
+        self.cookie = self
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.cookie is None:
+            raise StopIteration
+
+        if self.cookie is self:
+            # First time in.
+            self.cookie = None
+        oid, tid, state, self.cookie = self.storage.record_iternext(self.cookie)
+        return oid, tid, state
+
+    next = __next__ # Py2
+
+
+class _HistoryFreeCopier(_AbstractCopier):
+
+    units = 'objects'
+
+    def _compute_total_count(self):
+        return len(self.storage)
+
+    def __iter__(self):
+        return _RecordIternextIterator(self.storage)
+
+    def copy(self, progress):
+        # type: (_ProgressLogger) -> None
+        trans_meta = None
+        count = 0
+        begin = perf_counter()
+        txn_data_size = 0
+        for oid, tid, state in self:
+            count += 1
+            if trans_meta is None:
+                trans_meta = TransactionMetaData()
+                trans_meta.tid = tid # For display
+                self.tpc.tpc_begin(trans_meta, tid)
+
+            txn_data_size += self.restore_one(
+                trans_meta,
+                oid,
+                tid,
+                state
+            )
+
+            if count % 100 == 0:
+                # TODO: Parameterize. Match with the logger,
+                # let it do the hard work. As it is, we just get the periodic debug
+                # logging every time.
+                now = perf_counter()
+                self.tpc.tpc_vote(trans_meta)
+                self.tpc.tpc_finish(trans_meta)
+                num_blobs = self.clean_temp_blobs()
+                progress.copied(now, now - begin, trans_meta, count, count,
+                                txn_data_size, num_blobs)
+
+                trans_meta = None
+                begin = now
+                count = 0
+                txn_data_size = 0
+
+        if trans_meta is not None:
+            # Finished iterating, still the remainder to commit.
+            now = perf_counter()
+            self.tpc.tpc_vote(trans_meta)
+            self.tpc.tpc_finish(trans_meta)
+            num_blobs = self.clean_temp_blobs()
+            progress.copied(now, now - begin, trans_meta, count, count,
+                            txn_data_size, num_blobs)
+
 
 
 class _ProgressLogger(object):
 
     # Time in seconds between major progress logging.
-    # (minor progress logging occurs every ``log_count`` commits)
+    # (minor progress logging occurs every ``minor_log_count`` commits)
     log_interval = 60
 
     # Number of transactions to copy before checking if we should perform a major
@@ -185,7 +384,12 @@ class _ProgressLogger(object):
             self.total_size = 0
 
         def display_at(self, now, total_num_txns, include_elapsed=False):
-            pct_complete = '%1.2f%%' % (self.txns_copied * 100.0 / total_num_txns)
+            pct_complete = '%1.2f%%' % ((
+                (self.txns_copied * 100.0 if total_num_txns else 1)
+                /
+                (total_num_txns or 1)
+            ))
+
             elapsed_total = now - self.begin_time
             if elapsed_total:
                 rate_mb = self.total_size / elapsed_total
@@ -204,7 +408,7 @@ class _ProgressLogger(object):
                 result += ' %4.1f minutes' % (elapsed_total / 60.0)
             return result
 
-    def __init__(self, num_txns, other_storage, copy):
+    def __init__(self, num_txns):
         self.num_txns = num_txns
         begin_time = perf_counter()
         self._entire_stats = self._IntervalStats(begin_time)
@@ -214,32 +418,24 @@ class _ProgressLogger(object):
         self.minor_log_at = begin_time + self.minor_log_interval
         self.debug_enabled = logger.isEnabledFor(logging.DEBUG)
 
-        self._other_storage = other_storage
-        self._copy = copy
-
     def display_at(self, now):
         return self._entire_stats.display_at(now, self.num_txns, True)
 
-    def __call__(self, trans):
-        begin_copy = perf_counter()
-        result = self._copy(self._other_storage, trans)
-        now = perf_counter()
-        self._copied(now, now - begin_copy, trans, result)
-
-    def _copied(self, now, copy_duration, trans, copy_result):
+    def copied(self, now, copy_duration, trans,
+               num_txns_copied,
+               num_txn_records, txn_byte_size, num_txn_blobs):
+        # type: (float, float, Any, Tuple[int, int, int, int])
         entire_stats = self._entire_stats
         interval_stats = self._interval_stats
 
-        entire_stats.txns_copied += 1
-        interval_stats.txns_copied += 1
+        entire_stats.txns_copied += num_txns_copied
+        interval_stats.txns_copied += num_txns_copied
         total_txns_copied = self._entire_stats.txns_copied
-        txn_byte_size = copy_result[1]
 
         entire_stats.total_size += txn_byte_size
         interval_stats.total_size += txn_byte_size
 
         if self.debug_enabled:
-            num_txn_records, txn_byte_size, _num_txn_blobs = copy_result
             if (total_txns_copied % self.minor_log_count == 0 and now >= self.minor_log_at) \
                or txn_byte_size >= self.minor_log_tx_size \
                or num_txn_records >= self.minor_log_tx_record_count \
@@ -247,7 +443,8 @@ class _ProgressLogger(object):
                 self.minor_log_at = now + self.minor_log_interval
                 logger.debug(
                     "Copied %s in %1.4fs",
-                    self.__transaction_display(trans, copy_result),
+                    self.__transaction_display(trans, num_txn_records,
+                                               txn_byte_size, num_txn_blobs),
                     copy_duration
                 )
 
@@ -255,12 +452,10 @@ class _ProgressLogger(object):
             self.log_at = now + self.log_interval
             self.__major_log(
                 now,
-                self.__transaction_display(trans, copy_result))
+                self.__transaction_display(trans, num_txn_records, txn_byte_size, num_txn_blobs))
             self._interval_stats = self._IntervalStats(now)
 
-
     def __major_log(self, now, transaction_display):
-
         logger.info(
             "Copied %s | %60s | (%s)",
             transaction_display,
@@ -268,8 +463,7 @@ class _ProgressLogger(object):
             self._entire_stats.display_at(now, self.num_txns, True)
         )
 
-    def __transaction_display(self, trans, copy_result):
-        num_txn_records, txn_byte_size, num_txn_blobs = copy_result
+    def __transaction_display(self, trans, num_txn_records, txn_byte_size, num_txn_blobs):
         return 'transaction %s <%4d records, %3d blobs, %9s>' % (
             readable_tid_repr(trans.tid),
             num_txn_records, num_txn_blobs, byte_display(txn_byte_size)

--- a/src/relstorage/storage/copy.py
+++ b/src/relstorage/storage/copy.py
@@ -291,7 +291,17 @@ class _RecordIternextIterator(object):
         if self.cookie is self:
             # First time in.
             self.cookie = None
-        oid, tid, state, self.cookie = self.storage.record_iternext(self.cookie)
+        try:
+            result = self.storage.record_iternext(self.cookie)
+        except ValueError:
+            # FileStorage can raise this if the underlying storage
+            # is completely empty.
+            # See https://github.com/zopefoundation/ZODB/issues/330
+            if self.cookie is None:
+                raise StopIteration
+            raise # pragma: no cover
+
+        oid, tid, state, self.cookie = result
         return oid, tid, state
 
     next = __next__ # Py2

--- a/src/relstorage/storage/tpc/restore.py
+++ b/src/relstorage/storage/tpc/restore.py
@@ -52,6 +52,7 @@ class Restore(object):
         'tpc_abort',
         'no_longer_stale',
         'shared_state',
+        'close',
     )
 
     def __init__(self, begin_state, committing_tid, status):

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -1474,22 +1474,27 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
     relstorage_name = 'destination'
     filestorage_file = None
 
+    # XXX: Needs tests for:
+    # - keep_history = False
+    # - verifying that the final serials match.
+
     def setUp(self):
         super(AbstractRSZodbConvertTests, self).setUp()
+
         cfg = """
         %%import relstorage
         %%import zc.zlibstorage
         <zlibstorage %s>
-        <filestorage>
-            path %s
-        </filestorage>
+          <filestorage>
+              path %s
+          </filestorage>
         </zlibstorage>
         <zlibstorage %s>
-        <relstorage>
-            %s
-            cache-prefix %s
-            cache-local-dir %s
-        </relstorage>
+          <relstorage>
+              %s
+              cache-prefix %s
+              cache-local-dir %s
+          </relstorage>
         </zlibstorage>
         """ % (
             self.filestorage_name,

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -1473,20 +1473,13 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
     keep_history = True
     filestorage_name = 'source'
     relstorage_name = 'destination'
-    filestorage_file = None
-
-    # XXX: Needs tests for:
-    # - keep_history = False
-    # - verifying that the final serials match.
 
     def setUp(self):
         super(AbstractRSZodbConvertTests, self).setUp()
         # Zap the storage
         self.make_storage(zap=True).close()
 
-    def make_storage(self, zap=True, **kw):
-        if kw:
-            raise TypeError("kwargs not supported")
+    def make_storage(self, zap=True): # pylint:disable=arguments-differ
         if self.relstorage_name == 'source':
             meth = self._create_src_storage
         else:
@@ -1547,28 +1540,17 @@ class AbstractRSDestHPZodbConvertTests(AbstractRSZodbConvertTests):
     keep_history = True
     zap_supported_by_dest = True
     dest_db_needs_closed_before_zodbconvert = False
-    @property
-    def filestorage_file(self):
-        return self.srcfile
 
 class AbstractRSDestHFZodbConvertTests(AbstractRSZodbConvertTests):
     keep_history = False
     zap_supported_by_dest = True
     dest_db_needs_closed_before_zodbconvert = False
 
-    @property
-    def filestorage_file(self):
-        return self.srcfile
-
 
 class AbstractRSSrcZodbConvertTests(AbstractRSZodbConvertTests):
     src_db_needs_closed_before_zodbconvert = False
     filestorage_name = 'destination'
     relstorage_name = 'source'
-
-    @property
-    def filestorage_file(self):
-        return self.destfile
 
 class AbstractIDBOptionsTest(unittest.TestCase):
 

--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -1539,6 +1539,10 @@ class AbstractRSZodbConvertTests(StorageCreatingMixin,
         self.assertIn('_crs_untransform_record_data', new_storage.base.__dict__)
         self.assertIn('_crs_transform_record_data', new_storage.base.__dict__)
 
+        self.assertEqual(new_storage.copyTransactionsFrom,
+                         new_storage.base.copyTransactionsFrom)
+
+
 class AbstractRSDestHPZodbConvertTests(AbstractRSZodbConvertTests):
     keep_history = True
     zap_supported_by_dest = True

--- a/src/relstorage/tests/test_zodbconvert.py
+++ b/src/relstorage/tests/test_zodbconvert.py
@@ -172,6 +172,21 @@ class AbstractZODBConvertBase(unittest.TestCase):
         db.close()
         self.assertRaises(SystemExit, main, ['', self.cfgfile])
 
+
+    # XXX: Add tests for:
+    # - copying a blob
+    # - verifying that a state becomes compressed or uncompressed.
+    #
+    # Also:
+    # - when the destination keeps history: Verifying iteration
+    #   of all the records, including transaction metadata
+    # - verifying multiple states are saved when both keeps history
+    # - If destination doesn't keep history, verifying only the most recent state# is saved.
+    #
+    # Some of that is probably handled in the History[Free|Preserving][From|To]FileStorageTest,
+
+
+
 class FSZODBConvertTests(AbstractZODBConvertBase):
 
     def setUp(self):

--- a/src/relstorage/tests/test_zodbconvert.py
+++ b/src/relstorage/tests/test_zodbconvert.py
@@ -383,15 +383,22 @@ class FSZODBConvertTests(AbstractZODBConvertBase):
         return cfgfile
 
     def tearDown(self):
+        super(FSZODBConvertTests, self).tearDown() # Close files first.
+        def _rm(fname, meth):
+            try:
+                meth(fname)
+            except OSError:
+                import traceback
+                print("Failed to remove", fname)
+                traceback.print_exc()
+
         for fname in self.destfile, self.srcfile, self.cfgfile:
             if os.path.exists(fname):
-                os.remove(fname)
+                _rm(fname, os.remove)
         self.destfile = self.srcfile = self.cfgfile = None
         for dname in self.src_blobs, self.dest_blobs:
             if os.path.exists(dname):
-                rmtree(dname)
-
-        super(FSZODBConvertTests, self).tearDown()
+                _rm(dname, rmtree)
 
     def _load_zconfig(self):
         from relstorage.zodbconvert import schema_xml

--- a/src/relstorage/tests/util.py
+++ b/src/relstorage/tests/util.py
@@ -363,11 +363,14 @@ class AbstractTestSuiteBuilder(object):
         return classes
 
     def _make_zodbconvert_classes(self):
-        from .reltestbase import AbstractRSDestZodbConvertTests
+        from .reltestbase import AbstractRSDestHPZodbConvertTests
+        from .reltestbase import AbstractRSDestHFZodbConvertTests
         from .reltestbase import AbstractRSSrcZodbConvertTests
 
         classes = []
-        for base in (AbstractRSSrcZodbConvertTests, AbstractRSDestZodbConvertTests):
+        for base in (AbstractRSSrcZodbConvertTests,
+                     AbstractRSDestHPZodbConvertTests,
+                     AbstractRSDestHFZodbConvertTests):
             klass = type(
                 self.__name__ + base.__name__[8:],
                 (self.use_adapter, base),

--- a/src/relstorage/zodbconvert.py
+++ b/src/relstorage/zodbconvert.py
@@ -74,7 +74,7 @@ class _DefaultStartStorageIteration(object):
         self.__source = source
         self.__start = start
 
-    def __len__(self):
+    def __len__(self): # pragma: no cover
         return len(self.__source)
 
     def __repr__(self):
@@ -159,7 +159,7 @@ def main(argv=None):
         log.info("Clearing old data...")
         if hasattr(destination, 'zap_all'):
             destination.zap_all()
-        else:
+        else: # pragma: no cover
             msg = ("Error: no API is known for clearing this type "
                    "of storage. Use another method.")
             cleanup_and_exit(msg)

--- a/src/relstorage/zodbconvert.py
+++ b/src/relstorage/zodbconvert.py
@@ -20,11 +20,9 @@ from __future__ import print_function
 import argparse
 import logging
 import sys
-import traceback
 from io import StringIO
 
 import ZConfig
-from zope.interface import providedBy
 from zope.interface import implementer
 from persistent.timestamp import TimeStamp
 
@@ -214,11 +212,7 @@ def main(argv=None):
 
         try:
             destination.copyTransactionsFrom(source)
-        except:
-            traceback.print_exc()
-            cleanup_and_exit(repr(sys.exc_info()[1]))
-            raise # Won't do anything, but keeps the linters happy
-        else:
+        finally:
             cleanup_and_exit()
 
 


### PR DESCRIPTION
By using `record_iternext` and only copying current objects. The big win comes from batching up the transaction commits. The speed increase seems to be at least 5x or more.

Disabled with the ``--incremental`` option of zodbconvert; see updated documenattion.

There are additional tests to make sure blobs are copied, and for the handling of storage wrappers like zc.zlibstorage.

Fixes #425 