### PR TITLE
Temporarily pin to pypy 2.7-7.3.3

### DIFF
--- a/.github/actions/config-cc/action.yml
+++ b/.github/actions/config-cc/action.yml
@@ -9,8 +9,8 @@ runs:
         if [ "`uname`" = "Darwin" ]; then
           brew update
           brew install ccache
-          echo CFLAGS=$CFLAGS -Wno-parentheses-equality -Wno-constant-logical-operand >> $GITHUB_ENV
-          echo CXXFLAGS=$CXXFLAGS -Wno-parentheses-equality -Wno-constant-logical-operand >> $GITHUB_ENV
+          echo CFLAGS=$CFLAGS -Wno-parentheses-equality -Wno-constant-logical-operand -stdlib=libc++ >> $GITHUB_ENV
+          echo CXXFLAGS=$CXXFLAGS -Wno-parentheses-equality -Wno-constant-logical-operand -stdlib=libc++ >> $GITHUB_ENV
           echo CC=ccache /usr/bin/clang >> $GITHUB_ENV
           echo CXX=ccache /usr/bin/clang++ >> $GITHUB_ENV
           echo LDCXXSHARED=ccache /usr/bin/clang -bundle -undefined dynamic_lookup >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, pypy-2.7, pypy-3.6, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, pypy-2.7-7.3.3, pypy-3.6, 3.6, 3.7, 3.8, 3.9]
         # ubuntu 18.04 ships with mysql 5.7; ubuntu 20.04 ships with
         # mysql 8.0
         os: [ubuntu-18.04, macos-latest]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -417,6 +417,8 @@ jobs:
           key: ${{ runner.os }}-pip3-${{ matrix.python-version }}
           restore-keys: |
             ${{ runner.os }}-pip3-
+      - name: Install ccache, configure CFLAGS (ubuntu)
+        uses: ./.github/actions/config-cc
 
       - name: Download RelStorage wheel
         uses: actions/download-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
         os: [ubuntu-18.04, macos-latest]
         exclude:
           - os: macos-latest
-            python-version: pypy-2.7
+            python-version: pypy-2.7-7.3.3
           - os: macos-latest
             python-version: pypy-3.6
           - os: macos-latest
@@ -183,13 +183,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, pypy-2.7, pypy-3.6, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, pypy-2.7-7.3.3, pypy-3.6, 3.6, 3.7, 3.8, 3.9]
         # ubuntu 18.04 ships with mysql 5.7; ubuntu 20.04 ships with
         # mysql 8.0
         os: [ubuntu-18.04, macos-latest]
         exclude:
           - os: macos-latest
-            python-version: pypy-2.7
+            python-version: pypy-2.7-7.3.3
           - os: macos-latest
             python-version: pypy-3.6
           - os: macos-latest
@@ -300,7 +300,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, 3.9, pypy-2.7, pypy-3.6]
+        python-version: [2.7, 3.9, pypy-2.7-7.3.3, pypy-3.6]
         os: [ubuntu-18.04]
     services:
       # Label used to access the service container


### PR DESCRIPTION
Because PyPy X.Y-7.3.4 breaks gevent. We already had an implicit pin for PyPy3 because we use PyPy3.6, which stopped with 7.3.3; pypy3.7 is the first 7.3.4.

See https://github.com/gevent/gevent/issues/1785 and https://foss.heptapod.net/pypy/pypy/-/issues/3441