### PR TITLE
Scale and name the new timing stats the same as perfmetrics.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@
 3.4.5 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Scale the new timing metrics introduced in 3.4.2 to milliseconds.
+  This matches the scale of other timing metrics produced
+  automatically by the use of ``perfmetrics`` in this package.
+  Similarly, append ``.t`` to the end of their names for the same
+  reason.
 
 
 3.4.4 (2021-04-23)

--- a/src/relstorage/storage/tpc/__init__.py
+++ b/src/relstorage/storage/tpc/__init__.py
@@ -220,8 +220,20 @@ class SharedTPCState(object):
             client.sendbuf(buf)
 
     def stat_timing(self, stat, value, rate=1):
+        """
+        Record a timing value.
+
+        For compatibility with the default settings of ``perfmetrics``,
+        the stat name should end in ``.t``
+
+        The *value* should be a floating point difference of seconds
+        (eg, ``time.time() - time.time()``). This will be converted to an integer
+        number of milliseconds (again for consistency with ``perfmetrics``).
+        """
         client = statsd_client()
         if client is not None:
+            # scale from float seconds to milliseconds
+            value = int(value * 1000.0)
             client.timing(stat, value, rate, self._statsd_buf)
 
     def stat_count(self, stat, value, rate=1):
@@ -346,7 +358,7 @@ class AbstractTPCStateDatabaseAvailable(object):
         resources = sorted(global_tx._resources, key=rm_key)
         return "transaction=%r resources=%r" % (global_tx, resources)
 
-    def tpc_finish(self, storage, transaction, f=None): # pylint:disable=unused-argument
+    def tpc_finish(self, storage, transaction, f=None, _time=None): # pylint:disable=unused-argument
         # For the sake of some ZODB tests, we need to implement this everywhere,
         # even if it's not actually usable, and the first thing it needs to
         # do is check the transaction.

--- a/src/relstorage/storage/tpc/tests/test_vote.py
+++ b/src/relstorage/storage/tpc/tests/test_vote.py
@@ -176,12 +176,18 @@ class _TPCFinishMixin(object):
         vote.lock_and_vote_times[0] = 1
         vote.lock_and_vote_times[1] = 1
 
-        vote.tpc_finish(vote.shared_state._storage, vote.transaction)
+        finish_times = [2, 3]
+        def time():
+            return finish_times.pop()
+
+        vote.tpc_finish(vote.shared_state._storage, vote.transaction, _time=time)
 
         assert_that(self.stat_client,
                     contains_exactly(
-                        is_timer('relstorage.storage.tpc_vote.objects_locked'),
-                        is_timer('relstorage.storage.tpc_vote.between_vote_and_finish')
+                        # 2 - 1 as ms = 1000
+                        is_timer('relstorage.storage.tpc_vote.objects_locked.t', '1000'),
+                        # 3 - 1 as ms = 2000
+                        is_timer('relstorage.storage.tpc_vote.between_vote_and_finish.t', '2000')
                     ))
 
 


### PR DESCRIPTION
Unfortunately, GHA's mac runners are still having issues, which actually prevents any test from running on them (fortunately the manylinux wheels still build). We'll have to rely on my local testing and Appveyor.