### PR TITLE
Minor performance improvements for Postgresql lock_and_move, and incl…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,13 @@
 3.5.0a3 (unreleased)
 ====================
 
-- Nothing changed yet.
+- PostgreSQL: Stop sorting rows unnecessarily during the
+  ``lock_and_move`` part of ``tpc_finish`` (MySQL was already not
+  sorting). On larger transactions and/or busier servers, this shows a
+  slight performance increase in benchmarks.
+
+- Include the transaction ID in log messages about long-running
+  transactions (once available).
 
 
 3.5.0a2 (2021-05-24)

--- a/src/relstorage/_util.py
+++ b/src/relstorage/_util.py
@@ -239,7 +239,8 @@ _LOG_TIMED_COMPILETIME_ENABLE = get_boolean_from_environ(
 def do_log_duration_info(basic_msg, func,
                          args, kwargs,
                          actual_duration,
-                         log=perf_logger):
+                         log=perf_logger,
+                         log_extra_args=()):
     if func is None:
         # Timing was disabled at compile time
         return
@@ -248,7 +249,6 @@ def do_log_duration_info(basic_msg, func,
     # Defer capturing the name; it might get changed at
     # runtime.
     log_msg = basic_msg
-    log_args = (func.__name__, actual_duration)
     for level, duration in func.log_levels:
         if actual_duration < duration:
             break
@@ -257,6 +257,7 @@ def do_log_duration_info(basic_msg, func,
     if not log.isEnabledFor(log_level):
         return
 
+    log_args = (func.__name__, actual_duration) + log_extra_args
     if log_level >= func.log_details_threshold:
         # This will capture 'self' as the first argument,
         # so you can put useful things into that repr if you'd

--- a/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid_and_move.sql
+++ b/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid_and_move.sql
@@ -11,11 +11,12 @@ BEGIN
   END IF;
 
   -- move_from_temp()
-  -- First the state for objects
-  -- TODO: We probably do not need to order the
-  -- temp rows. The locks we need are already held.
-  -- Skipping that appears to make a difference in plans and
-  -- benchmarks. Confirm that and remove.
+  -- First the state for objects.
+  --
+  -- We previously ordered the temp rows by zoid, presumably to avoid
+  -- deadlock, but that's not necessary. The locks we need are
+  -- already held. Skipping that appears to make a difference in plans
+  -- and benchmarks for larger transactions.
   INSERT INTO object_state (
     zoid,
     tid,
@@ -27,7 +28,6 @@ BEGIN
          COALESCE(LENGTH(state), 0),
          state
   FROM temp_store
-  ORDER BY zoid
   ON CONFLICT (zoid) DO UPDATE SET
      tid = excluded.tid,
      state_size = excluded.state_size,

--- a/src/relstorage/adapters/postgresql/procs/hp/lock_and_choose_tid_and_move.sql
+++ b/src/relstorage/adapters/postgresql/procs/hp/lock_and_choose_tid_and_move.sql
@@ -29,8 +29,7 @@ BEGIN
          md5,
          COALESCE(LENGTH(state), 0),
          state
-  FROM temp_store
-  ORDER BY zoid;
+  FROM temp_store;
 
   -- Now blob chunks.
   INSERT INTO blob_chunk (
@@ -47,7 +46,6 @@ BEGIN
   SELECT zoid, tid
   FROM object_state
   WHERE tid = p_committing_tid
-  ORDER BY zoid
   ON CONFLICT (zoid) DO UPDATE SET
      tid = excluded.tid;
 

--- a/src/relstorage/storage/tpc/temporary_storage.py
+++ b/src/relstorage/storage/tpc/temporary_storage.py
@@ -29,7 +29,7 @@ from relstorage._compat import OidObjectMap_max_key
 from relstorage._compat import iteroiditems
 from relstorage._compat import NStringIO
 
-class TemporaryStorage(object):
+class TPCTemporaryStorage(object):
     __slots__ = (
         '_queue',
         '_queue_contents',
@@ -118,11 +118,17 @@ class TemporaryStorage(object):
             self._queue_contents = () # Not None so len() keeps working
 
     def __repr__(self):
-        return "<%s.%s at 0x%x len: %d>" % (
-            type(self).__module__,
+        approx_size = 0
+        if self._queue is not None:
+            self._queue.seek(0, 2)  # seek to end
+            # The number of bytes we stored isn't necessarily the
+            # number of bytes we send to the server, if there are duplicates
+            approx_size = self._queue.tell()
+        return "<%s at 0x%x count=%d bytes=%d>" % (
             type(self).__name__,
             id(self),
-            len(self)
+            len(self),
+            approx_size
         )
 
     def __str__(self):
@@ -161,3 +167,5 @@ class TemporaryStorage(object):
 
 
         return out.getvalue()
+
+TemporaryStorage = TPCTemporaryStorage # BWC

--- a/src/relstorage/storage/tpc/tests/test_temporary_storage.py
+++ b/src/relstorage/storage/tpc/tests/test_temporary_storage.py
@@ -25,7 +25,7 @@ class TestTemporaryStorage(unittest.TestCase):
         del temporary_storage.id
         super(TestTemporaryStorage, self).tearDown()
 
-    _EMPTY_STR = '<relstorage.storage.tpc.temporary_storage.TemporaryStorage at 0xdeadbeef len: 0>'
+    _EMPTY_STR = '<TPCTemporaryStorage at 0xdeadbeef count=0 bytes=0>'
 
     def test_empty_str(self):
         temp = self._makeOne()
@@ -54,13 +54,13 @@ class TestTemporaryStorage(unittest.TestCase):
         self.assertEqual(
             s,
             dedent("""\
-            <relstorage.storage.tpc.temporary_storage.TemporaryStorage at 0xdeadbeef len: 3>
-            ================================================================================
-            | OID                      | Length                   | Previous TID            |
-            ================================================================================
-                                    1  |                        3 |                        0
-                                    2  |                        3 |                       42
-                                 6547  |                        9 |                       23
+            <TPCTemporaryStorage at 0xdeadbeef count=3 bytes=15>
+            ====================================================
+            | OID            | Length         | Previous TID  |
+            ====================================================
+                          1  |              3 |              0
+                          2  |              3 |             42
+                       6547  |              9 |             23
             """
                    )
         )

--- a/src/relstorage/storage/tpc/vote.py
+++ b/src/relstorage/storage/tpc/vote.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import time
+from logging import DEBUG
 
 from zope.interface import implementer
 
@@ -44,6 +45,7 @@ from . import LOCK_EARLY
 from . import AbstractTPCStateDatabaseAvailable
 from .finish import Finish
 
+LOG_LEVEL_TID = DEBUG
 
 logger = __import__('logging').getLogger(__name__)
 perf_logger = logger.getChild('timing')
@@ -573,19 +575,22 @@ class AbstractVote(AbstractTPCStateDatabaseAvailable):
 
             locked_duration = locks_released - self.lock_and_vote_times[0]
             between_vote_and_finish = finish_entry - self.lock_and_vote_times[1]
+            log_extra_args = (self.committing_tid_lock.tid_int,)
             do_log_duration_info(
-                "Objects were locked by %s for %.3fs",
+                "Objects were locked by %s for %.3fs (tid=%d)",
                 AbstractVote.tpc_finish.__wrapped__, # pylint:disable=no-member
                 self, None,
                 locked_duration,
-                perf_logger
+                perf_logger,
+                log_extra_args
             )
             do_log_duration_info(
-                "Time between vote exiting and %s entering was %.3fs",
+                "Time between vote exiting and %s entering was %.3fs (tid=%d)",
                 AbstractVote.tpc_finish.__wrapped__, # pylint:disable=no-member
                 self, None,
                 between_vote_and_finish,
-                perf_logger
+                perf_logger,
+                log_extra_args
             )
             self.shared_state.stat_timing(
                 'relstorage.storage.tpc_vote.objects_locked.t',


### PR DESCRIPTION
…ude the TID in certain long-running log messages.

Also include the approx byte count of objects stored in the TemporaryStorage output.