### PR TITLE
Add ``ssl`` option to MySQLAdapterFactory configuration.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 3.5.0a7 (unreleased)
 ====================
 
-- Nothing changed yet.
+- Add ``ssl`` option to MySQLAdapterFactory configuration.
+  This enables explicit use of SSL when connection is opened.
 
 
 3.5.0a6 (2021-07-21)

--- a/src/relstorage/component.xml
+++ b/src/relstorage/component.xml
@@ -211,6 +211,12 @@
       </description>
     </key>
 
+    <key name="ssl" datatype="boolean" required="no">
+      <description>
+        if set, connection uses ssl
+      </description>
+    </key>
+
     <key name="named_pipe" datatype="boolean" required="no">
       <description>
         if set, connect to server via named pipe (Windows only)


### PR DESCRIPTION
This enables explicit use of SSL when connection is opened.