### PR TITLE
Add ``ssl`` option to MySQLAdapterFactory configuration.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
  Changes
 =========
 
+3.5.6 (unreleased)
+==================
+
+- Add ``ssl`` option to MySQLAdapterFactory configuration.
+  This enables explicit use of SSL when connection is opened.
+
 3.4.5 (2021-04-23)
 ==================
 

--- a/src/relstorage/component.xml
+++ b/src/relstorage/component.xml
@@ -211,6 +211,12 @@
       </description>
     </key>
 
+    <key name="ssl" datatype="boolean" required="no">
+      <description>
+        if set, connection uses ssl
+      </description>
+    </key>
+
     <key name="named_pipe" datatype="boolean" required="no">
       <description>
         if set, connect to server via named pipe (Windows only)


### PR DESCRIPTION
This enables explicit use of SSL when connection is opened.