### PR TITLE
Check cache for read current

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@
 
 - Revert :issue:`469` and return to taking shared locks before
   exclusive locks. Testing in a large, busy application indicated that
-  performance was overall slightly worse this way.
+  performance was overall slightly worse this way. See :pr:`471`.
 
 
 3.5.0a1 (2021-05-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@
   This more closely matches what ``FileStorage`` does and can help
   avoid some unnecessary work.
 
+- Fix the speed of getting the approximate number of objects in a
+  storage by using ``len(storage)`` on PostgreSQL. This was a
+  regression after 3.0a13.
+
 3.5.0a1 (2021-05-17)
 ====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,16 @@
   exclusive locks. Testing in a large, busy application indicated that
   performance was overall slightly worse this way. See :pr:`471`.
 
+- Use the cache to cheaply check if a ``readCurrent()``  violation
+  will take place during an early part of two-phase commit, instead of
+  waiting until ``tpc_vote`` when we've sent data to the database. If
+  the cache can prove that there is a newer version of an object
+  stored, the conflict error will be raised during ``commit``; if the
+  cache can't prove it, the error will still be raised during
+  ``tpc_vote``.
+
+  This more closely matches what ``FileStorage`` does and can help
+  avoid some unnecessary work.
 
 3.5.0a1 (2021-05-17)
 ====================

--- a/src/relstorage/adapters/postgresql/stats.py
+++ b/src/relstorage/adapters/postgresql/stats.py
@@ -34,6 +34,8 @@ class PostgreSQLStats(AbstractStats):
         "SELECT reltuples::bigint FROM pg_class WHERE relname = 'object_state'"
     )
 
+    _get_object_count_query = query_property('_get_object_count')
+
     _update_object_count_queries = (
         # Only on PG11 can you list more than one table.
         'ANALYZE current_object',
@@ -41,6 +43,15 @@ class PostgreSQLStats(AbstractStats):
     )
 
     _update_object_count_query = query_property('_update_object_count')
+
+    def get_object_count(self):
+        """Returns the approximate number of objects in the database"""
+        conn, cursor = self.connmanager.open_for_load()
+        try:
+            cursor.execute(self._get_object_count_query)
+            return cursor.fetchone()[0]
+        finally:
+            self.connmanager.close(conn, cursor)
 
     def get_db_size(self):
         """Returns the approximate size of the database in bytes"""

--- a/src/relstorage/cache/c_cache.cpp
+++ b/src/relstorage/cache/c_cache.cpp
@@ -612,6 +612,16 @@ bool Cache::contains(const OID_t key) const
     return this->data.count(key) == 1;
 }
 
+TID_t Cache::contains_oid_with_newer_tid(OID_t key, const TID_t tid)
+{
+    if_existing(key, -1);
+    TID_t newest = existing_entry.newest_tid();
+    if (newest > tid) {
+        return newest;
+    }
+    return -1;
+}
+
 ICacheEntry* Cache::get(const OID_t key)
 {
     if_existing(key, nullptr);

--- a/src/relstorage/cache/c_cache.h
+++ b/src/relstorage/cache/c_cache.h
@@ -492,6 +492,7 @@ namespace cache {
         virtual ICacheEntry* freeze_to_tid(const TID_t tid) = 0;
         virtual ICacheEntry* discarding_tids_before(const TID_t tid) = 0;
 
+        virtual TID_t newest_tid() const = 0;
     };
 
     // BIT::key_of_value function object, must:
@@ -705,6 +706,11 @@ namespace cache {
             return this->_tid;
         }
 
+        virtual TID_t newest_tid() const
+        {
+            return this->_tid;
+        }
+
         bool& frozen()
         {
             return this->_frozen;
@@ -885,7 +891,7 @@ namespace cache {
             return new_entry;
         }
 
-        TID_t newest_tid() const
+        virtual TID_t newest_tid() const
         {
             return this->p_values.rbegin()->tid;
         }
@@ -1284,6 +1290,8 @@ namespace cache {
         void freeze(OID_t key, TID_t tid);
 
         bool contains(const OID_t key) const;
+
+        TID_t contains_oid_with_newer_tid(const OID_t key, const TID_t tid);
 
         /**
           * Return the entry for the OID, if it exists. May return a

--- a/src/relstorage/cache/c_cache.pxd
+++ b/src/relstorage/cache/c_cache.pxd
@@ -99,6 +99,7 @@ cdef extern from "c_cache.h" namespace "relstorage::cache":
         void delitem(OID_t key, TID_t tid) except +
         void freeze(OID_t key, TID_t tid) except +
         bool contains(OID_t key)
+        TID_t contains_oid_with_newer_tid(OID_t key, TID_t tid)
         void age_frequencies()
         ICacheEntry* get(OID_t key)
         SVCacheEntry* get(OID_t, TID_t)

--- a/src/relstorage/cache/cache.pyx
+++ b/src/relstorage/cache/cache.pyx
@@ -340,6 +340,15 @@ cdef class PyCache:
     def __len__(self):
         return self.cache.size()
 
+    def contains_oid_with_newer_tid(self, OID_t key, TID_t tid):
+        """
+        Answer whether we know that we have a cached value containing
+        a TID newer than the given TID.
+
+        If we do, return the TID. If we don't, return -1.
+        """
+        return self.cache.contains_oid_with_newer_tid(key, tid)
+
     cpdef CachedValue get(self, OID_t key):
         entry = self.cache.get(key)
         if not entry:

--- a/src/relstorage/cache/cache.pyx
+++ b/src/relstorage/cache/cache.pyx
@@ -345,9 +345,11 @@ cdef class PyCache:
         Answer whether we know that we have a cached value containing
         a TID newer than the given TID.
 
-        If we do, return the TID. If we don't, return -1.
+        If we do, return the TID. If we don't, return None.
         """
-        return self.cache.contains_oid_with_newer_tid(key, tid)
+        cdef TID_t result = self.cache.contains_oid_with_newer_tid(key, tid)
+        if result != -1:
+            return result
 
     cpdef CachedValue get(self, OID_t key):
         entry = self.cache.get(key)

--- a/src/relstorage/cache/local_client.py
+++ b/src/relstorage/cache/local_client.py
@@ -355,9 +355,7 @@ class LocalClient(object):
         return self._cache.get_item_with_tid(oid, tid) is not None
 
     def contains_oid_with_newer_tid(self, oid, tid):
-        tid = self._cache.contains_oid_with_newer_tid(oid, tid)
-        if tid > -1:
-            return tid
+        return self._cache.contains_oid_with_newer_tid(oid, tid)
 
     def get(self, oid_tid, peek=False):
         oid, tid = oid_tid

--- a/src/relstorage/cache/local_client.py
+++ b/src/relstorage/cache/local_client.py
@@ -354,6 +354,11 @@ class LocalClient(object):
         oid, tid = oid_tid
         return self._cache.get_item_with_tid(oid, tid) is not None
 
+    def contains_oid_with_newer_tid(self, oid, tid):
+        tid = self._cache.contains_oid_with_newer_tid(oid, tid)
+        if tid > -1:
+            return tid
+
     def get(self, oid_tid, peek=False):
         oid, tid = oid_tid
         assert tid is None or tid >= 0

--- a/src/relstorage/storage/tpc/__init__.py
+++ b/src/relstorage/storage/tpc/__init__.py
@@ -120,6 +120,10 @@ class SharedTPCState(object):
         self._used_resources = []
 
     @_LazyResource
+    def local_client(self):
+        return self._storage._cache.local_client
+
+    @_LazyResource
     def store_connection(self):
         conn = self._storage._store_connection_pool.borrow()
         # Report on the connection we will use.

--- a/src/relstorage/storage/tpc/tests/test_vote.py
+++ b/src/relstorage/storage/tpc/tests/test_vote.py
@@ -66,6 +66,7 @@ class MockCache(object):
     def after_tpc_finish(self, *_args):
         """does nothing"""
 
+
 class MockStorage(object):
 
     def __init__(self):


### PR DESCRIPTION
Use the cache to cheaply check if a ``readCurrent()``  violation will take place during an early part of two-phase commit, instead of  waiting until ``tpc_vote`` when we've sent data to the database. 

If the cache can prove that there is a newer version of an object stored, the conflict error will be raised during ``commit``; if the  cache can't prove it, the error will still be raised during ``tpc_vote``.

This more closely matches what ``FileStorage`` does and can help avoid some unnecessary work.

I'm running the micro benchmark suite now, but I'm not expecting it to show any differences (the benchmarks don't actually trigger readCurrent conflicts, but they do use it). (ETA: They don't show any difference.)

/cc @jzuech3 @cutz 