### PR TITLE
Test on 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, pypy-2.7-7.3.3, pypy-3.6, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [2.7, pypy-2.7-7.3.3, pypy-3.6, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
         # ubuntu 18.04 ships with mysql 5.7; ubuntu 20.04 ships with
         # mysql 8.0
         os: [ubuntu-18.04, macos-latest]


### PR DESCRIPTION
Since half a year ago Python 3.11 was released, so maybe knowing if there are any tests that break with it would at least give a bit more confidence on running the current last release release of Relstorage in that Python version 🤞🏾 