### PR TITLE
Revert #469 and return to taking shared locks first

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 3.5.0a2 (unreleased)
 ====================
 
-- Nothing changed yet.
+- Revert :issue:`469` and return to taking shared locks before
+  exclusive locks. Testing in a large, busy application indicated that
+  performance was overall slightly worse this way.
 
 
 3.5.0a1 (2021-05-17)

--- a/src/relstorage/adapters/adapter.py
+++ b/src/relstorage/adapters/adapter.py
@@ -217,7 +217,6 @@ class AbstractAdapter(DatabaseHelpersMixin):
             # We go ahead and compare the readCurrent TIDs here, so
             # that we don't have to make the call to detect conflicts
             # or even lock rows if there are readCurrent violations.
-            # Recall this function is called twice.
             for oid_int, expect_tid_int in read_current_oids.items():
                 actual_tid_int = current.get(oid_int, 0)
                 if actual_tid_int != expect_tid_int:

--- a/src/relstorage/adapters/locker.py
+++ b/src/relstorage/adapters/locker.py
@@ -183,21 +183,16 @@ class AbstractLocker(DatabaseHelpersMixin,
         # locked when they are returned by the cursor, so we must
         # consume all the rows.
 
-        # Lock order is explained in IRelStorageAdapter.lock_objects_and_detect_conflicts.
-
-        after_lock_share() # Call once for a quick check
+        # Lock rows we need shared access to, typically without blocking.
+        if read_current_oid_ints:
+            self._lock_readCurrent_oids_for_share(cursor, read_current_oid_ints,
+                                                  shared_locks_block)
+            after_lock_share()
 
         # Lock the rows we need exclusive access to.
         # This will block for up to ``commit_lock_timeout``,
         # possibly * N
         self._lock_rows_being_modified(cursor)
-
-        # Next lock rows we need shared access to, typically without blocking.
-        if read_current_oid_ints:
-            self._lock_readCurrent_oids_for_share(cursor, read_current_oid_ints,
-                                                  shared_locks_block)
-            after_lock_share() # call again to verify
-
 
     def _lock_readCurrent_oids_for_share(self, cursor, current_oids, shared_locks_block):
         _, table = self._get_current_objects_query

--- a/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
+++ b/src/relstorage/adapters/mysql/procs/lock_objects_and_detect_conflicts.sql
@@ -82,40 +82,6 @@ label_proc:BEGIN
       SET i = i + 1;
     END WHILE;
 
-
-    -- Now return any such rows that we locked
-    -- that are in conflict.
-    -- No point doing any more work taking exclusive locks, etc,
-    -- because we will immediately abort, but we must be careful not to return
-    -- an extra result set that's empty: that intereferes with our socket IO
-    -- waiting for query results.
-    SELECT zoid, {CURRENT_OBJECT}.tid
-    INTO con_oid, con_tid
-    FROM {CURRENT_OBJECT}
-    INNER JOIN temp_read_current USING (zoid)
-    WHERE temp_read_current.tid <> {CURRENT_OBJECT}.tid
-    LIMIT 1;
-
-    IF con_oid IS NOT NULL THEN
-      SELECT con_oid, con_tid, NULL as prev_tid, NULL as state;
-      ROLLBACK; -- release locks.
-      LEAVE label_proc; -- return
-    END IF;
-
-  END IF;
-
-
-  INSERT INTO temp_locked_zoid
-  SELECT o.zoid
-  FROM {CURRENT_OBJECT} o FORCE INDEX (PRIMARY)
-  INNER JOIN temp_store t FORCE INDEX (PRIMARY)
-      ON o.zoid = t.zoid
-  WHERE t.prev_tid <> 0
-  ORDER BY t.zoid
-  FOR UPDATE;
-
-  IF read_current_oids_tids IS NOT NULL THEN
-
     -- The timeout only goes to 1; this procedure seems to always take roughtly 2s
     -- to actually detect a lock timeout problem, however.
     -- TODO: Can we apply the MAX_EXECUTION_TIME() optimizer hint?
@@ -158,6 +124,18 @@ label_proc:BEGIN
     END IF;
 
   END IF;
+
+
+  INSERT INTO temp_locked_zoid
+  SELECT o.zoid
+  FROM {CURRENT_OBJECT} o FORCE INDEX (PRIMARY)
+  INNER JOIN temp_store t FORCE INDEX (PRIMARY)
+      ON o.zoid = t.zoid
+  WHERE t.prev_tid <> 0
+  ORDER BY t.zoid
+  FOR UPDATE;
+
+
 
   SELECT cur.zoid, cur.tid, temp_store.prev_tid, {OBJECT_STATE_NAME}.state
   FROM {CURRENT_OBJECT} cur

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -62,7 +62,7 @@ class PostgreSQLLocker(AbstractLocker):
         exc_str = str(exc).lower()
         if 'for update' in exc_str:
             kind = UnableToLockRowsToModifyError
-        elif 'return query' in exc_str or 'readCurrent' in exc_str:
+        elif 'return query' in exc_str or 'readcurrent' in exc_str:
             kind = UnableToLockRowsToReadCurrentError
         return kind
 


### PR DESCRIPTION
Stress testing a large busy Zope application indicated that performance did not improve and was actually slightly worse this way.

The following is part of an internal discussion on why that could have been.

> In the test run, there were only 8 UnableToLockRowsToModifyError recorded as triggering retries, vs 66 UnableToLockRowsToReadCurrentError. In at least one case, a transaction got *both*, first Modify then ReadCurrent on the retry.

> In the other thread about BTree sizes, we ran through an analysis of all the reported ReadCurrent errors and came to the conclusion that they're *all* due to modifications to the BTrees involved in the IntId utility.

> The hypothesis goes that many transactions wind up waiting on an exclusive lock for one of those objects, and only after waiting for some period do they discover the ReadCurrent failure and doom the transaction.

> If they check for the ReadCurrent failure first, and either find one or deadlock, they doom the transaction quickly without waiting and hopefully a retry succeeds.

> I think what we didn't pay close enough attention to in the original discussion about changing the lock order is that any time there was a deadlock, it always really represented a doomed transaction --- there would be no way to recover without retrying *anyway*. The hope was that (1) instead of letting the RDBMS kill an arbitrary transaction, we would be in control of which transaction died, thus letting the one with the most invested already proceed and commit; and (2) maybe we could do more conflict resolution. (1) didn't pan out because it turns out that if two or more processes are sitting waiting on locks and the RDBMS kills one of them, neither one really had that much of an advantage over the other --- they were basically both in the same place. (2) didn't pan out because one of the transactions was doomed anyway.

This also fixes two bugs in the PostgreSQL implementation:

- Selecting the right kind of lock error
- Raising an exception in the stored proc had  a Syntax error.