### PR TITLE
Reverse the order of locking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,15 @@
   rolled back in Python. Previously, shared locks could be held during
   this process, preventing other transactions from moving forward.
 
+- Take exclusive locks first, and then shared locks in NOWAIT mode.
+  This reverses :pr:`317`, but it eliminates the requirement that the
+  database server finds and breaks deadlocks (by eliminating
+  deadlocks). Deadlocks could never be resolved without retrying the
+  entire transaction, and which transaction got killed was unknowable.
+  Provisions are made to keep fast detection of ``readCurrent``
+  conflicts. Benchmarks with zodbshootout find no substantial
+  differences.
+
 3.4.5 (2021-04-23)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@
 
 - Fix the logging of some environment variables RelStorage uses.
 
+- If there is a read conflict error, PostgreSQL no longer holds any
+  database locks while the error is raised and the transaction is
+  rolled back in Python. Previously, shared locks could be held during
+  this process, preventing other transactions from moving forward.
 
 3.4.5 (2021-04-23)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,7 @@
   entire transaction, and which transaction got killed was unknowable.
   Provisions are made to keep fast detection of ``readCurrent``
   conflicts. Benchmarks with zodbshootout find no substantial
-  differences.
+  differences. See :issue:`469`.
 
 3.4.5 (2021-04-23)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -260,9 +260,9 @@ setup(
             # get Windows.
             'pg8000 >= 1.11.0 ; python_version == "2.7" or platform_python_implementation == "PyPy"',
             # CFFI, runs on all implementations.
-            # We get coverage from 3.5 on Travis and verification it works on Windows from Travis.
+            # We get coverage from 3.x on Travis and verification it works on Windows from Travis.
             # We get 2.7 testing from PyPy on Travis.
-            'psycopg2cffi >= 2.7.4; python_version == "3.5" or platform_python_implementation == "PyPy"',
+            'psycopg2cffi >= 2.7.4; python_version == "3.6" or platform_python_implementation == "PyPy"',
             # Psycopg2 on all CPython, it's the default
             'psycopg2 >= 2.8.3; platform_python_implementation == "CPython"',
         ],

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -217,6 +217,7 @@ class AbstractAdapter(DatabaseHelpersMixin):
             # We go ahead and compare the readCurrent TIDs here, so
             # that we don't have to make the call to detect conflicts
             # or even lock rows if there are readCurrent violations.
+            # Recall this function is called twice.
             for oid_int, expect_tid_int in read_current_oids.items():
                 actual_tid_int = current.get(oid_int, 0)
                 if actual_tid_int != expect_tid_int:
@@ -225,13 +226,11 @@ class AbstractAdapter(DatabaseHelpersMixin):
                         serials=(int64_to_8bytes(actual_tid_int),
                                  int64_to_8bytes(expect_tid_int)))
 
-        conflicts = self.mover.detect_conflict(cursor)
-
         self.locker.lock_current_objects(
             cursor, read_current_oid_ints,
             self.force_lock_readCurrent_for_share_blocking,
             after_lock_share)
-
+        conflicts = self.mover.detect_conflict(cursor)
         return conflicts
 
     #: Subclasses that have the ability to implement

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -38,7 +38,7 @@ from ..options import Options
 from ._util import DatabaseHelpersMixin
 from .drivers import _select_driver
 from .interfaces import UnableToLockRowsToModifyError
-from .interfaces import UnableToLockRowsToReadCurrentError
+from .interfaces import UnableToLockRowsDeadlockError
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -192,19 +192,16 @@ class AbstractAdapter(DatabaseHelpersMixin):
             # various concurrency situations.
             return self._composed_lock_objects_and_detect_conflicts(cursor,
                                                                     read_current_oids)
-        begin = time.time()
         try:
             return self._best_lock_objects_and_detect_conflicts(cursor, read_current_oids)
         except self.locker.lock_exceptions as ex:
-            # Heuristic to guess. If the stored proc or stored proc runner can do better,
-            # they should.
-            elapsed = time.time() - begin
+            # Heuristic to guess.
+            # XXX: we should do a lot better. We used to be time based, but since we take
+            # exclusive locks first, that's now useless.
             kind = UnableToLockRowsToModifyError
-            if read_current_oids and elapsed < self.locker.commit_lock_timeout:
-                kind = UnableToLockRowsToReadCurrentError
-            if 'deadlock' in str(ex):
-                # With postgresql asd psycopg2, we can use the pgcode to get this.
-                kind = UnableToLockRowsToModifyError
+            if self.driver.exception_is_deadlock(ex):
+                kind = UnableToLockRowsDeadlockError
+
             del ex
             self.locker.reraise_commit_lock_error(
                 cursor,
@@ -228,12 +225,13 @@ class AbstractAdapter(DatabaseHelpersMixin):
                         serials=(int64_to_8bytes(actual_tid_int),
                                  int64_to_8bytes(expect_tid_int)))
 
+        conflicts = self.mover.detect_conflict(cursor)
+
         self.locker.lock_current_objects(
             cursor, read_current_oid_ints,
             self.force_lock_readCurrent_for_share_blocking,
             after_lock_share)
 
-        conflicts = self.mover.detect_conflict(cursor)
         return conflicts
 
     #: Subclasses that have the ability to implement

--- a/src/relstorage/adapters/drivers.py
+++ b/src/relstorage/adapters/drivers.py
@@ -84,6 +84,7 @@ class AbstractModuleDriver(object):
     - ``__name__`` property
     - Implementation of ``get_driver_module``; this should import the
       module at runtime.
+    - Implementation of ``exception_is_deadlock``
     """
 
     #: The name of the DB-API module to import.
@@ -293,6 +294,11 @@ class AbstractModuleDriver(object):
 
     def exit_critical_phase(self, connection, cursor):
         "Default implementation; does nothing."
+
+    def exception_is_deadlock(self, exc):
+        __traceback_info__ = dir(exc), exc
+        raise NotImplementedError(type(self))
+
 
 class MemoryViewBlobDriverMixin(object):
     # psycopg2 is smart enough to return memoryview or buffer on

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -1631,6 +1631,26 @@ class IRelStorageAdapter(Interface):
         immediately able to determine that 2 has been modified and
         quickly raise an exception without holding any other locks.
 
+        However, this does introduce a problem of its own: The deadlocks
+        we talked about above are common in this scenario. While that's
+        fine in-and-of-itself, it does mean that we're possibly missing out
+        on the chance to catch and resolve conflicts (because the deadlock
+        errors immediately abort the transaction). Since most databases
+        support NOWAI or a good approximation of it, we can avoid the deadlocks
+        by taking the exclusive locks first, and then taking share locks NOWAIT
+        (taking the share lock NOWAIT will immediately abort if some other transaction
+        is already holding an exclusive lock; the reverse is not true).
+
+        But what about fast notification of transactions that
+        are going to have to abort anyway? For databases that implement all of this
+        in a single step in the database, we can first do a no-lock check
+        of ``readCurrent`` items, and if anything has changed, we can
+        bail immediately. It's only in the case that some other transaction is
+        actually modifying an object that we want to ``readCurrent`` on, *and*
+        some other transaction is modifying an object that we also want to modify
+        (so we have to wait on an exclusive lock) that we wind up waiting
+        longer than we did before to abort a doomed transaction.
+
         :param cursor: The store cursor.
         :param read_current_oids: A mapping from oid integer to tid
             integer that the transaction expects.
@@ -1657,6 +1677,12 @@ class UnableToAcquireCommitLockError(StorageError, UnableToAcquireLockError):
     However, for historical reasons, this exception is not a ``TransientError``.
     """
 
+
+class UnableToLockRowsDeadlockError(ConflictError, UnableToAcquireLockError):
+    """
+    The root class for a lock error because there was a deadlock.
+    """
+
 # TransientError -> ConflictError -> ReadConflictError
 
 class UnableToLockRowsToModifyError(ConflictError, UnableToAcquireLockError):
@@ -1671,8 +1697,11 @@ class UnableToLockRowsToModifyError(ConflictError, UnableToAcquireLockError):
     This is a type of ``ConflictError``, which is a transient error.
     """
 
-class UnableToLockRowsDeadlockError(UnableToLockRowsToModifyError):
+class UnableToLockRowsToModifyDeadlockError(UnableToLockRowsToModifyError,
+                                            UnableToLockRowsDeadlockError):
     pass
+
+UnableToLockRowsToModifyError.DEADLOCK_VARIANT = UnableToLockRowsToModifyDeadlockError
 
 class UnableToLockRowsToReadCurrentError(ReadConflictError, UnableToAcquireLockError):
     """
@@ -1685,6 +1714,12 @@ class UnableToLockRowsToReadCurrentError(ReadConflictError, UnableToAcquireLockE
 
     This is a type of ``ReadConflictError``, which is a transient error.
     """
+
+class UnableToLockRowsToReadCurrentDeadlockError(UnableToLockRowsToReadCurrentError,
+                                                 UnableToLockRowsDeadlockError):
+    pass
+
+UnableToLockRowsToReadCurrentError.DEADLOCK_VARIANT = UnableToLockRowsToReadCurrentDeadlockError
 
 class UnableToAcquirePackUndoLockError(StorageError, UnableToAcquireLockError):
     """A pack or undo operation is in progress."""

--- a/src/relstorage/adapters/interfaces.py
+++ b/src/relstorage/adapters/interfaces.py
@@ -197,6 +197,14 @@ class IDBDriver(Interface):
     def exit_critical_phase(connection, cursor):
         "If currently in a critical phase, de-escalate."
 
+    def exception_is_deadlock(exc):
+        """
+        Given an exception object, return True if it represents a deadlock
+        in the database.
+
+        The exception need not be an exception produced by the driver.
+        """
+
 class IDBDriverSupportsCritical(IDBDriver):
     """
     A marker for database drivers that support
@@ -1526,6 +1534,9 @@ class IRelStorageAdapter(Interface):
         deadlock detection, and starting with MySQL 8, it supports
         ``NOWAIT``.
 
+        In both implementations, though, deadlocks lead to annoying
+        database server error logs, so they should be avoided.
+
         .. rubric:: Lock Order
 
         The original strategy was to first take exclusive locks of
@@ -1659,6 +1670,9 @@ class UnableToLockRowsToModifyError(ConflictError, UnableToAcquireLockError):
 
     This is a type of ``ConflictError``, which is a transient error.
     """
+
+class UnableToLockRowsDeadlockError(UnableToLockRowsToModifyError):
+    pass
 
 class UnableToLockRowsToReadCurrentError(ReadConflictError, UnableToAcquireLockError):
     """

--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -255,9 +255,11 @@ class AbstractLocker(DatabaseHelpersMixin,
             sys.exc_info()[1],
             '\n' + debug_info if debug_info else '(No debug info.)'
         )
+        val = kind(message)
+        val.__relstorage_cause__ = sys.exc_info()[1]
         six.reraise(
             kind,
-            kind(message),
+            val,
             sys.exc_info()[2])
 
     # MySQL allows aggregates in the top level to use FOR UPDATE,

--- a/src/relstorage/adapters/mysql/adapter.py
+++ b/src/relstorage/adapters/mysql/adapter.py
@@ -325,7 +325,7 @@ class MySQLAdapter(AbstractAdapter):
             # On MySQL 5.7, the time-based mechanism to determine that
             # we failed to take NOWAIT shared locks is not reliable
             # when the commit lock timeout is very small (close to 1),
-            # because it can take several seconds for the procedure te
+            # because it can take several seconds for the procedure to
             # error out. Thus we provide a specific error message that
             # we key off. (We don't change errno or state or anything
             # like that in case anybody introspects that stuff.)

--- a/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
+++ b/src/relstorage/adapters/mysql/drivers/mysqlconnector.py
@@ -64,6 +64,8 @@ class PyMySQLConnectorDriver(AbstractMySQLDriver):
         if self.Binary is str:
             self.Binary = bytearray
 
+        self.mysql_deadlock_exc = self.driver_module.DatabaseError
+
         if PYPY:
             # Patch to work around JIT bug found in (at least) 7.1.1
             # https://bitbucket.org/pypy/pypy/issues/3014/jit-issue-inlining-structunpack-hh
@@ -211,6 +213,7 @@ class PyMySQLConnectorDriver(AbstractMySQLDriver):
     def callproc_no_result(self, cursor, proc, args=()):
         # Again, weird. The call's empty result set seems to be consumed.
         cursor.execute("CALL " + proc, args)
+
 
 class CMySQLConnectorDriver(PyMySQLConnectorDriver):
     __name__ = 'C ' + _base_name

--- a/src/relstorage/adapters/oracle/drivers.py
+++ b/src/relstorage/adapters/oracle/drivers.py
@@ -19,6 +19,7 @@ Oracle IDBDriver implementations.
 from __future__ import absolute_import
 from __future__ import print_function
 
+import warnings
 
 from zope.interface import implementer
 
@@ -59,6 +60,9 @@ class cx_OracleDriver(AbstractModuleDriver):
         self.BINARY = cx_Oracle.BINARY
         self.STRING = cx_Oracle.STRING
         self.version = cx_Oracle.version
+
+    def exception_is_deadlock(self, exc):
+        warnings.warn("exception_is_deadlock() unimplemented for cx_Oracle")
 
 
 implement_db_driver_options(

--- a/src/relstorage/adapters/postgresql/drivers/pg8000.py
+++ b/src/relstorage/adapters/postgresql/drivers/pg8000.py
@@ -244,3 +244,6 @@ class PG8000Driver(AbstractPostgreSQLDriver):
         if conn.readonly:
             return False
         return conn.in_transaction
+
+    def _get_exception_pgcode(self, exc):
+        return exc.args[0]['C']

--- a/src/relstorage/adapters/postgresql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/postgresql/procs/lock_objects_and_detect_conflicts.sql
@@ -7,14 +7,89 @@ AS
 $$
 BEGIN
 
+  -- Order matters here.
+  --
+  -- We want to first take exclusive locks for the modified objects
+  -- (and wait if needed) and then take NOWAIT shared locks for the
+  -- readCurrent objects.
+  --
+  -- If we do it the other way around (RelStorage < 3.5), we can
+  -- *easily* deadlock in lock order on the server, which would result
+  -- in us raising ``UnableToLockRows...`` exception, which
+  -- immediately aborts the transaction and doesn't allow for any
+  -- conflict resolution.
+  --
+  -- However, taking exclusive first and only then shared NOWAIT
+  -- doesn't deadlock (I think), certainly not as easily. This means a
+  -- transaction might have to wait, or timeout, but if it gets
+  -- through, it has a chance to resolve conflicts and commit.
+  --
+  -- One of the appealing properties of taking the shared first,
+  -- though, is that if we *are* doomed to failure (because of a
+  -- ReadCurrent error), we can know it immediately. We can still make
+  -- that check before we try to wait for exclusive locks, but since
+  -- we can't actually lock those rows yet, we need to perform the
+  -- check *again*, after taking the exclusive locks (and this time
+  -- lock them to be sure they don't change).
+
   -- lock in share should NOWAIT
+  IF read_current_oids IS NOT NULL THEN
+    -- A pre-check: If we can detect a single readCurrent conflict,
+    -- do so, send it to the server where it will raise VoteConflictError,
+    -- and just bail. We could make this raise an exception and abort the
+    -- transaction, but we're not holding any locks here, and the error message
+    -- from VoteConflictError is more informative.
+    RETURN QUERY -- This just adds to the result table; a final bare ``RETURN`` actually ends execution
+      SELECT {CURRENT_OBJECT}.zoid, {CURRENT_OBJECT}.tid, NULL::BIGINT, NULL::BYTEA
+      FROM {CURRENT_OBJECT}
+      INNER JOIN unnest(read_current_oids, read_current_tids) t(zoid, tid)
+          USING (zoid)
+      WHERE {CURRENT_OBJECT}.tid <> t.tid
+      LIMIT 1;
+    IF FOUND THEN
+      RETURN;
+    END IF;
+  END IF;
+
+
+  -- Unlike MySQL, we can simply do the SELECT (with PERFORM) for its
+  -- side effects to lock the rows.
+  -- This one will block. (We set the PG configuration variable ``lock_timeout``
+  -- from the ``commit-lock-timeout`` configuration variable to determine how long.)
+
+  -- A note on the query: PostgreSQL will typcially choose a
+  -- sequential scan on the temp_store table and do a nested loop join
+  -- against the object_state_pkey index culminating in a sort after
+  -- the join. This is the same whether we write a WHERE IN (SELECT)
+  -- or a INNER JOIN. (This is without a WHERE prev_tid <> 0 clause.)
+
+  -- That changes substantially if we ANALYZE the temp table;
+  -- depending on the data, it might do an MERGE join with an index
+  -- scan on temp_store_pkey (lots of data) or it might do a
+  -- sequential scan and sort in memory before doing a MERGE join
+  -- (little data). (Again without the WHERE prev_tid clause.)
+
+  -- However, ANALYZE takes time, often more time than it takes to actually
+  -- do the nested loop join.
+
+  -- If we add a WHERE prev_tid clause, even if we ANALYZE, it will
+  -- choose a sequential scan on temp_store with a FILTER. Given that most
+  -- transactions contain relatively few objects, and that it would do a
+  -- sequential scan /anyway/, this is fine, and worth it to avoid probing
+  -- the main index for new objects.
+
+  -- TODO: Is it worth doing partitioning and putting prev_tid = 0 in their own
+  -- partition? prev_tid isn't the primary key, zoid is, though, and range
+  -- partitioning has to include the primary key when there is one.
+
+  PERFORM {CURRENT_OBJECT}.zoid
+  FROM {CURRENT_OBJECT}
+  INNER JOIN temp_store USING(zoid)
+  WHERE temp_store.prev_tid <> 0
+  ORDER BY {CURRENT_OBJECT}.zoid
+  FOR UPDATE OF {CURRENT_OBJECT};
 
   IF read_current_oids IS NOT NULL THEN
-    -- readCurrent conflicts first so we don't waste time resolving
-    -- state conflicts if we are going to fail the transaction. We only need to return
-    -- the first conflict; it will immediately raise an exception.
-    -- Up through PG12, RETURN QUERY does *NOT* stream to the client, it buffers
-    -- everything. So we must manually break and not do the locking.
 
     -- Doing this in a single query takes some effort to make sure
     -- that the required rows all get locked. The optimizer is smart
@@ -53,46 +128,13 @@ BEGIN
       FROM locked WHERE locked.tid <> locked.desired
       LIMIT 1;
     IF FOUND THEN
-      RETURN;
+      -- We're holding exclusive locks here, so abort the transaction
+      -- and release them; don't wait for Python to do it.
+      RAISE EXCEPTION USING ERRCODE = 'lock_not_available'
+            HINT = 'readCurrent';
     END IF;
   END IF;
 
-  -- Unlike MySQL, we can simply do the SELECT (with PERFORM) for its
-  -- side effects to lock the rows.
-  -- This one will block. (We set the PG configuration variable ``lock_timeout``
-  -- from the ``commit-lock-timeout`` configuration variable to determine how long.)
-
-  -- A note on the query: PostgreSQL will typcially choose a
-  -- sequential scan on the temp_store table and do a nested loop join
-  -- against the object_state_pkey index culminating in a sort after
-  -- the join. This is the same whether we write a WHERE IN (SELECT)
-  -- or a INNER JOIN. (This is without a WHERE prev_tid <> 0 clause.)
-
-  -- That changes substantially if we ANALYZE the temp table;
-  -- depending on the data, it might do an MERGE join with an index
-  -- scan on temp_store_pkey (lots of data) or it might do a
-  -- sequential scan and sort in memory before doing a MERGE join
-  -- (little data). (Again without the WHERE prev_tid clause.)
-
-  -- However, ANALYZE takes time, often more time than it takes to actually
-  -- do the nested loop join.
-
-  -- If we add a WHERE prev_tid clause, even if we ANALYZE, it will
-  -- choose a sequential scan on temp_store with a FILTER. Given that most
-  -- transactions contain relatively few objects, and that it would do a
-  -- sequential scan /anyway/, this is fine, and worth it to avoid probing
-  -- the main index for new objects.
-
-  -- TODO: Is it worth doing partitioning and putting prev_tid = 0 in their own
-  -- partition? prev_tid isn't the primary key, zoid is, though, and range
-  -- partitioning has to include the primary key when there is one.
-
-  PERFORM {CURRENT_OBJECT}.zoid
-  FROM {CURRENT_OBJECT}
-  INNER JOIN temp_store USING (zoid)
-  WHERE temp_store.prev_tid <> 0
-  ORDER BY {CURRENT_OBJECT}.zoid
-  FOR UPDATE OF {CURRENT_OBJECT};
 
   RETURN QUERY
   SELECT cur.zoid, cur.tid,

--- a/src/relstorage/adapters/postgresql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/postgresql/procs/lock_objects_and_detect_conflicts.sql
@@ -127,6 +127,8 @@ BEGIN
       SELECT locked.zoid, locked.tid, NULL::BIGINT, NULL::BYTEA
       FROM locked WHERE locked.tid <> locked.desired
       LIMIT 1;
+    -- If that failed to get a lock because it is being modified by another transaction,
+    -- it raised an exception.
     IF FOUND THEN
       -- We're holding exclusive locks here, so abort the transaction
       -- and release them; don't wait for Python to do it.

--- a/src/relstorage/adapters/sqlite/drivers.py
+++ b/src/relstorage/adapters/sqlite/drivers.py
@@ -571,6 +571,9 @@ class Sqlite3Driver(MemoryViewBlobDriverMixin,
             isolation_level=isolation_level
         )
 
+    def exception_is_deadlock(self, exc):
+        # Not possible in sqlite, only one writer
+        return False
 
 
 

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -423,7 +423,7 @@ class MockDriver(object):
         if cursor is not None:
             cursor.fetchall()
 
-    def exception_is_deadlock(self, exc):
+    def exception_is_deadlock(self, exc): # pylint:disable=unused-argument
         return None
 
 class MockObjectMover(object):

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -423,6 +423,9 @@ class MockDriver(object):
         if cursor is not None:
             cursor.fetchall()
 
+    def exception_is_deadlock(self, exc):
+        return None
+
 class MockObjectMover(object):
     def __init__(self):
         self.data = {}  # {oid_int: (state, tid_int)}

--- a/src/relstorage/tests/__init__.py
+++ b/src/relstorage/tests/__init__.py
@@ -136,6 +136,13 @@ class TestCase(unittest.TestCase):
         self.assertEqual(len(container), length,
                          '%s -- %s' % (msg, container) if msg else container)
 
+    def assertExceptionNotCausedByDeadlock(self, exc, storage):
+        cause = exc
+        while cause is not None:
+            if storage._adapter.driver.exception_is_deadlock(cause):
+                raise AssertionError("Exception was a deadlock.", exc)
+            cause = getattr(cause, '__relstorage_cause__', None)
+
 def skipIfNoConcurrentWriters(func):
     # Skip the test if only one writer is allowed at a time.
     # e.g., sqlite


### PR DESCRIPTION
Fixes #469.

Also explicitly distinguishes exceptions that are caused by deadlocks (in PostgreSQL and MySQL); those shouldn't be happening anymore after this.

PostgreSQL goes from heuristic to deterministic about which lock error it raises (and is always sure to unlock rows if there is a share lock conflict).

/cc @jzuech3 @cutz 