### PR TITLE
Improve the way store connections are managed

### DIFF
--- a/.github/actions/config-cc/action.yml
+++ b/.github/actions/config-cc/action.yml
@@ -3,10 +3,11 @@ description: Configure ccache and CFLAGS
 runs:
   using: "composite"
   steps:
-    - name: Install ccache, configure CFLAGS
+    - name: Install ccache, configure CFLAGS, update brew
       shell: bash
       run: |
         if [ "`uname`" = "Darwin" ]; then
+          brew update
           brew install ccache
           echo CFLAGS=$CFLAGS -Wno-parentheses-equality -Wno-constant-logical-operand >> $GITHUB_ENV
           echo CXXFLAGS=$CXXFLAGS -Wno-parentheses-equality -Wno-constant-logical-operand >> $GITHUB_ENV

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@
 - RelStorage is now tested with PostgreSQL 13.1. See :issue:`427`.
 - RelStorage is now tested with PyMySQL 1.0. See :issue:`434`.
 - Update the bundled boost C++ library from 1.71 to 1.75.
+- Improve the way store connections are managed to make it less likely
+  a "stale" store connection that hasn't actually been checked for
+  liveness gets used.
 
 3.4.0 (2020-10-19)
 ==================

--- a/src/relstorage/adapters/oracle/scriptrunner.py
+++ b/src/relstorage/adapters/oracle/scriptrunner.py
@@ -175,7 +175,7 @@ class CXOracleScriptRunner(OracleScriptRunner):
             try:
                 cursor.execute(stmt + ' ', args)
                 rows = [
-                    tuple([self._read_lob(x) for x in row])
+                    tuple(self._read_lob(x) for x in row)
                     for row in cursor
                 ]
             finally:

--- a/src/relstorage/adapters/postgresql/drivers/psycopg2.py
+++ b/src/relstorage/adapters/postgresql/drivers/psycopg2.py
@@ -94,7 +94,7 @@ class Psycopg2Driver(MemoryViewBlobDriverMixin,
     def _get_extension_module(self):
         # Subclasses should override this method if they use a different
         # DB-API module.
-        from psycopg2 import extensions # pylint:disable=no-name-in-module
+        from psycopg2 import extensions # pylint:disable=no-name-in-module,import-error
         return extensions
 
     _WANT_WAIT_CALLBACK = False

--- a/src/relstorage/adapters/postgresql/drivers/psycopg2cffi.py
+++ b/src/relstorage/adapters/postgresql/drivers/psycopg2cffi.py
@@ -63,7 +63,7 @@ class Psycopg2cffiDriver(Psycopg2Driver):
         return mod.RSPsycopg2cffiConnection
 
     def _get_extension_module(self):
-        from psycopg2cffi import extensions # pylint:disable=no-name-in-module
+        from psycopg2cffi import extensions # pylint:disable=no-name-in-module,import-error
         return extensions
 
     # as of psycopg2cffi 2.8.1 connection has no '.info' attribute.

--- a/src/relstorage/storage/tpc/__init__.py
+++ b/src/relstorage/storage/tpc/__init__.py
@@ -126,8 +126,8 @@ class SharedTPCState(object):
                     store_connection,
                     self.prepared_txn)
 
-                if force:
-                    store_connection.drop()
+            if force:
+                store_connection.drop()
         finally:
             storage._store_connection_pool.replace(store_connection)
         return _CLOSED_CONNECTION

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -296,14 +296,18 @@ class MockOptions(Options):
 class MockConnectionManager(object):
 
     isolation_load = 'SERIALIZABLE'
+    clean_rollback = None
 
-    def __init__(self, driver=None):
+    def __init__(self, driver=None, clean_rollback=None):
         if driver is None:
             self.driver = MockDriver()
+        if clean_rollback is not None:
+            self.clean_rollback = clean_rollback
 
     def rollback_quietly(self, conn, cursor): # pylint:disable=unused-argument
         if hasattr(conn, 'rollback'):
             conn.rollback()
+        return self.clean_rollback
 
     rollback_store_quietly = rollback_quietly
 


### PR DESCRIPTION
This makes it much less likely a "stale" store connection that hasn't
actually been checked for liveness gets used. (Long story short, there
could be one more connection than RelStorage instance because of how
these were managed, and that connection would be rarely used, only
when the ZODB connection pool is overgrown. Closing or timing out ZODB
connections wouldn't actually remove that one.)

With psycopg2, restarting a store connection sometimes/often doesn't
have to actually communicate with the database if we know we're not in
a transaction. This could make a OperationalError pop up at an unusual
time.

This doesn't change that, but it does fix it so that resolving the
underlying issue doesn't leave a time bomb waiting.

Gardening changes
---------
* Run brew update before installing.
[Getting an error installing ccache](https://github.com/zodb/relstorage/runs/2326416136?check_suite_focus=true), thinking maybe the old version is gone now?
```
==> Downloading https://homebrew.bintray.com/bottles/ccache-4.2.1.catalina.bottle.tar.gz
curl: (22) The requested URL returned error: 403 Forbidden
Error: Failed to download resource ccache
Download failed: https://homebrew.bintray.com/bottles/ccache-4.2.1.catalina.bottle.tar.gz
Error: Process completed with exit code 1.

```

* Fix linting errors found by updated pylint/astroid.