### PR TITLE
Provide loadBeforeEx

### DIFF
--- a/src/relstorage/tests/reltestbase.py
+++ b/src/relstorage/tests/reltestbase.py
@@ -164,6 +164,7 @@ class ThreadWrapper(object):
             return func
 
         for name in (
+                'loadBeforeEx',
                 'loadBefore',
                 'load',
                 'store',


### PR DESCRIPTION
loadBeforeEx is like loadBefore, but simpler, provides better
information for object delete records and can be more efficiently
implemented by many storages: https://github.com/zopefoundation/ZODB/pull/323

On RelStorage loadBefore is currently implemented via 3 SQL queries:

  1) check whether object record exists at all
  2) retrieve object state
  3) retrieve serial of next object revision

Compared to that loadBeforeEx is implemented via only one SQL query "2"
from the above - "retrieve object state". It is exactly the same query
that loadBefore uses and after the patch loadBefore actually invokes
loadBeforeEx for step 2.

This change was outlined in

https://github.com/zopefoundation/ZODB/issues/318#issuecomment-657683419 and
https://github.com/zopefoundation/ZODB/issues/318#issuecomment-657685745

and as explained in the first link this patch is also semantically coupled with

https://github.com/zodb/relstorage/pull/484

This patch passes tests with both ZODB5 and with ZODB5+https://github.com/zopefoundation/ZODB/pull/323:

- when ran with ZODB5 it verifies that loadBefore implementation does
  not become broken.

- when ran with ZODB5+https://github.com/zopefoundation/ZODB/pull/323 it
  verifies that loadBeforeEx implementation is correct.

For tests to pass with
ZODB5+https://github.com/zopefoundation/ZODB/pull/323 we also need
https://github.com/zopefoundation/zc.zlibstorage/pull/11 because without
that fix zc.zlibstorage does not decompress data on loadBeforeEx.