### PR TITLE
Use advisory locks instead of row locks in PostgreSQL.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,29 @@
 
 - Stop closing RDBMS connections when ``tpc_vote`` raises a
   semi-expected ``TransientError`` such as a ``ConflictError``.
+- PostgreSQL: Now uses advisory locks instead of row-level locks
+  during the commit process. This benchmarks substantially faster and
+  reduces the potential for table bloat.
+
+  For environments that process many large, concurrent transactions,
+  or deploy many RelStorage instances to the same database server, it
+  might be necessary to increase the PostgreSQL configuration value
+  ``max_locks_per_transaction.`` The default value of 64 is multiplied
+  by the default value of ``max_connections`` (100) to allow for 6,400
+  total objects to be locked across the entire database server. See
+  `the PostgreSQL documentation
+  <https://www.postgresql.org/docs/13/runtime-config-locks.html>`_ for
+  more information.
+
+  .. caution:: Be careful deploying this version while older versions
+               are executing. There could be a small window of time
+               where the locking strategies are different, leading to
+               database corruption.
+
+  .. note:: Deploying multiple RelStorage instances to separate
+            schemas in the same PostgreSQL database (e.g., the default
+            of "public" plus another) has never been supported. It is
+            even less supported now.
 
 
 3.5.0a3 (2021-05-26)

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -50,6 +50,7 @@ Internal Details
    relstorage.adapters.postgresql.schema
    relstorage.adapters.postgresql.stats
    relstorage.adapters.postgresql.txncontrol
+   relstorage.adapters.postgresql.util
    relstorage.adapters.replica
    relstorage.adapters.schema
    relstorage.adapters.scriptrunner

--- a/docs/postgresql/index.rst
+++ b/docs/postgresql/index.rst
@@ -11,9 +11,9 @@
 
 .. tip::
 
-   Using ZODB's ``readCurrent(ob)`` method will result in taking
-   shared locks (``SELECT FOR SHARE``) in PostgreSQL for the row
-   holding the data for *ob*.
+   Prior to version 3.5.0a4, using ZODB's ``readCurrent(ob)`` method
+   will result in taking shared locks (``SELECT FOR SHARE``) in
+   PostgreSQL for the row holding the data for *ob*.
 
    This operation performs disk I/O, and consequently has an
    associated cost. We recommend using this method judiciously.

--- a/docs/postgresql/setup.rst
+++ b/docs/postgresql/setup.rst
@@ -4,6 +4,11 @@
 
 .. highlight:: shell
 
+.. important::
+
+   RelStorage can only be installed into a single schema within a
+   database. This is usually the default "public" schema. It may be
+   possible to use other schemas, but this is not supported or tested.
 
 If you installed PostgreSQL from a binary package, you probably have a
 user account named ``postgres``. Since PostgreSQL respects the name of
@@ -40,18 +45,133 @@ configuration file::
 Configuration
 =============
 
-.. tip::
+The default PostgreSQL server configuration will work fine for most
+users. However, some configuration changes may yield increased performance.
 
-   For packing large databases, a larger value of the PostgreSQL
-   configuration paramater ``work_mem`` is likely to yield improved
-   performance. The default is 4MB; try 16MB if packing performance is
-   unacceptable.
+Defaults and Background
+-----------------------
 
-.. tip::
+This section is current for PostgreSQL 13 and earlier versions.
 
-   For packing large databases, setting the ``pack_object``,
-   ``object_ref`` and ``object_refs_added`` tables to `UNLOGGED
-   <https://www.postgresql.org/docs/12/sql-createtable.html#SQL-CREATETABLE-UNLOGGED>`_
-   can provide a performance boost (if replication doesn't matter and
-   you don't care about the contents of these tables). This can be
-   done after the schema is created with ``ALTER TABLE table SET UNLOGGED``.
+``max_connections`` (100) gives the number of worker processes that could
+possibly be active at a time. Each worker consumes (at most)
+``work_mem`` (4MB) + ``temp_mem`` (8MB) = 12MB (plus a tiny bit of
+overhead).
+
+``shared_buffers`` is the amount of memory that PostgreSQL will
+allocate to keeping database data in memory. It is perhaps the single
+most important tunable, larger values are better. If data is not in
+this, then a worker will have to go to the operating system with an
+I/O request (or two). The default is a measly 128MB.
+
+``max_wal_size`` determines how often the data must be taken from the
+write-ahead log and placed into the main tables. Reasons to keep this
+small are (a) low amount of disk space; (b) reduced crash recovery
+time; (c) if you're doing replication in the WAL-based way, keeping
+online replicas more up-to-date.
+
+``random_page_cost`` (4.0) is relative to ``seq_page_cost`` (1.0) and
+tells how relatively expensive it is to do random I/O versus large
+blocks of sequential I/O. This in turn influences whether the planner
+will use an index or not. For solid-state drives, the
+``random_page_cost`` should generally be lowered.
+
+
+General
+-------
+
+Many PostgreSQL configuration defaults are conservative on modern
+machines. Without knowing the resources available to any particular
+installation, some general tips are listed below.
+
+.. important:: Be sure you understand the consequences before changing
+               any settings. Some of those listed here may be risky,
+               depending on your level of risk tolerance.
+
+* Increase ``temp_mem``. This prevents having to use disk tables for
+  temporary storage. RelStorage does a lot with temp tables. In my
+  benchmarks, I use 32MB.
+
+* ``work_mem`` improves sorting and hashing, that sort of thing.
+  RelStorage doesn't do much of that *except* when you do a native GC,
+  and then it can make a big difference. Because this is a max that's
+  not allocated unless needed, it should be safe to increase it. In my
+  benchmarks, I leave this alone.
+
+* Increase ``shared_buffers`` as much as you are able. When I
+  benchmark, on my 16GB laptop, I use 2GB. The rule of thumb for
+  dedicated servers is 25% of available RAM.
+
+* If deploying on SSDs, then the cost of random page access can probably
+  be lowered some more. I know they're old SSDs, but the cost is
+  relative to sequential access, not absolute. This is probably not
+  important though, unless you're experiencing issues accessing blobs
+  (the only thing doing sequential scans).
+
+* If you are not doing replication, setting ``wal_level = minimal``
+  will improve write speed and reduce disk usage. Similarly, setting
+  ``wal_compression = on`` will reduce disk IO for writes (at a tiny
+  CPU cost). I benchmark with both those settings.
+
+* If you're not doing replication and can stand some longer recovery
+  times, increasing ``max_wal_size`` (I use 10GB) has benefit for
+  heavy writes. Even if you are doing replication, increasing
+  ``checkpoint_timeout`` (I use 30 minutes, up from 5),
+  ``checkpoint_completion_target`` (I use 0.9, up from 0.5) and either
+  increasing or disabling ``checkpoint_flush_after`` (I disable, the
+  default is a skimpy 256KB) also help. This especially helps on
+  spinning rust, and for very "bursty" workloads.
+
+* If our IO bandwidth is constrained, and you can't increase
+  ``shared_buffers`` enough to compensate, disabling the background
+  writer can help too. ``bgwriter_lru_maxpages = 0`` and
+  ``bgwriter_flush_after = 0``. I set these when I benchmark using
+  spinning rust.
+
+* Setting ``synchronous_commit = off`` makes for faster turnaround
+  time on ``COMMIT`` calls. This is safe in the sense that it can
+  never corrupt the database in the event of a crash, but it might
+  leave the application *thinking* something was saved when it really
+  wasn't. Since the whole site will go down in the event of a database
+  crash anyway, you might consider setting this to off if you're
+  struggling with database performance. I benchmark with it off.
+
+
+Large Sites
+-----------
+
+* For very large sites processing many large or concurrent
+  transactions, or deploying many RelStorage instances to a single
+  database server, it may be necessary to increase the value of
+  ``max_locks_per_transaction`` beginning with RelStorage 3.5.0a4. The
+  default value (64) allows about 6,400 objects to be locked because
+  it is multiplied by the value of ``max_connections`` (which defaults
+  to 100). Large sites may have already increased this second value.
+
+* For systems with very high write levels, setting
+  ``wal_writer_flush_after = 10MB`` (or something higher than the
+  default of 1MB) and ``wal_writer_delay = 10s`` will improve write
+  speed without any appreciable safety loss (because your write volume
+  is so high already). I run write benchmarks this way.
+
+* Likewise for high writes, I increase ``autovacuum_max_workers`` from
+  the default of 3 to 8 so they can keep up. Similarly, consider
+  lowering ``autovacuum_vacuum_scale_factor`` from its default of 20%
+  to 10% or even 1%. You might also raise
+  ``autovacuum_vacuum_cost_limit`` from its default of 200 to 1000
+  or 2000.
+
+Packing
+-------
+
+* For packing large databases, a larger value of the PostgreSQL
+  configuration paramater ``work_mem`` is likely to yield improved
+  performance. The default is 4MB; try 16MB if packing performance is
+  unacceptable.
+
+* For packing large databases, setting the ``pack_object``,
+  ``object_ref`` and ``object_refs_added`` tables to `UNLOGGED
+  <https://www.postgresql.org/docs/12/sql-createtable.html#SQL-CREATETABLE-UNLOGGED>`_
+  can provide a performance boost (if replication doesn't matter and
+  you don't care about the contents of these tables). This can be done
+  after the schema is created with ``ALTER TABLE table SET UNLOGGED``.

--- a/src/relstorage/adapters/mysql/packundo.py
+++ b/src/relstorage/adapters/mysql/packundo.py
@@ -20,12 +20,8 @@ from ..packundo import HistoryFreePackUndo
 from ..packundo import HistoryPreservingPackUndo
 from ..schema import Schema
 
-class _LockStmt(object):
-    # 8.0 supports 'FOR SHARE' but before that we have
-    # this.
-    _lock_for_share = 'LOCK IN SHARE MODE'
 
-class MySQLHistoryPreservingPackUndo(_LockStmt, HistoryPreservingPackUndo):
+class MySQLHistoryPreservingPackUndo(HistoryPreservingPackUndo):
 
     # Previously we needed to work around a MySQL performance bug by
     # avoiding an expensive subquery.
@@ -112,5 +108,5 @@ class MySQLHistoryPreservingPackUndo(_LockStmt, HistoryPreservingPackUndo):
     ).limit(1000)
 
 
-class MySQLHistoryFreePackUndo(_LockStmt, HistoryFreePackUndo):
+class MySQLHistoryFreePackUndo(HistoryFreePackUndo):
     pass

--- a/src/relstorage/adapters/packundo.py
+++ b/src/relstorage/adapters/packundo.py
@@ -51,10 +51,6 @@ class PackUndo(DatabaseHelpersMixin):
 
     _choose_pack_transaction_query = None
 
-
-    _lock_for_share = 'FOR SHARE'
-    _lock_for_update = 'FOR UPDATE'
-
     driver = None
     connmanager = None
     runner = None
@@ -106,8 +102,7 @@ class PackUndo(DatabaseHelpersMixin):
             # (checkPackWhileReferringObjectChanges)
             return self
         result = self.__class__(self.driver, self.connmanager, self.runner, self.locker, options)
-        # Setting the MAX_TID is important for SQLite,
-        # as is the _lock_for_share.
+        # Setting the MAX_TID is important for SQLite.
         # This should probably be handled directly in subclasses.
         for k, v in vars(self).items():
             if k != 'options' and getattr(result, k, None) is not v:

--- a/src/relstorage/adapters/postgresql/adapter.py
+++ b/src/relstorage/adapters/postgresql/adapter.py
@@ -150,8 +150,6 @@ class PostgreSQLAdapter(AbstractAdapter):
                 locker=self.locker,
                 options=options,
             )
-            # TODO: Subclass for this.
-            self.packundo._lock_for_share = 'FOR KEY SHARE OF object_state'
             self.dbiter = HistoryFreeDatabaseIterator(
                 driver,
             )

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 
 from zope.interface import implementer
 
+from relstorage._util import Lazy
 from ..interfaces import ILocker
 from ..interfaces import UnableToLockRowsToModifyError
 from ..interfaces import UnableToLockRowsToReadCurrentError
@@ -28,6 +29,22 @@ from ..locker import AbstractLocker
 
 @implementer(ILocker)
 class PostgreSQLLocker(AbstractLocker):
+    """
+    On PostgreSQL, for locking individual objects, we use advisory
+    locks, not row locks.
+
+    This is because row locks perform disk I/O, which can "bloat" tables;
+    this is especially an issue for shared (readCurrent) locks, which perform
+    I/O to pages that might not otherwise need it. Using many row locks
+    requires a good (auto)vacuuming setup to prevent this bloat from becoming
+    a problem.
+
+    Also, advisory locks are much faster than row locks.
+
+    We take advisory locks based on OID. OIDs begin at 0 and increase. To avoid
+    conflicting with those, any advisory locks used for "administrative" purposes,
+    such as the pack lock, need to use negative numbers.
+    """
 
     def _on_store_opened_set_row_lock_timeout(self, cursor, restart=False):
         # This only lasts beyond the current transaction if it
@@ -47,6 +64,45 @@ class PostgreSQLLocker(AbstractLocker):
         timeout_ms = int(timeout * 1000.0)
         self.driver.set_lock_timeout(cursor, timeout_ms)
 
+
+    @Lazy
+    def _lock_current_objects_query(self):
+        # This is not used in production, only in tests that try to interleave
+        # different types of locking.
+        get = self._get_current_objects_query[0]
+        stmt = get.replace('SELECT zoid', 'SELECT pg_advisory_xact_lock(zoid)')
+        stmt += ' ORDER BY zoid'
+        return stmt
+
+    def _lock_suffix_for_readCurrent(self, shared_locks_block):
+        # This is not used in production, only in tests that try to interleave
+        # different types of locking.
+        return ''
+
+    def _lock_column_name_for_readCurrent(self, shared_locks_block):
+        # This is not used in production, only in tests that try to interleave
+        # different types of locking.
+        return (
+            'pg_advisory_xact_lock_shared(zoid)'
+            if shared_locks_block
+            else
+            'pg_try_advisory_xact_lock_shared(zoid)'
+        )
+
+    def _lock_consume_rows_for_readCurrent(self, rows, shared_locks_block):
+        # This is not used in production, only in tests that try to interleave
+        # different types of locking.
+
+        # If we used the blocking version, it returned void (NULL/None),
+        # or raised an error. No need to examine the rows.
+        if shared_locks_block:
+            return super(PostgreSQLLocker, self)._lock_consume_rows_for_readCurrent(
+                rows,
+                shared_locks_block)
+
+        for got_lock, in rows:
+            if not got_lock:
+                raise UnableToLockRowsToReadCurrentError
 
     def release_commit_lock(self, cursor):
         # no action needed, locks released with transaction.
@@ -85,11 +141,11 @@ class PostgreSQLLocker(AbstractLocker):
 
         Raise an exception if packing or undo is already in progress.
         """
-        cursor.execute("SELECT pg_try_advisory_lock(1)")
+        cursor.execute("SELECT pg_try_advisory_lock(-1)")
         locked = cursor.fetchone()[0]
         if not locked:
             raise UnableToAcquirePackUndoLockError('A pack or undo operation is in progress')
 
     def release_pack_lock(self, cursor):
         """Release the pack lock."""
-        cursor.execute("SELECT pg_advisory_unlock(1)")
+        cursor.execute("SELECT pg_advisory_unlock(-1)")

--- a/src/relstorage/adapters/postgresql/locker.py
+++ b/src/relstorage/adapters/postgresql/locker.py
@@ -44,6 +44,11 @@ class PostgreSQLLocker(AbstractLocker):
     We take advisory locks based on OID. OIDs begin at 0 and increase. To avoid
     conflicting with those, any advisory locks used for "administrative" purposes,
     such as the pack lock, need to use negative numbers.
+
+    Locks include:
+
+    - -1: The commit lock
+    - -2: The pack lock
     """
 
     def _on_store_opened_set_row_lock_timeout(self, cursor, restart=False):
@@ -141,11 +146,11 @@ class PostgreSQLLocker(AbstractLocker):
 
         Raise an exception if packing or undo is already in progress.
         """
-        cursor.execute("SELECT pg_try_advisory_lock(-1)")
+        cursor.execute("SELECT pg_try_advisory_lock(-2)")
         locked = cursor.fetchone()[0]
         if not locked:
             raise UnableToAcquirePackUndoLockError('A pack or undo operation is in progress')
 
     def release_pack_lock(self, cursor):
         """Release the pack lock."""
-        cursor.execute("SELECT pg_advisory_unlock(-1)")
+        cursor.execute("SELECT pg_advisory_unlock(-2)")

--- a/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid.sql
+++ b/src/relstorage/adapters/postgresql/procs/hf/lock_and_choose_tid.sql
@@ -20,10 +20,7 @@ BEGIN
   -- to indicate that the TIDs were the same, and a later view of the
   -- transaction would be incorrect (containing multiple distinct
   -- transactions).
-  SELECT tid
-  INTO scratch
-  FROM commit_row_lock
-  FOR UPDATE;
+  PERFORM pg_advisory_xact_lock(-1);
 
   SELECT COALESCE(MAX(tid), 0)
   INTO current_tid_64

--- a/src/relstorage/adapters/postgresql/procs/hp/lock_and_choose_tid.sql
+++ b/src/relstorage/adapters/postgresql/procs/hp/lock_and_choose_tid.sql
@@ -17,10 +17,8 @@ DECLARE
     current_tid_64 BIGINT;
   next_tid_64 BIGINT;
 BEGIN
-    SELECT tid
-    INTO scratch
-    FROM commit_row_lock
-    FOR UPDATE;
+    PERFORM pg_advisory_xact_lock(-1);
+
 
     SELECT COALESCE(MAX(tid), 0)
     INTO current_tid_64

--- a/src/relstorage/adapters/sqlite/adapter.py
+++ b/src/relstorage/adapters/sqlite/adapter.py
@@ -142,8 +142,6 @@ class Sqlite3Adapter(AbstractAdapter):
                 locker=self.locker,
                 options=options,
             )
-            # TODO: Subclass for this.
-            self.packundo._lock_for_share = 'FOR KEY SHARE OF object_state'
             self.dbiter = HistoryFreeDatabaseIterator(
                 driver,
             )

--- a/src/relstorage/tests/locking.py
+++ b/src/relstorage/tests/locking.py
@@ -452,8 +452,9 @@ class TestLocking(TestCase):
         duration_blocking = end - begin
 
         # Now, one or the other storage got killed by the deadlock
-        # detector, but NOT both. Which one depends on the database.
-        # PostgreSQL likes to kill the foreground thread (storageB),
+        # detector, or possibly both. Which one depends on the database.
+        # PostgreSQL likes to kill the foreground thread (storageB)
+        # when using row locks, but it sometimes kills them both ,
         # MySQL likes to kill the background thread (storageA)...
         # And Oracle likes to kill them both! Argh!
         self.assertTrue(storageA.last_error or storageB.last_error,


### PR DESCRIPTION
This is generally much faster.

Here's 20 concurrent processes hitting a server on a separate machine across the network. The tests are increasingly torturous. The last row is the test I designed specifically to be evil. It readCurrent's a bunch of objects that are being changed by other processes and also changes some objects being changed by other processes. It deliberately
triggers a huge variety of conflict errors, including the UnableToLock*Errors, and also does conflict resolution. It retries if
any of that fails.

The second to last row also involves readCurrent and conflicts, but most of the readCurrent doesn't actually conflict, just the objects do. This should be close-ish to what many applications actually see (e.g., traversing a BTree and modifying some leaf value, including splitting a BTree node).

(Ignore the absolute times --- this isn't how long it necessarily takes to do 250 objects, there are internal loops.)

| Benchmark                                                           | 3.5.0a3            | Advisory Locks                      |
|---------------------------------------------------------------------|--------------------|------------------------------|
| {c=20 processes, o=250} pg: update 250 objects                      | 533 ms             | 504 ms: 1.06x faster         |
| {c=20 processes, o=250} pg: update 250 conflicting objects          | 521 ms             | 483 ms: 1.08x faster         |
| {c=20 processes, o=250} pg: update 250 conflicting objects in place | 989 ms             | 883 ms: 1.12x faster         |
| {c=20 processes, o=250} pg: readCurrent 250 conflicts               | 1.59 sec           | 996 ms: 1.60x faster         |

Benchmark hidden because not significant (1): {c=20 processes, o=250} pg: add 250 objects

Here's 40 concurrent processes and a full run of the benchmark suite.

| Benchmark                                                           | 3.5.0a3                    | Phase 1                            |
|---------------------------------------------------------------------|----------------------------|------------------------------------|
| {c=40 processes, o=250} pg: add 250 objects                         | 1.05 sec                   | 1.00 sec: 1.05x faster             |
| {c=40 processes, o=250} pg: update 250 conflicting objects          | 1.30 sec                   | 1.08 sec: 1.20x faster             |
| {c=40 processes, o=250} pg: update 250 conflicting objects in place | 2.28 sec                   | 2.03 sec: 1.12x faster             |

Benchmark hidden because not significant (10): {c=40 processes, o=250} pg: store 250 raw pickles, {c=40 processes, o=250} pg: update 250 objects, {c=40 processes, o=250} pg: read 250 cold objects, {c=40 processes, o=250} pg: read 250 cold prefeteched objects, {c=40 processes, o=250} pg: readCurrent 250 objects, {c=40 processes, o=250} pg: read 250 hot objects, {c=40 processes, o=250} pg: read 250 steamin objects, {c=40 processes, o=250} pg: empty implicit commit, {c=40 processes, o=250} pg: tpc, {c=40 processes, o=250} pg: readCurrent 250 conflicts

(I suspect I may have been hitting the limits of the hardware in this benchmark.)

Examining the metrics for this case, the time spent in tpc_vote is dramatically improved (roughly half). So acquiring the locks is much faster.

The time for tpc_finish does actually seem to go up a little, so maybe releasing these locks is more expensive? (Or that may be an artifact of how it's measured.)

Note that the "readCurrent 250 conflicts" benchmark was updated between the two benchmark runs. The version used with 20 concurrent processes actually slowed down substantially with 40 concurrent process on the new locks. Tracing this showed that the number of transaction retries sky-rocketed with the new locks. Essentially, a process would spin in a retry loop before finally getting lucky enough to be the one to get the lock and commit.

The hypothesis is that tpc_vote is so much faster that we detect conflicts so much faster and thus retry so much faster --- before the other process has had a chance to commit --- that we wind up doing overall more work.

The benchmark was adjusted to be (hopefully) more realistic. Instead of conflicting on every object every time and immediately retrying, the benchmark now only conflicts on some objects some of the time and allows for some delay time between retries (like most real-world transaction manager loops do.)

Here's a graph of these times. The left run is the new code; the right run is the old code. The blue line is `tpc_vote` times, the green line is `tpc_finish` times, and the pink line is transaction retry attempts (I'm not sure if this is the final version of the benchmark, but it is definitely improved from the original; in any case, the new code is retrying about twice as much as the old code — and retries count against the benchmark time!). In the new code, `tpc_vote` is *much* smaller, even though we're doing many more of them because of higher retries; `tpc_finish` is larger, which could be actual database time, or could be a result of higher contention on the commit lock, because more processes are faster getting through to it at the same time. (I'm just remembering that I should also try to make the final commit lock advisory.)

![250_objects_advisory](https://user-images.githubusercontent.com/1256082/121233645-71642d80-c858-11eb-9efe-c57e40c4e7c9.png)

Large sites may need to increase the configuration value ``max_locks_per_transaction`` (or maybe not, if they've already
increased ``max_connections``).